### PR TITLE
Report an error when an array length is defined with a backpatch value

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -81,6 +81,10 @@ extern void finish_array(int32 i, int is_static)
       area = static_array_area;
       area_size = static_array_area_size;
   }
+
+  if (i == 0) {
+      error("An array must have at least one entry");
+  }
   
     /*  Write the array size into the 0th byte/word of the array, if it's
         a "table" or "string" array                                          */
@@ -245,7 +249,7 @@ extern void array_entry(int32 i, int is_static, assembly_operand VAL)
 /*                                                                           */
 /*      | ->       |  <number-of-entries>                                    */
 /*      | -->      |  <entry-1> ... <entry-n>                                */
-/*      | string   |  [ <entry-1> [,] [;] <entry-2> ... <entry-n> ];         */
+/*      | string   |  [ <entry-1> [;] <entry-2> ... <entry-n> ];             */
 /*      | table                                                              */
 /*      | buffer                                                             */
 /*                                                                           */
@@ -530,8 +534,8 @@ extern void make_global(int array_flag, int name_only)
 
             CalculatedArraySize:
 
-            if (module_switch && (AO.marker != 0))
-            {   error("Array sizes must be known now, not externally defined");
+            if (AO.marker != 0)
+            {   error("Array sizes must be known now, not defined later");
                 break;
             }
 


### PR DESCRIPTION
This catches these errors:

    Array foo --> 'dictword';
    Array foo --> FunctionName;

Note that I'm not trying to mandate that array lengths can only be defined with integer literals. This will still work, although it's confusing:

    Array foo --> 'A';

(`'A'` is an ASCII character with value 65, which suffices to define a 65-word array.)

I also fixed a comment and added an error check for zero-length arrays. It was already an error to write

    Array foo --> 0;

We now catch the following case, which previously slipped through:

    Array foo --> [];

Fixes https://github.com/DavidKinder/Inform6/issues/40