### PR TITLE
Support MAX_ABBREVS in Z-code

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -93,11 +93,6 @@ extern int parse_given_directive(int internal_flag)
            if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
                return FALSE;
 
-           /* Z-code has a 64-abbrev limit; Glulx doesn't. */
-           if (!glulx_mode && no_abbreviations==64)
-           {   error("All 64 abbreviations already declared");
-               panic_mode_error_recovery(); return FALSE;
-           }
            if (no_abbreviations==MAX_ABBREVS)
                memoryerror("MAX_ABBREVS", MAX_ABBREVS);
 

--- a/directs.c
+++ b/directs.c
@@ -93,6 +93,10 @@ extern int parse_given_directive(int internal_flag)
            if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
                return FALSE;
 
+           if (!glulx_mode && no_abbreviations==96)
+           {   error("All 96 Z-machine abbreviations already declared");
+               panic_mode_error_recovery(); return FALSE;
+           }
            if (no_abbreviations==MAX_ABBREVS)
                memoryerror("MAX_ABBREVS", MAX_ABBREVS);
 

--- a/directs.c
+++ b/directs.c
@@ -595,6 +595,10 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         {   error("'LowString' cannot be used in -M (Module) mode");
             panic_mode_error_recovery(); return FALSE;
         }
+        if (glulx_mode) {
+            error("The LowString directive has no meaning in Glulx.");
+            panic_mode_error_recovery(); return FALSE;
+        }
         get_next_token(); i = token_value;
         if (token_type != SYMBOL_TT)
             return ebf_error_recover("new low string name", token_text);

--- a/header.h
+++ b/header.h
@@ -2530,7 +2530,7 @@ extern int MAX_QTEXT_SIZE,  MAX_SYMBOLS,    HASH_TAB_SIZE,   MAX_DICT_ENTRIES,
            MAX_EXPRESSION_NODES, MAX_LABELS,            MAX_LINESPACE,
            MAX_LOW_STRINGS,      MAX_CLASSES,           MAX_VERBS,
            MAX_VERBSPACE,        MAX_ARRAYS,            MAX_INCLUSION_DEPTH,
-           MAX_SOURCE_FILES;
+           MAX_SOURCE_FILES,     MAX_DYNAMIC_STRINGS;
 
 extern int32 MAX_STATIC_STRINGS, MAX_ZCODE_SIZE, MAX_LINK_DATA_SIZE,
            MAX_TRANSCRIPT_SIZE,  MAX_INDIV_PROP_TABLE_SIZE,
@@ -2736,8 +2736,6 @@ extern int32 static_strings_extent;
 
 extern int32 no_strings, no_dynamic_strings;
 extern int no_unicode_chars;
-
-#define MAX_DYNAMIC_STRINGS (64)
 
 typedef struct unicode_usage_s unicode_usage_t;
 struct unicode_usage_s {

--- a/inform.c
+++ b/inform.c
@@ -210,12 +210,20 @@ static void select_target(int targ)
   if (!targ) {
     /* Z-machine */
     /* The Z-machine's 96 abbreviations are used for these two purposes.
-       We were supposed to make sure they were set consistently. This
-       is a double-check. */
+       Make sure they are set consistently. If exactly one has been
+       set non-default, set the other to match. */
+    if (MAX_DYNAMIC_STRINGS == 32 && MAX_ABBREVS != 64) {
+        MAX_DYNAMIC_STRINGS = 96 - MAX_ABBREVS;
+    }
+    if (MAX_ABBREVS == 64 && MAX_DYNAMIC_STRINGS != 32) {
+        MAX_ABBREVS = 96 - MAX_DYNAMIC_STRINGS;
+    }
     if (MAX_ABBREVS + MAX_DYNAMIC_STRINGS != 96
-        || MAX_ABBREVS > 96
-        || MAX_DYNAMIC_STRINGS > 96) {
-      compiler_error("MAX_ABBREVS plus MAX_DYNAMIC_STRINGS must be 96 in Z-code");
+        || MAX_ABBREVS < 0
+        || MAX_DYNAMIC_STRINGS < 0) {
+      warning("MAX_ABBREVS plus MAX_DYNAMIC_STRINGS must be 96 in Z-code; resetting");
+      MAX_DYNAMIC_STRINGS = 32;
+      MAX_ABBREVS = 64;
     }
   }
   else {

--- a/inform.c
+++ b/inform.c
@@ -206,6 +206,16 @@ static void select_target(int targ)
       DICT_ENTRY_FLAG_POS = (4+DICT_WORD_BYTES);
     }
   }
