### PR TITLE
Ifv3 and Ifv5 directives should explicitly exclude and include Glulx

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -420,11 +420,13 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         break;
 
     case IFV3_CODE:
-        flag = FALSE; if (version_number == 3) flag = TRUE;
+        flag = FALSE;
+        if (!glulx_mode && version_number <= 3) flag = TRUE;
         goto HashIfCondition;
 
     case IFV5_CODE:
-        flag = TRUE; if (version_number == 3) flag = FALSE;
+        flag = TRUE;
+        if (!glulx_mode && version_number <= 3) flag = FALSE;
         goto HashIfCondition;
 
     case IFTRUE_CODE:

--- a/inform.c
+++ b/inform.c
@@ -1504,6 +1504,8 @@ extern void switches(char *p, int cmode)
                   r_e_c_s_set = TRUE; break;
         case 'G': if (cmode == 0)
                       error("The switch '-G' can't be set with 'Switches'");
+                  else if (version_set_switch)
+                      error("The '-G' switch cannot follow the '-v' switch");
                   else
                   {   glulx_mode = state;
                       adjust_memory_sizes();


### PR DESCRIPTION
Fixes http://inform7.com/mantis/view.php?id=2148 .

The ifv3 and ifv5 directive are now clear (in their implementation) that ifv3 excludes Glulx and ifv5 includes Glulx.

This doesn't change any compiler behavior, unless you use the nonsensical arguments "-v3 -G". To be safe, that combination of arguments is now rejected as an error.
