### PR TITLE
Fix for https://github.com/DavidKinder/Inform6/issues/35

### DIFF
--- a/syntax.c
+++ b/syntax.c
@@ -600,6 +600,11 @@ extern void parse_code_block(int break_label, int continue_label,
     {   do
         {   begin_syntax_line(TRUE);
             get_next_token();
+            
+            if ((token_type == SEP_TT) && (token_value == HASH_SEP))
+            {   parse_directive(TRUE);
+                continue;
+            }
             if (token_type == SEP_TT && token_value == CLOSE_BRACE_SEP)
             {   if (switch_clause_made && (!default_clause_made))
                     assemble_label_no(switch_label);


### PR DESCRIPTION
"Ifdef doesn't work at the start of a switch block"

I wrote up a test of #ifdef in many places, which is now at
https://github.com/erkyrath/Inform6-Testing/blob/master/src/internaldirecttest.inf

Also tested recompiling Advent.inf and some I7 games; no change to generated game file. (The Inform6-Testing now automates this!)