+
+  if (!targ) {
+    /* Z-machine */
+    /* The Z-machine's 96 abbreviations are used for these two purposes.
+       We were supposed to make sure they were set consistently. This
+       is a double-check. */
+    if (MAX_ABBREVS + MAX_DYNAMIC_STRINGS != 96) {
+      compiler_error("MAX_ABBREVS plus MAX_DYNAMIC_STRINGS must be 96 in Z-code");
+    }
+  }
 }
 
 /* ------------------------------------------------------------------------- */

--- a/inform.c
+++ b/inform.c
@@ -212,8 +212,18 @@ static void select_target(int targ)
     /* The Z-machine's 96 abbreviations are used for these two purposes.
        We were supposed to make sure they were set consistently. This
        is a double-check. */
-    if (MAX_ABBREVS + MAX_DYNAMIC_STRINGS != 96) {
+    if (MAX_ABBREVS + MAX_DYNAMIC_STRINGS != 96
+        || MAX_ABBREVS > 96
+        || MAX_DYNAMIC_STRINGS > 96) {
       compiler_error("MAX_ABBREVS plus MAX_DYNAMIC_STRINGS must be 96 in Z-code");
+    }
+  }
+  else {
+    if (MAX_DYNAMIC_STRINGS > 100) {
+      MAX_DYNAMIC_STRINGS = 100;
+      warning("MAX_DYNAMIC_STRINGS cannot exceed 100; resetting to 100");
+      /* This is because they are specified in text literals like "@00",
+         with two digits. */
     }
   }
 }

--- a/inform.c
+++ b/inform.c
@@ -221,7 +221,7 @@ static void select_target(int targ)
     if (MAX_ABBREVS + MAX_DYNAMIC_STRINGS != 96
         || MAX_ABBREVS < 0
         || MAX_DYNAMIC_STRINGS < 0) {
-      warning("MAX_ABBREVS plus MAX_DYNAMIC_STRINGS must be 96 in Z-code; resetting");
+      warning("MAX_ABBREVS plus MAX_DYNAMIC_STRINGS must be 96 in Z-code; resetting both");
       MAX_DYNAMIC_STRINGS = 32;
       MAX_ABBREVS = 64;
     }

--- a/memory.c
+++ b/memory.c
@@ -691,7 +691,7 @@ static void explain_parameter(char *command)
     if (strcmp(command,"MAX_DYNAMIC_STRINGS")==0)
     {   printf(
 "  MAX_DYNAMIC_STRINGS is the maximum number of string substitution variables\n\
-  (\"@00\").  It is not allowed to exceed 96 in Z-code or 99 in Glulx.\n");
+  (\"@00\").  It is not allowed to exceed 96 in Z-code or 100 in Glulx.\n");
         return;
     }
     if (strcmp(command,"MAX_ARRAYS")==0)

--- a/memory.c
+++ b/memory.c
@@ -383,8 +383,6 @@ extern void set_memory_sizes(int size_flag)
         MAX_PROP_TABLE_SIZE_z = 30000;
         MAX_PROP_TABLE_SIZE_g = 60000;
 
-        MAX_ABBREVS = 64;
-
         MAX_EXPRESSION_NODES = 100;
         MAX_VERBS = 200;
         MAX_VERBSPACE = 4096;
