### PR TITLE
Default_Language define allows default language to be determined at compile time

### DIFF
--- a/header.h
+++ b/header.h
@@ -576,6 +576,10 @@ static int32 unique_task_id(void)
 #endif
 #endif
 
+#ifndef Default_Language
+#define Default_Language "English"
+#endif
+
 #ifndef FN_SEP
 #define FN_SEP '/'
 #endif


### PR DESCRIPTION
Default_Language define allows default language to be determined at compile time

Do this by passing -DDefault_Language="French" or whatever to the C compiler.

Fixes #30.