### PR TITLE
Fix for https://github.com/DavidKinder/Inform6/issues/27

### DIFF
--- a/objects.c
+++ b/objects.c
@@ -1262,7 +1262,7 @@ the names '%s' and '%s' actually refer to the same property",
        warning_named("Version 3 limit of 4 values per property exceeded \
 (use -v5 to get 32), so truncating property",
                     (char *) symbs[property_name_symbol]);
-                full_object.pp[next_prop].l=4;
+                length = 8;
             }
         }
 


### PR DESCRIPTION
If a common property array overflows in V3, don't mess up the object.

Tested by compiling:

```
Property genprop;

Object test
	with indiv 0,
	with genprop 5 149 7 8 1 42 33 53,
    with boom [;
        print "Boom.";
    ];
```

...and observing that the .z3 file comes out the same as if I compile:

```
	with genprop 5 149 7 8,
```