@@ -432,8 +430,6 @@ extern void set_memory_sizes(int size_flag)
 
         MAX_PROP_TABLE_SIZE_z = 15000;
         MAX_PROP_TABLE_SIZE_g = 30000;
-
-        MAX_ABBREVS = 64;
 
         MAX_EXPRESSION_NODES = 100;
         MAX_VERBS = 140;
@@ -483,8 +479,6 @@ extern void set_memory_sizes(int size_flag)
         MAX_PROP_TABLE_SIZE_z = 8000;
         MAX_PROP_TABLE_SIZE_g = 16000;
 
-        MAX_ABBREVS = 64;
-
         MAX_EXPRESSION_NODES = 40;
         MAX_VERBS = 110;
         MAX_VERBSPACE = 2048;
@@ -526,6 +520,7 @@ extern void set_memory_sizes(int size_flag)
     DICT_WORD_SIZE_g = 9;
     NUM_ATTR_BYTES_z = 6;
     NUM_ATTR_BYTES_g = 7;
+    MAX_ABBREVS = 64;
     /* Backwards-compatible behavior: allow for a unicode table
        whether we need one or not. The user can set this to zero if
        there's no unicode table. */

--- a/memory.c
+++ b/memory.c
@@ -242,6 +242,7 @@ int MAX_DICT_ENTRIES;
 int MAX_STATIC_DATA;
 int MAX_PROP_TABLE_SIZE;
 int MAX_ABBREVS;
+int MAX_DYNAMIC_STRINGS;
 int MAX_EXPRESSION_NODES;
 int MAX_VERBS;
 int MAX_VERBSPACE;
@@ -286,6 +287,7 @@ static int MAX_LOCAL_VARIABLES_z, MAX_LOCAL_VARIABLES_g;
 static int DICT_WORD_SIZE_z, DICT_WORD_SIZE_g;
 static int NUM_ATTR_BYTES_z, NUM_ATTR_BYTES_g;
 static int ALLOC_CHUNK_SIZE_z, ALLOC_CHUNK_SIZE_g;
+static int MAX_DYNAMIC_STRINGS_z, MAX_DYNAMIC_STRINGS_g;
 
 /* ------------------------------------------------------------------------- */
 /*   Memory control from the command line                                    */
@@ -306,6 +308,7 @@ static void list_memory_sizes(void)
     printf("|  %25s = %-7d |\n","DICT_WORD_SIZE",DICT_WORD_SIZE);
     if (glulx_mode)
       printf("|  %25s = %-7d |\n","DICT_CHAR_SIZE",DICT_CHAR_SIZE);
+    printf("|  %25s = %-7d |\n","MAX_DYNAMIC_STRINGS",MAX_DYNAMIC_STRINGS);
     printf("|  %25s = %-7d |\n","MAX_EXPRESSION_NODES",MAX_EXPRESSION_NODES);
     printf("|  %25s = %-7d |\n","MAX_GLOBAL_VARIABLES",MAX_GLOBAL_VARIABLES);
     printf("|  %25s = %-7d |\n","HASH_TAB_SIZE",HASH_TAB_SIZE);
@@ -521,6 +524,8 @@ extern void set_memory_sizes(int size_flag)
     NUM_ATTR_BYTES_z = 6;
     NUM_ATTR_BYTES_g = 7;
     MAX_ABBREVS = 64;
+    MAX_DYNAMIC_STRINGS_z = 32;
+    MAX_DYNAMIC_STRINGS_g = 64;
     /* Backwards-compatible behavior: allow for a unicode table
        whether we need one or not. The user can set this to zero if
        there's no unicode table. */
@@ -551,6 +556,7 @@ extern void adjust_memory_sizes()
     DICT_WORD_SIZE = DICT_WORD_SIZE_z;
     NUM_ATTR_BYTES = NUM_ATTR_BYTES_z;
     ALLOC_CHUNK_SIZE = ALLOC_CHUNK_SIZE_z;
