### PR TITLE
C89 variable fix

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -279,6 +279,10 @@ extern void make_global(int array_flag, int name_only)
     int array_type, data_type;
     int is_static = FALSE;
     assembly_operand AO;
+	
+	int extraspace;
+	int orig_area_size;
+	int32 new_area_size;
 
     int32 global_symbol;
     const char *global_name;
@@ -512,13 +516,11 @@ extern void make_global(int array_flag, int name_only)
 
     /*  Leave room to write the array size in later, if string/table array   */
     
-    int extraspace = 0;
+    extraspace = 0;
     if ((array_type==STRING_ARRAY) || (array_type==TABLE_ARRAY))
         extraspace += array_entry_size;
     if (array_type==BUFFER_ARRAY)
         extraspace += WORDSIZE;
-
-    int orig_area_size;
     
     if (!is_static) {
         orig_area_size = dynamic_array_area_size;
@@ -685,7 +687,7 @@ advance as part of 'Zcharacter table':", unicode);
         debug_file_printf("<value>");
         write_debug_array_backpatch(svals[global_symbol]);
         debug_file_printf("</value>");
-        int32 new_area_size = (!is_static ? dynamic_array_area_size : static_array_area_size);
+        new_area_size = (!is_static ? dynamic_array_area_size : static_array_area_size);
         debug_file_printf
             ("<byte-count>%d</byte-count>",
              new_area_size - array_base);

--- a/errors.c
+++ b/errors.c
@@ -80,6 +80,10 @@ static void print_preamble(void)
 
 static char *location_text(brief_location report_line)
 {
+	int j;
+    char *p;
+	int len;
+
     /* Convert the location to a brief string. 
        (Some error messages need to report a secondary location.)
        This uses the static buffer other_pos_buff. */
@@ -91,9 +95,6 @@ static char *location_text(brief_location report_line)
     errpos.main_flag = 0;
     errpos.orig_source = NULL;
     export_brief_location(report_line, &errpos);
-
-    int j;
-    char *p;
     
     j = errpos.file_number;
     if (j <= 0 || j > total_files) p = errpos.source;
@@ -101,7 +102,7 @@ static char *location_text(brief_location report_line)
     
     if (!p) p = "";
 
-    int len = 0;
+    len = 0;
     
     if (!(errpos.main_flag)) {
         snprintf(other_pos_buff+len, ERROR_BUFLEN-len,

--- a/files.c
+++ b/files.c
@@ -182,6 +182,7 @@ extern void close_all_source(void)
 extern int register_orig_sourcefile(char *filename)
 {
     int ix;
+	char *name;
 
     /* If the filename has already been used as an origsource filename,
        return that entry. We check the most-recently-used file first, and
@@ -203,7 +204,7 @@ extern int register_orig_sourcefile(char *filename)
     /* This filename has never been used before. Allocate a new InputFiles
        entry. */
 
-    char *name = filename; /* no translation */
+    name = filename; /* no translation */
 
     if (total_files == MAX_SOURCE_FILES)
         memoryerror("MAX_SOURCE_FILES", MAX_SOURCE_FILES);

--- a/inform.c
+++ b/inform.c
@@ -1901,14 +1901,17 @@ static void read_command_line(int argc, char **argv)
 }
 #else
 static void read_command_line(int argc, char **argv)
-{   int i;
+{   
+	int i;
+	int consumed2;
+
     if (argc==1) switches("-h",1);
 
     for (i=1, cli_files_specified=0; i<argc; i++)
         if (argv[i][0] == '-' && argv[i][1] == '-') {
             char *nextarg = NULL;
             if (i+1 < argc) nextarg = argv[i+1];
-            int consumed2 = execute_dashdash_command(argv[i]+2, nextarg);
+            consumed2 = execute_dashdash_command(argv[i]+2, nextarg);
             if (consumed2 && i+1 < argc) {
                 i++;
             }

--- a/lexer.c
+++ b/lexer.c
@@ -940,6 +940,8 @@ extern int is_systemfile(void)
 
 extern void set_origsource_location(char *source, int32 line, int32 charnum)
 {
+	int file_no;
+
     if (!source) {
         /* Clear the Origsource declaration. */
         CurrentLB->orig_file = 0;
@@ -950,7 +952,7 @@ extern void set_origsource_location(char *source, int32 line, int32 charnum)
     }
 
     /* Get the file number for a new or existing InputFiles entry. */
-    int file_no = register_orig_sourcefile(source);
+    file_no = register_orig_sourcefile(source);
 
     CurrentLB->orig_file = file_no;
     CurrentLB->orig_source = InputFiles[file_no-1].filename;

--- a/symbols.c
+++ b/symbols.c
@@ -1210,6 +1210,9 @@ uint32 df_stripped_offset_for_code_offset(uint32 offset, int *stripped)
 {
     df_function_t *func;
     int count;
+	int beg;
+	int end;
+	int new;
 
     if (!track_unused_routines)
         compiler_error("DF: df_stripped_offset_for_code_offset called, but function references have not been mapped");
@@ -1237,8 +1240,8 @@ uint32 df_stripped_offset_for_code_offset(uint32 offset, int *stripped)
 
     /* Do a binary search. Maintain beg <= res < end, where res is the
        function containing the desired address. */
-    int beg = 0;
-    int end = df_functions_sorted_count;
+    beg = 0;
+    end = df_functions_sorted_count;
 
     /* Set stripped flag until we decide on a non-stripped function. */
     *stripped = TRUE;
@@ -1255,7 +1258,7 @@ uint32 df_stripped_offset_for_code_offset(uint32 offset, int *stripped)
             *stripped = FALSE;
             return func->newaddress + (offset - func->address);
         }
-        int new = (beg + end) / 2;
+        new = (beg + end) / 2;
         if (new <= beg || new >= end)
             compiler_error("DF: binary search went off the rails");
 


### PR DESCRIPTION
This commit moves variable declarations to the top of their functions. C99 has no problems with variables being declared in the middle of a function, but C89/VC++6 chokes on this.

NOTE: This change *doesn't* mean you can just compile Inform6 with C89/VC++6 as-is -- there are other issues that you will need to patch yourself:

* `remove` needs to be mapped to `unlink`
* A drop-in replacement for `snprintf` must be provided