### PR TITLE
Fix for v3 compilation error in veneer

### DIFF
--- a/veneer.c
+++ b/veneer.c
@@ -232,7 +232,11 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
          {   if (identifier >= 1 && identifier < 64 && obj.#identifier <= 2)\
                  return obj.identifier;\
              RT__Err(\"read\", obj, identifier); return; }\
+         #IFV3;\
+         if (obj..#identifier > 2) RT__Err(\"read\", obj, identifier);\
+         #IFNOT;\
          if (obj..#identifier > 2) RT__Err(\"read\", obj, identifier, 2);\
+         #ENDIF;\
          return x-->0;\
          ]", "", "", "", "", ""
     },


### PR DESCRIPTION
See https://github.com/DavidKinder/Inform6/issues/20 .

V3 only supports three arguments per function call. One of the error cases in RV__Pr() uses four when calling RT__Err().

This is a minimal patch which just drops the fourth argument in V3. The result is a degraded error message. If an object is defined with an individual property containing several values:

```
Object bar
  with barprop 'one' 'two' 'three';
```

...and you try to access `bar.barprop`, you are supposed to get an error message:

> [** Programming error: (bar) (object number 6) has a property barprop, but it is longer than 2 bytes so you cannot use "." to read **]

 With this fix, in V3, you instead get the misleading error message:

> [** Programming error: (bar) (object number 6)  has no property barprop to read **]

A better fix would require more code, and at this point V3 is used only by people who are trying to optimize code size. So I think this is fine.

(Fix does not affect compilation for V4+ or Glulx.)