+    MAX_DYNAMIC_STRINGS = MAX_DYNAMIC_STRINGS_z;
     INDIV_PROP_START = 64;
   }
   else {
@@ -561,6 +567,7 @@ extern void adjust_memory_sizes()
     DICT_WORD_SIZE = DICT_WORD_SIZE_g;
     NUM_ATTR_BYTES = NUM_ATTR_BYTES_g;
     ALLOC_CHUNK_SIZE = ALLOC_CHUNK_SIZE_g;
+    MAX_DYNAMIC_STRINGS = MAX_DYNAMIC_STRINGS_g;
     INDIV_PROP_START = 256;
   }
 }
@@ -678,7 +685,13 @@ static void explain_parameter(char *command)
     if (strcmp(command,"MAX_ABBREVS")==0)
     {   printf(
 "  MAX_ABBREVS is the maximum number of declared abbreviations.  It is not \n\
-  allowed to exceed 64.\n");
+  allowed to exceed 96 in Z-code.\n");
+        return;
+    }
+    if (strcmp(command,"MAX_DYNAMIC_STRINGS")==0)
+    {   printf(
+"  MAX_DYNAMIC_STRINGS is the maximum number of string substitution variables\n\
+  (\"@00\").  It is not allowed to exceed 96 in Z-code or 99 in Glulx.\n");
         return;
     }
     if (strcmp(command,"MAX_ARRAYS")==0)
@@ -1015,6 +1028,10 @@ extern void memory_command(char *command)
                 flag=2;
             if (strcmp(command,"MAX_ABBREVS")==0)
                 MAX_ABBREVS=j, flag=1;
+            if (strcmp(command,"MAX_DYNAMIC_STRINGS")==0)
+            {   MAX_DYNAMIC_STRINGS=j, flag=1;
+                MAX_DYNAMIC_STRINGS_g=MAX_DYNAMIC_STRINGS_z=j;
+            }
             if (strcmp(command,"MAX_ARRAYS")==0)
                 MAX_ARRAYS=j, flag=1;
             if (strcmp(command,"MAX_EXPRESSION_NODES")==0)

--- a/states.c
+++ b/states.c
@@ -1584,6 +1584,11 @@ static void parse_statement_z(int break_label, int continue_label)
                  assemblez_2_to(loadw_zc, AO, AO2, AO3);
                  AO2 = code_generate(parse_expression(QUANTITY_CONTEXT),
                      QUANTITY_CONTEXT, -1);
