### PR TITLE
Fix an obvious typo in Glulx branch range checking

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -2064,13 +2064,13 @@ static void transfer_routine_g(void)
                 ((form_len == 2) ? "short" : "long")));
         }
         if (form_len == 1) {
-            if (addr < -0x80 && addr >= 0x80) {
+            if (addr < -0x80 || addr >= 0x80) {
                 error("*** Label out of range for byte branch ***");
             }
-        zcode_holding_area[i] = (addr) & 0xFF;
+            zcode_holding_area[i] = (addr) & 0xFF;
         }
         else if (form_len == 2) {
-            if (addr < -0x8000 && addr >= 0x8000) {
+            if (addr < -0x8000 || addr >= 0x8000) {
                 error("*** Label out of range for short branch ***");
             }
             zcode_holding_area[i] = (addr >> 8) & 0xFF;


### PR DESCRIPTION
(This has been in there forever, or at least since 6.30.)

The latest version of the clang compiler displayed a warning:

```
asm.c:2067:30: warning: overlapping comparisons always evaluate to false
      [-Wtautological-overlap-compare]
            if (addr < -0x80 && addr >= 0x80) {
asm.c:2073:32: warning: overlapping comparisons always evaluate to false
      [-Wtautological-overlap-compare]
            if (addr < -0x8000 && addr >= 0x8000) {
```

Indeed, those lines are blatantly wrong -- they should be `||` rather than `&&`. So the errors caught by those lines have never really been caught.

It's possible that, once upon a time, this has failed to catch a real error and thus generated a bad game file. But I don't remember anybody complaining about Glulx games crashing because of bad jumps. I think this was a backup check.

