### PR TITLE
Exclude most directives from being used inside a function or object definition

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -51,6 +51,26 @@ extern int parse_given_directive(int internal_flag)
     const char *constant_name;
     debug_location_beginning beginning_debug_location;
 
+    if (internal_flag)
+    {
+        /* Only certain directives, such as #ifdef, are permitted within
+           a routine or object definition. In older versions of Inform,
+           nearly any directive was accepted, but this was -- to quote
+           an old code comment -- "about as well-supported as Wile E. 
+           Coyote one beat before the plummet-lines kick in." */
+        
+        if (token_value != IFV3_CODE && token_value != IFV5_CODE
+            && token_value != IFDEF_CODE && token_value != IFNDEF_CODE
+            && token_value != IFTRUE_CODE && token_value != IFFALSE_CODE
+            && token_value != IFNOT_CODE && token_value != ENDIF_CODE
+            && token_value != MESSAGE_CODE && token_value != ORIGSOURCE_CODE
+            && token_value != TRACE_CODE) {
+            char *dirname = directives.keywords[token_value];
+            error_named("Cannot nest this directive inside a routine or object:", dirname);
+            panic_mode_error_recovery(); return FALSE;
+        }
+    }
+    
     switch(token_value)
     {
 
@@ -110,10 +130,6 @@ extern int parse_given_directive(int internal_flag)
     /* --------------------------------------------------------------------- */
 
     case CLASS_CODE: 
-        if (internal_flag)
-        {   error("Cannot nest #Class inside a routine or object");
-            panic_mode_error_recovery(); return FALSE;
-        }
         make_class(NULL);                                 /* See "objects.c" */
         return FALSE;
 
@@ -631,10 +647,6 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     /* --------------------------------------------------------------------- */
 
     case NEARBY_CODE:
-        if (internal_flag)
-        {   error("Cannot nest #Nearby inside a routine or object");
-            panic_mode_error_recovery(); return FALSE;
-        }
         make_object(TRUE, NULL, -1, -1, -1);
         return FALSE;                                     /* See "objects.c" */
 
@@ -643,10 +655,6 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     /* --------------------------------------------------------------------- */
 
     case OBJECT_CODE:
-        if (internal_flag)
-        {   error("Cannot nest #Object inside a routine or object");
-            panic_mode_error_recovery(); return FALSE;
-        }
         make_object(FALSE, NULL, -1, -1, -1);
         return FALSE;                                     /* See "objects.c" */
 
@@ -837,11 +845,6 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     /* --------------------------------------------------------------------- */
 
     case STUB_CODE:
-        if (internal_flag)
-        {   error("Cannot nest #Stub inside a routine or object");
-            panic_mode_error_recovery(); return FALSE;
-        }
-
         /* The upcoming symbol is a definition; don't count it as a
            top-level reference *to* the stub function. */
         df_dont_note_global_symbols = TRUE;

--- a/syntax.c
+++ b/syntax.c
@@ -71,13 +71,7 @@ extern void get_next_token_with_directives(void)
 
        This is called while parsing a long construct, such as Class or
        Object, where we want to support internal #ifdefs. (Although
-       function-parsing predates this and doesn't make use of it.)
-
-       (Technically this permits *any* #-directive, which means you
-       can define global variables or properties or what-have-you in
-       the middle of an object. You can do that in the middle of an
-       object, too. Don't. It's about as well-supported as Wile E.
-       Coyote one beat before the plummet-lines kick in.) */
+       function-parsing predates this and doesn't make use of it.) */
 
     int directives_save, segment_markers_save, statements_save;
 
@@ -142,6 +136,8 @@ extern int parse_directive(int internal_flag)
     /*  Internal_flag is FALSE if the directive is encountered normally,
         TRUE if encountered with a # prefix inside a routine or object
         definition.
+
+        (Only directives like #ifdef are permitted inside a definition.)
 
         Returns: TRUE if program continues, FALSE if end of file reached.    */
 


### PR DESCRIPTION
Only these directives will be permitted in a function or object definition:

    #ifv3 #ifv5 #ifdef #ifndef #iftrue #iffalse #ifnot #endif
    #message #origsource #trace

Previously, this check was only done for a few directives, which
meant you could (e.g.) define an array or grammar line in the middle
of defining a function. A comment mentioned that this was
"...about as well-supported as Wile E. Coyote one beat before the
plummet-lines kick in." Now there's a safety rail. Probably an
Acme brand safety rail.

I considered including `#undef` on the list, but couldn't think of a
real use case for it.

Conceivably we might want to support `#include` (imagine defining a very
large function that `#include`s code from another file). I'm not convinced
that this would work reliably, though, so I'm leaving it off the list
unless someone asks for it.

(This PR is independent of my PR from yesterday.)