+                 if (is_constant_ot(AO2.type) && AO2.marker == 0) {
+                     if (AO2.value < 0 || AO2.value >= 32) { //### MAX_DYNAMIC_STRINGS
+                         memoryerror("MAX_DYNAMIC_STRINGS", MAX_DYNAMIC_STRINGS);
+                     }
+                 }
                  get_next_token();
                  if (token_type == DQ_TT)
                  {   INITAOT(&AO4, LONG_CONSTANT_OT);
@@ -2516,6 +2521,11 @@ static void parse_statement_g(int break_label, int continue_label)
         case STRING_CODE:
                  AO2 = code_generate(parse_expression(QUANTITY_CONTEXT),
                      QUANTITY_CONTEXT, -1);
+                 if (is_constant_ot(AO2.type) && AO2.marker == 0) {
+                     if (AO2.value < 0 || AO2.value >= MAX_DYNAMIC_STRINGS) {
+                         memoryerror("MAX_DYNAMIC_STRINGS", MAX_DYNAMIC_STRINGS);
+                     }
+                 }
                  get_next_token();
                  if (token_type == DQ_TT)
                  {   INITAOT(&AO4, CONSTANT_OT);

--- a/states.c
+++ b/states.c
@@ -1585,6 +1585,10 @@ static void parse_statement_z(int break_label, int continue_label)
                  AO2 = code_generate(parse_expression(QUANTITY_CONTEXT),
                      QUANTITY_CONTEXT, -1);
                  if (is_constant_ot(AO2.type) && AO2.marker == 0) {
+                     if (AO2.value >= 96)
+                     {   error("Z-machine dynamic strings are limited to 96");
+                         AO2.value = 0;
+                     }
                      if (AO2.value < 0 || AO2.value >= MAX_DYNAMIC_STRINGS) {
                          memoryerror("MAX_DYNAMIC_STRINGS", MAX_DYNAMIC_STRINGS);
                      }

--- a/states.c
+++ b/states.c
@@ -1585,7 +1585,7 @@ static void parse_statement_z(int break_label, int continue_label)
                  AO2 = code_generate(parse_expression(QUANTITY_CONTEXT),
                      QUANTITY_CONTEXT, -1);
                  if (is_constant_ot(AO2.type) && AO2.marker == 0) {
-                     if (AO2.value < 0 || AO2.value >= 32) { //### MAX_DYNAMIC_STRINGS
+                     if (AO2.value < 0 || AO2.value >= MAX_DYNAMIC_STRINGS) {
                          memoryerror("MAX_DYNAMIC_STRINGS", MAX_DYNAMIC_STRINGS);
                      }
                  }

--- a/tables.c
+++ b/tables.c
@@ -282,13 +282,23 @@ static void construct_storyfile_z(void)
         p[0x42+i]=low_strings[i];
 
     abbrevs_at = mark;
-    for (i=0; i<3*32; i++)                       /* Initially all 96 entries */
-    {   p[mark++]=0; p[mark++]=0x20;                     /* are set to "   " */
+    
+    if (MAX_ABBREVS + MAX_DYNAMIC_STRINGS != 96)
+        fatalerror("MAX_ABBREVS + MAX_DYNAMIC_STRINGS is not 96");
+    
+    /* Initially all 96 entries are set to "   ". (We store half of 0x40,
+       the address of the "   " we wrote above.) */
+    for (i=0; i<3*32; i++)
+    {   p[mark++]=0; p[mark++]=0x20;
     }
-    for (i=0; i<no_abbreviations; i++)            /* Write any abbreviations */
-    {   j=abbrev_values[i];                            /* into banks 2 and 3 */
-        p[abbrevs_at+64+2*i]=j/256;               /* (bank 1 is reserved for */
-        p[abbrevs_at+65+2*i]=j%256;                   /* "variable strings") */
+    
+    /* Entries from 0 to MAX_DYNAMIC_STRINGS (default 32) are "variable 
+       strings". Write the abbreviations after these. */
+    k = abbrevs_at+2*MAX_DYNAMIC_STRINGS;
+    for (i=0; i<no_abbreviations; i++)
+    {   j=abbrev_values[i];
+        p[k++]=j/256;
+        p[k++]=j%256;
     }
 
     /*  ------------------- Header extension table ------------------------- */

--- a/text.c
+++ b/text.c
@@ -443,8 +443,9 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text)
         if ((economy_switch) && (!is_abbreviation)
             && ((k=abbrevs_lookup[text_in[i]])!=-1))
         {   if ((j=try_abbreviations_from(text_in, i, k))!=-1)
-            {   if (j<32) { write_z_char_z(2); write_z_char_z(j); }
-                else { write_z_char_z(3); write_z_char_z(j-32); }
+            {   /* abbreviations run from MAX_DYNAMIC_STRINGS to 96 */
+                j += MAX_DYNAMIC_STRINGS;
+                write_z_char_z(j/32+1); write_z_char_z(j%32);
             }
         }
 

--- a/text.c
+++ b/text.c
@@ -507,8 +507,14 @@ advance as part of 'Zcharacter table':", unicode);
                 if ((d1 == 127) || (d1 >= 10) || (d2 == 127) || (d2 >= 10))
                     error("'@..' must have two decimal digits");
                 else
-                {   i+=2;
-                    write_z_char_z(1); write_z_char_z(d1*10 + d2);
+                {
+                    j = d1*10 + d2;
+                    if (j >= 32) { //### MAX_DYNAMIC_STRINGS
+                        memoryerror("MAX_DYNAMIC_STRINGS", MAX_DYNAMIC_STRINGS);
+                        j = 0;
+                    }
+                    i+=2;
+                    write_z_char_z(1); write_z_char_z(j);
                 }
             }
             else

--- a/text.c
+++ b/text.c
@@ -509,7 +509,7 @@ advance as part of 'Zcharacter table':", unicode);
                 else
                 {
                     j = d1*10 + d2;
-                    if (j >= 32) { //### MAX_DYNAMIC_STRINGS
+                    if (j >= MAX_DYNAMIC_STRINGS) {
                         memoryerror("MAX_DYNAMIC_STRINGS", MAX_DYNAMIC_STRINGS);
                         j = 0;
                     }

--- a/text.c
+++ b/text.c
@@ -510,6 +510,10 @@ advance as part of 'Zcharacter table':", unicode);
                 else
                 {
                     j = d1*10 + d2;
+                    if (!glulx_mode && j >= 96)
+                    {   error("Z-machine dynamic strings are limited to 96");
+                        j = 0;
+                    }
                     if (j >= MAX_DYNAMIC_STRINGS) {
                         memoryerror("MAX_DYNAMIC_STRINGS", MAX_DYNAMIC_STRINGS);
                         j = 0;

--- a/text.c
+++ b/text.c
@@ -25,10 +25,7 @@ char *all_text, *all_text_top;         /* Start and next byte free in (large)
                                           text buffer holding the entire text
                                           of the game, when it is being
                                           recorded                           */
-int put_strings_in_low_memory,         /* When TRUE, put static strings in
-                                          the low strings pool at 0x100 rather
-                                          than in the static strings area    */
-    is_abbreviation,                   /* When TRUE, the string being trans
+int is_abbreviation,                   /* When TRUE, the string being trans
                                           is itself an abbreviation string
                                           so can't make use of abbreviations */
     abbrevs_lookup_table_made,         /* The abbreviations lookup table is
@@ -2198,7 +2195,6 @@ extern void init_text_vars(void)
     grandflags = NULL;
     no_chars_transcribed = 0;
     is_abbreviation = FALSE;
-    put_strings_in_low_memory = FALSE;
 
     for (j=0; j<256; j++) abbrevs_lookup[j] = -1;
 

--- a/text.c
+++ b/text.c
@@ -501,7 +501,7 @@ advance as part of 'Zcharacter table':", unicode);
             else if (isdigit(text_in[i+1])!=0)
             {   int d1, d2;
 
-                /*   @..   */
+                /*   @.. (dynamic string)   */
 
                 d1 = character_digit_value[text_in[i+1]];
                 d2 = character_digit_value[text_in[i+2]];
@@ -515,7 +515,7 @@ advance as part of 'Zcharacter table':", unicode);
                         j = 0;
                     }
                     i+=2;
-                    write_z_char_z(1); write_z_char_z(j);
+                    write_z_char_z(j/32+1); write_z_char_z(j%32);
                 }
             }
             else


### PR DESCRIPTION
See https://github.com/DavidKinder/Inform6/issues/58 .

Tests are in https://github.com/erkyrath/inform6-testing , the `max-abbrevs` branch. See also:

https://github.com/erkyrath/glk-dev/blob/master/unittests/abbrevtest.inf
https://github.com/erkyrath/glk-dev/blob/master/unittests/abbrevtest96.inf
https://github.com/erkyrath/glk-dev/blob/master/unittests/dynamicstringtest.inf

