### PR TITLE
Redefine errors

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -304,8 +304,8 @@ extern void make_global(int array_flag, int name_only)
     if ((token_type != SYMBOL_TT) || (!(sflags[i] & UNKNOWN_SFLAG)))
     {   discard_token_location(beginning_debug_location);
         if (array_flag)
-            ebf_error("new array name", token_text);
-        else ebf_error("new global variable name", token_text);
+            ebf_symbol_error("new array name", token_text, typename(stypes[i]), slines[i]);
+        else ebf_symbol_error("new global variable name", token_text, typename(stypes[i]), slines[i]);
         panic_mode_error_recovery(); return;
     }
 

--- a/arrays.c
+++ b/arrays.c
@@ -301,7 +301,15 @@ extern void make_global(int array_flag, int name_only)
             goto RedefinitionOfSystemVar;
     }
 
-    if ((token_type != SYMBOL_TT) || (!(sflags[i] & UNKNOWN_SFLAG)))
+    if (token_type != SYMBOL_TT)
+    {   discard_token_location(beginning_debug_location);
+        if (array_flag)
+            ebf_error("new array name", token_text);
+        else ebf_error("new global variable name", token_text);
+        panic_mode_error_recovery(); return;
+    }
+
+    if (!(sflags[i] & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
         if (array_flag)
             ebf_symbol_error("new array name", token_text, typename(stypes[i]), slines[i]);

--- a/errors.c
+++ b/errors.c
@@ -85,6 +85,11 @@ static char *location_text(brief_location report_line)
        This uses the static buffer other_pos_buff. */
     
     ErrorPosition errpos;
+    errpos.file_number = -1;
+    errpos.source = NULL;
+    errpos.line_number = 0;
+    errpos.main_flag = 0;
+    errpos.orig_source = NULL;
     export_brief_location(report_line, &errpos);
 
     int j;

--- a/errors.c
+++ b/errors.c
@@ -280,7 +280,7 @@ extern void ebf_error(char *s1, char *s2)
 }
 
 extern void ebf_symbol_error(char *s1, char *name, char *type, brief_location report_line)
-{   snprintf(error_message_buff, ERROR_BUFLEN, "\"%s\" is a name already in use and may not be used as a %s too (%s \"%s\" was defined at %s)", name, s1, type, name, location_text(report_line));
+{   snprintf(error_message_buff, ERROR_BUFLEN, "\"%s\" is a name already in use and may not be used as a %s (%s \"%s\" was defined at %s)", name, s1, type, name, location_text(report_line));
     ellipsize_error_message_buff();
     error(error_message_buff);
 }

--- a/header.h
+++ b/header.h
@@ -2276,6 +2276,7 @@ extern void error_named(char *s1, char *s2);
 extern void error_numbered(char *s1, int val);
 extern void error_named_at(char *s1, char *s2, brief_location report_line);
 extern void ebf_error(char *s1, char *s2);
+extern void ebf_symbol_error(char *s1, char *name, char *type, brief_location report_line);
 extern void char_error(char *s, int ch);
 extern void unicode_char_error(char *s, int32 uni);
 extern void no_such_label(char *lname);

--- a/objects.c
+++ b/objects.c
@@ -121,9 +121,16 @@ more than",
 
     get_next_token();
     i = token_value; name = token_text;
-    if ((token_type != SYMBOL_TT) || (!(sflags[i] & UNKNOWN_SFLAG)))
+    if (token_type != SYMBOL_TT)
     {   discard_token_location(beginning_debug_location);
         ebf_error("new attribute name", token_text);
+        panic_mode_error_recovery(); 
+        put_token_back();
+        return;
+    }
+    if (!(sflags[i] & UNKNOWN_SFLAG))
+    {   discard_token_location(beginning_debug_location);
+        ebf_symbol_error("new attribute name", token_text, typename(stypes[i]), slines[i]);
         panic_mode_error_recovery(); 
         put_token_back();
         return;
@@ -212,9 +219,16 @@ Advanced game to get an extra 62)");
     get_next_token();
 
     i = token_value; name = token_text;
-    if ((token_type != SYMBOL_TT) || (!(sflags[i] & UNKNOWN_SFLAG)))
+    if (token_type != SYMBOL_TT)
     {   discard_token_location(beginning_debug_location);
         ebf_error("new property name", token_text);
+        panic_mode_error_recovery();
+        put_token_back();
+        return;
+    }
+    if (!(sflags[i] & UNKNOWN_SFLAG))
+    {   discard_token_location(beginning_debug_location);
+        ebf_symbol_error("new property name", token_text, typename(stypes[i]), slines[i]);
         panic_mode_error_recovery();
         put_token_back();
         return;
@@ -1752,10 +1766,15 @@ inconvenience, please contact the maintainers.");
     }
     else
     {   get_next_token();
-        if ((token_type != SYMBOL_TT)
-            || (!(sflags[token_value] & UNKNOWN_SFLAG)))
+        if (token_type != SYMBOL_TT)
         {   discard_token_location(beginning_debug_location);
             ebf_error("new class name", token_text);
+            panic_mode_error_recovery();
+            return;
+        }
+        if (!(sflags[token_value] & UNKNOWN_SFLAG))
+        {   discard_token_location(beginning_debug_location);
+            ebf_symbol_error("new class name", token_text, typename(stypes[token_value]), slines[token_value]);
             panic_mode_error_recovery();
             return;
         }

--- a/objects.c
+++ b/objects.c
@@ -1067,12 +1067,7 @@ static void properties_segment_z(int this_segment)
             {   if (stypes[token_value]==INDIVIDUAL_PROPERTY_T)
                     this_identifier_number = svals[token_value];
                 else
-                {   char already_error[128];
-                    sprintf(already_error,
-                        "\"%s\" is a name already in use (with type %s) \
-and may not be used as a property name too",
-                        token_text, typename(stypes[token_value]));
-                    error(already_error);
+                {   ebf_symbol_error("property name", token_text, typename(stypes[token_value]), slines[token_value]);
                     return;
                 }
             }
@@ -1336,12 +1331,7 @@ static void properties_segment_g(int this_segment)
             {   if (stypes[token_value]==INDIVIDUAL_PROPERTY_T)
                     this_identifier_number = svals[token_value];
                 else
-                {   char already_error[128];
-                    sprintf(already_error,
-                        "\"%s\" is a name already in use (with type %s) \
-and may not be used as a property name too",
-                        token_text, typename(stypes[token_value]));
-                    error(already_error);
+                {   ebf_symbol_error("property name", token_text, typename(stypes[token_value]), slines[token_value]);
                     return;
                 }
             }

--- a/objects.c
+++ b/objects.c
@@ -1971,10 +1971,13 @@ extern void make_object(int nearby_flag,
 
     if (token_type == DQ_TT) textual_name = token_text;
     else
-    {   if ((token_type != SYMBOL_TT)
-            || (!(sflags[token_value] & UNKNOWN_SFLAG)))
+    {   if (token_type != SYMBOL_TT) {
             ebf_error("name for new object or its textual short name",
                 token_text);
+        }
+        else if (!(sflags[token_value] & UNKNOWN_SFLAG)) {
+            ebf_symbol_error("new object", token_text, typename(stypes[token_value]), slines[token_value]);
+        }
         else
         {   internal_name_symbol = token_value;
             strcpy(internal_name, token_text);

--- a/syntax.c
+++ b/syntax.c
@@ -170,7 +170,7 @@ extern int parse_directive(int internal_flag)
         if ((token_type != SYMBOL_TT)
             || ((!(sflags[token_value] & UNKNOWN_SFLAG))
                 && (!(sflags[token_value] & REPLACE_SFLAG))))
-        {   ebf_error("routine name", token_text);
+        {   ebf_symbol_error("routine name", token_text, typename(stypes[token_value]), slines[token_value]);
             return(FALSE);
         }
 

--- a/syntax.c
+++ b/syntax.c
@@ -167,9 +167,12 @@ extern int parse_directive(int internal_flag)
         df_dont_note_global_symbols = TRUE;
         get_next_token();
         df_dont_note_global_symbols = FALSE;
-        if ((token_type != SYMBOL_TT)
-            || ((!(sflags[token_value] & UNKNOWN_SFLAG))
-                && (!(sflags[token_value] & REPLACE_SFLAG))))
+        if (token_type != SYMBOL_TT)
+        {   ebf_error("routine name", token_text);
+            return(FALSE);
+        }
+        if ((!(sflags[token_value] & UNKNOWN_SFLAG))
+            && (!(sflags[token_value] & REPLACE_SFLAG)))
         {   ebf_symbol_error("routine name", token_text, typename(stypes[token_value]), slines[token_value]);
             return(FALSE);
         }

--- a/verbs.c
+++ b/verbs.c
@@ -132,13 +132,15 @@ extern void make_fake_action(void)
         ebf_error("new fake action name", token_text);
         panic_mode_error_recovery(); return;
     }
+    /* Action symbols (including fake_actions) may collide with other kinds of symbols. So we don't check that. */
 
     snprintf(action_sub, MAX_IDENTIFIER_LENGTH+4, "%s__A", token_text);
     i = symbol_index(action_sub, -1);
 
     if (!(sflags[i] & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
-        ebf_error("new fake action name", token_text);
+        /* The user didn't know they were defining FOO__A, but they were and it's a problem. */
+        ebf_symbol_error("new fake action name", action_sub, typename(stypes[i]), slines[i]);
         panic_mode_error_recovery(); return;
     }
 


### PR DESCRIPTION
Displays better error messages if you try to redefine an existing symbol.

This only touches error-reporting code, not code generation.

I've generally divided each error into two cases. If the token is not a symbol, it displays the original error:

    Object ?;

> line 11: Error:  Expected name for new object or its textual short name but found ?

If the token is an already-defined symbol, it instead displays:

    Object Main;

> line 11: Error:  "Main" is a name already in use and may not be used as a new object too (Routine "Main" was defined at line 3)

