### PR TITLE
Add Unix-style command-line options

### DIFF
--- a/inform.c
+++ b/inform.c
@@ -1247,18 +1247,21 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   +dir          set Include_Path to this directory\n\
   +PATH=dir     change the PATH to this directory\n\n\
   $...          one of the following memory commands:\n");
+  
   printf(
 "     $list            list current memory allocation settings\n\
      $huge            make standard \"huge game\" settings %s\n\
      $large           make standard \"large game\" settings %s\n\
      $small           make standard \"small game\" settings %s\n\
      $?SETTING        explain briefly what SETTING is for\n\
-     $SETTING=number  change SETTING to given number\n\n\
-  (filename)    read in a list of commands (in the format above)\n\
-                from this \"setup file\"\n\n",
+     $SETTING=number  change SETTING to given number\n\n",
     (DEFAULT_MEMORY_SIZE==HUGE_SIZE)?"(default)":"",
     (DEFAULT_MEMORY_SIZE==LARGE_SIZE)?"(default)":"",
     (DEFAULT_MEMORY_SIZE==SMALL_SIZE)?"(default)":"");
+
+  printf(
+"  (filename)    read in a list of commands (in the format above)\n\
+                from this \"setup file\"\n\n");
 
 #ifndef PROMPT_INPUT
     printf("For example: \"inform -dexs $huge curses\".\n\n");
@@ -1790,7 +1793,7 @@ static int execute_dashdash_command(char *p, char *p2)
         strcpyupper(cli_buff+2, p2, 254);
     }
     else {
-        printf("Switch \"--%s\" unknown (try \"inform -h\")\n", p);
+        printf("Option \"--%s\" unknown (try \"inform -h\")\n", p);
         return FALSE;
     }
 

--- a/inform.c
+++ b/inform.c
@@ -1797,8 +1797,7 @@ static int execute_dashdash_command(char *p, char *p2)
     }
     else if (!strcmp(p, "opt")) {
         consumed2 = TRUE;
-        //### or no equals sign
-        if (!p2) {
+        if (!p2 || !strchr(p2, '=')) {
             printf("--opt must be followed by \"setting=number\"\n");
             return consumed2;
         }

--- a/inform.c
+++ b/inform.c
@@ -1222,7 +1222,8 @@ static void cli_print_help(int help_level)
 {
     printf(
 "\nThis program is a compiler of Infocom format (also called \"Z-machine\")\n\
-story files: copyright (c) Graham Nelson 1993 - 2020.\n\n");
+story files, as well as \"Glulx\" story files:\n\
+Copyright (c) Graham Nelson 1993 - 2020.\n\n");
 
    /* For people typing just "inform", a summary only: */
 
@@ -1325,7 +1326,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   w   disable warning messages\n\
   x   print # for every 100 lines compiled\n\
   y   trace linking system\n\
-  z   print memory map of the Z-machine\n\n");
+  z   print memory map of the virtual machine\n\n");
 
 printf("\
   B   use big memory model (for large V6/V7 files)\n\

--- a/inform.c
+++ b/inform.c
@@ -1263,6 +1263,12 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 "  (filename)    read in a list of commands (in the format above)\n\
                 from this \"setup file\"\n\n");
 
+  printf("Alternate command-line formats for the above:\n\
+     --list\n\
+     --size huge, --size large, --size small\n\
+     --helpopt SETTING\n\
+     --opt SETTING=number\n\n");
+
 #ifndef PROMPT_INPUT
     printf("For example: \"inform -dexs $huge curses\".\n\n");
 #endif

--- a/inform.c
+++ b/inform.c
@@ -1267,10 +1267,12 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
                 from this \"setup file\"\n\n");
 
   printf("Alternate command-line formats for the above:\n\
-     --list\n\
-     --size huge, --size large, --size small\n\
-     --helpopt SETTING\n\
-     --opt SETTING=number\n\n");
+  --help                 (this page)\n\
+  --list\n\
+  --size huge, --size large, --size small\n\
+  --helpopt SETTING\n\
+  --opt SETTING=number\n\
+  --config filename      (setup file)\n\n");
 
 #ifndef PROMPT_INPUT
     printf("For example: \"inform -dexs $huge curses\".\n\n");
@@ -1813,7 +1815,14 @@ static int execute_dashdash_command(char *p, char *p2)
         strcpy(cli_buff, "$?");
         strcpyupper(cli_buff+2, p2, CMD_BUF_SIZE-2);
     }
-    //### --config
+    else if (!strcmp(p, "config")) {
+        consumed2 = TRUE;
+        if (!p2) {
+            printf("--config must be followed by \"file.icl\"\n");
+            return consumed2;
+        }
+        snprintf(cli_buff, CMD_BUF_SIZE, "(%s)", p2);
+    }
     //### --path name=foo?
     else {
         printf("Option \"--%s\" unknown (try \"inform -h\")\n", p);

--- a/inform.c
+++ b/inform.c
@@ -1248,7 +1248,9 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   -switches     a list of compiler switches, 1 or 2 letter\n\
                 (see \"inform -h2\" for the full range)\n\n\
   +dir          set Include_Path to this directory\n\
-  +PATH=dir     change the PATH to this directory\n\n\
+  ++dir         add this directory to Include_Path\n\
+  +PATH=dir     change the PATH to this directory\n\
+  ++PATH=dir    add this directory to the PATH\n\n\
   $...          one of the following memory commands:\n");
   
   printf(
@@ -1268,6 +1270,8 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 
   printf("Alternate command-line formats for the above:\n\
   --help                 (this page)\n\
+  --path PATH=dir\n\
+  --addpath PATH=dir\n\
   --list\n\
   --size huge, --size large, --size small\n\
   --helpopt SETTING\n\
@@ -1815,6 +1819,22 @@ static int execute_dashdash_command(char *p, char *p2)
         strcpy(cli_buff, "$?");
         strcpyupper(cli_buff+2, p2, CMD_BUF_SIZE-2);
     }
+    else if (!strcmp(p, "path")) {
+        consumed2 = TRUE;
+        if (!p2 || !strchr(p2, '=')) {
+            printf("--path must be followed by \"name=path\"\n");
+            return consumed2;
+        }
+        snprintf(cli_buff, CMD_BUF_SIZE, "+%s", p2);
+    }
+    else if (!strcmp(p, "addpath")) {
+        consumed2 = TRUE;
+        if (!p2 || !strchr(p2, '=')) {
+            printf("--addpath must be followed by \"name=path\"\n");
+            return consumed2;
+        }
+        snprintf(cli_buff, CMD_BUF_SIZE, "++%s", p2);
+    }
     else if (!strcmp(p, "config")) {
         consumed2 = TRUE;
         if (!p2) {
@@ -1823,7 +1843,6 @@ static int execute_dashdash_command(char *p, char *p2)
         }
         snprintf(cli_buff, CMD_BUF_SIZE, "(%s)", p2);
     }
-    //### --path name=foo?
     else {
         printf("Option \"--%s\" unknown (try \"inform -h\")\n", p);
         return FALSE;


### PR DESCRIPTION
Options look like:

  --help
  --path PATH=dir
  --addpath PATH=dir
  --list
  --size huge, --size large, --size small
  --helpopt SETTING
  --opt SETTING=number
  --config filename

SETTING names and PATH names are case-insensitive, same as they are in the old option syntax.

These are *not* new ICL commands. They can only be used on the command line, not in .icl files or !% source comments.

This addresses https://github.com/DavidKinder/Inform6/issues/26 .

I also fixed some potential buffer overflows, and defined a constant CMD_BUF_SIZE (in inform.c) so that it's easier to read the buffer overflow checks.
