### PR TITLE
Alternate transcript format

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -1562,7 +1562,7 @@ extern int32 assemble_routine_header(int no_locals,
         sprintf(fnt, "[ %s(", name);
         AO.marker = STRING_MV;
         AO.type   = CONSTANT_OT;
-        AO.value  = compile_string(fnt, FALSE, FALSE);
+        AO.value  = compile_string(fnt, STRCTX_INFIX);
         assembleg_1(streamstr_gc, AO);
 
         if (!stackargs) {
@@ -1570,7 +1570,7 @@ extern int32 assemble_routine_header(int no_locals,
             sprintf(fnt, "%s%s = ", (ix==1)?"":", ", variable_name(ix));
             AO.marker = STRING_MV;
             AO.type   = CONSTANT_OT;
-            AO.value  = compile_string(fnt, FALSE, FALSE);
+            AO.value  = compile_string(fnt, STRCTX_INFIX);
             assembleg_1(streamstr_gc, AO);
             AO.marker = 0;
             AO.type = LOCALVAR_OT;
@@ -1583,7 +1583,7 @@ extern int32 assemble_routine_header(int no_locals,
           sprintf(fnt, "%s = ", variable_name(1));
           AO.marker = STRING_MV;
           AO.type   = CONSTANT_OT;
-          AO.value  = compile_string(fnt, FALSE, FALSE);
+          AO.value  = compile_string(fnt, STRCTX_INFIX);
           assembleg_1(streamstr_gc, AO);
           AO.marker = 0;
           AO.type = LOCALVAR_OT;
@@ -1617,7 +1617,7 @@ extern int32 assemble_routine_header(int no_locals,
 
         AO.marker = STRING_MV;
         AO.type   = CONSTANT_OT;
-        AO.value  = compile_string(") ]^", FALSE, FALSE);
+        AO.value  = compile_string(") ]^", STRCTX_INFIX);
         assembleg_1(streamstr_gc, AO);
       }
     }

--- a/asm.c
+++ b/asm.c
@@ -854,7 +854,7 @@ extern void assemblez_instruction(assembly_instruction *AI)
 
     if (operand_rules==TEXT)
     {   int32 i;
-        uchar *tmp = translate_text(zcode_holding_area + zcode_ha_size, zcode_holding_area+MAX_ZCODE_SIZE, AI->text);
+        uchar *tmp = translate_text(zcode_holding_area + zcode_ha_size, zcode_holding_area+MAX_ZCODE_SIZE, AI->text, FALSE);
         if (!tmp)
             memoryerror("MAX_ZCODE_SIZE", MAX_ZCODE_SIZE);
         j = subtract_pointers(tmp, (zcode_holding_area + zcode_ha_size));

--- a/asm.c
+++ b/asm.c
@@ -854,7 +854,8 @@ extern void assemblez_instruction(assembly_instruction *AI)
 
     if (operand_rules==TEXT)
     {   int32 i;
-        uchar *tmp = translate_text(zcode_holding_area + zcode_ha_size, zcode_holding_area+MAX_ZCODE_SIZE, AI->text, FALSE);
+        /* Should we use a different flag here, like STRCTX_INLINE, to distinguish text compiled inline in an opcode? We'd need INLINEVENEER too, I suppose. */
+        uchar *tmp = translate_text(zcode_holding_area + zcode_ha_size, zcode_holding_area+MAX_ZCODE_SIZE, AI->text, STRCTX_GAME);
         if (!tmp)
             memoryerror("MAX_ZCODE_SIZE", MAX_ZCODE_SIZE);
         j = subtract_pointers(tmp, (zcode_holding_area + zcode_ha_size));

--- a/asm.c
+++ b/asm.c
@@ -854,8 +854,7 @@ extern void assemblez_instruction(assembly_instruction *AI)
 
     if (operand_rules==TEXT)
     {   int32 i;
-        /* Should we use a different flag here, like STRCTX_INLINE, to distinguish text compiled inline in an opcode? We'd need INLINEVENEER too, I suppose. */
-        uchar *tmp = translate_text(zcode_holding_area + zcode_ha_size, zcode_holding_area+MAX_ZCODE_SIZE, AI->text, STRCTX_GAME);
+        uchar *tmp = translate_text(zcode_holding_area + zcode_ha_size, zcode_holding_area+MAX_ZCODE_SIZE, AI->text, STRCTX_GAMEOPC);
         if (!tmp)
             memoryerror("MAX_ZCODE_SIZE", MAX_ZCODE_SIZE);
         j = subtract_pointers(tmp, (zcode_holding_area + zcode_ha_size));

--- a/directs.c
+++ b/directs.c
@@ -608,7 +608,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         if (token_type != DQ_TT)
             return ebf_error_recover("literal string in double-quotes", token_text);
 
-        assign_symbol(i, compile_string(token_text, TRUE, TRUE), CONSTANT_T);
+        assign_symbol(i, compile_string(token_text, STRCTX_LOWSTRING), CONSTANT_T);
         break;
 
     /* --------------------------------------------------------------------- */

--- a/expressp.c
+++ b/expressp.c
@@ -803,7 +803,7 @@ static int evaluate_term(token_data t, assembly_operand *o)
                  o->type = LONG_CONSTANT_OT;
              else
                  o->type = CONSTANT_OT;
-             o->value = compile_string(t.text, FALSE, FALSE);
+             o->value = compile_string(t.text, STRCTX_GAME);
              return(TRUE);
         case VARIABLE_TT:
              if (!glulx_mode) {

--- a/files.c
+++ b/files.c
@@ -1339,8 +1339,11 @@ extern void open_transcript_file(char *what_of)
     write_to_transcript_file(topline_buffer, STRCTX_INFO);
     sprintf(topline_buffer, "[From %s]", banner_line);
     write_to_transcript_file(topline_buffer, STRCTX_INFO);
-    if (TRANSCRIPT_FORMAT == 1)
+    if (TRANSCRIPT_FORMAT == 1) {
         write_to_transcript_file("[I:info, G:game text, V:veneer text, L:lowmem string, A:abbreviation, D:dict word, O:object name, S:symbol, X:infix]", STRCTX_INFO);
+        if (!glulx_mode)
+            write_to_transcript_file("[H:game text inline in opcode, W:veneer text inline in opcode]", STRCTX_INFO);
+    }
     write_to_transcript_file("",  STRCTX_INFO);
 }
 

--- a/files.c
+++ b/files.c
@@ -1336,7 +1336,7 @@ extern void open_transcript_file(char *what_of)
     sprintf(topline_buffer, "[From %s]", banner_line);
     write_to_transcript_file(topline_buffer, STRCTX_INFO);
     if (TRANSCRIPT_FORMAT == 1)
-        write_to_transcript_file("[I:info, G:game text, V:veneer text, D:dict word, O:object name]", STRCTX_INFO);
+        write_to_transcript_file("[I:info, G:game text, V:veneer text, L:lowmem string, A:abbreviation, D:dict word, O:object name, S:symbol, X:infix]", STRCTX_INFO);
     write_to_transcript_file("",  STRCTX_INFO);
 }
 

--- a/files.c
+++ b/files.c
@@ -1301,10 +1301,18 @@ extern void write_to_transcript_file(char *text, int linetype)
                 ch = 'G'; break;
             case STRCTX_VENEER:
                 ch = 'V'; break;
+            case STRCTX_LOWSTRING:
+                ch = 'L'; break;
+            case STRCTX_ABBREV:
+                ch = 'A'; break;
             case STRCTX_DICT:
                 ch = 'D'; break;
             case STRCTX_OBJNAME:
                 ch = 'O'; break;
+            case STRCTX_SYMBOL:
+                ch = 'S'; break;
+            case STRCTX_INFIX:
+                ch = 'X'; break;
         }
         fputc(ch, transcript_file_handle);
         fputs(": ", transcript_file_handle);

--- a/files.c
+++ b/files.c
@@ -1299,8 +1299,12 @@ extern void write_to_transcript_file(char *text, int linetype)
                 ch = 'I'; break;
             case STRCTX_GAME:
                 ch = 'G'; break;
+            case STRCTX_GAMEOPC:
+                ch = 'H'; break;
             case STRCTX_VENEER:
                 ch = 'V'; break;
+            case STRCTX_VENEEROPC:
+                ch = 'W'; break;
             case STRCTX_LOWSTRING:
                 ch = 'L'; break;
             case STRCTX_ABBREV:

--- a/files.c
+++ b/files.c
@@ -1295,15 +1295,15 @@ extern void write_to_transcript_file(char *text, int linetype)
     if (TRANSCRIPT_FORMAT == 1) {
         char ch = '?';
         switch (linetype) {
-            case TRLN_INFO:
+            case STRCTX_INFO:
                 ch = 'I'; break;
-            case TRLN_GAME:
+            case STRCTX_GAME:
                 ch = 'G'; break;
-            case TRLN_VENEER:
+            case STRCTX_VENEER:
                 ch = 'V'; break;
-            case TRLN_DICT:
+            case STRCTX_DICT:
                 ch = 'D'; break;
-            case TRLN_OBJNAME:
+            case STRCTX_OBJNAME:
                 ch = 'O'; break;
         }
         fputc(ch, transcript_file_handle);
@@ -1324,12 +1324,12 @@ extern void open_transcript_file(char *what_of)
     transcript_open = TRUE;
 
     sprintf(topline_buffer, "Transcript of the text of \"%s\"", what_of);
-    write_to_transcript_file(topline_buffer, TRLN_INFO);
+    write_to_transcript_file(topline_buffer, STRCTX_INFO);
     sprintf(topline_buffer, "[From %s]", banner_line);
-    write_to_transcript_file(topline_buffer, TRLN_INFO);
+    write_to_transcript_file(topline_buffer, STRCTX_INFO);
     if (TRANSCRIPT_FORMAT == 1)
-        write_to_transcript_file("[I:info, G:game text, V:veneer text, D:dict word, O:object name]", TRLN_INFO);
-    write_to_transcript_file("",  TRLN_INFO);
+        write_to_transcript_file("[I:info, G:game text, V:veneer text, D:dict word, O:object name]", STRCTX_INFO);
+    write_to_transcript_file("",  STRCTX_INFO);
 }
 
 extern void abort_transcript_file(void)
@@ -1345,9 +1345,9 @@ extern void close_transcript_file(void)
     write_serial_number(sn_buffer);
     sprintf(botline_buffer, "[End of transcript: release %d, serial %s]",
         release_number, sn_buffer);
-    write_to_transcript_file("",  TRLN_INFO);
-    write_to_transcript_file(botline_buffer, TRLN_INFO);
-    write_to_transcript_file("",  TRLN_INFO);
+    write_to_transcript_file("",  STRCTX_INFO);
+    write_to_transcript_file(botline_buffer, STRCTX_INFO);
+    write_to_transcript_file("",  STRCTX_INFO);
 
     if (ferror(transcript_file_handle))
         fatalerror("I/O failure: couldn't write to transcript file");

--- a/header.h
+++ b/header.h
@@ -1937,6 +1937,16 @@ typedef struct operator_s
                                         how far back from the label to go
                                         to find the opmode byte to modify. */
 
+/* ------------------------------------------------------------------------- */
+/*   "Line types", used for the transcript file (gametext.txt)               */
+/* ------------------------------------------------------------------------- */
+
+#define TRLN_INFO    0
+#define TRLN_GAME    1
+#define TRLN_VENEER  2
+#define TRLN_DICT    3
+#define TRLN_OBJNAME 4
+
 /* ========================================================================= */
 /*   Initialisation extern definitions                                       */
 /*                                                                           */
@@ -2349,7 +2359,7 @@ extern void check_temp_files(void);
 extern void remove_temp_files(void);
 
 extern void open_transcript_file(char *what_of);
-extern void write_to_transcript_file(char *text);
+extern void write_to_transcript_file(char *text, int linetype);
 extern void close_transcript_file(void);
 extern void abort_transcript_file(void);
 
@@ -2543,6 +2553,7 @@ extern int DICT_WORD_SIZE, DICT_CHAR_SIZE, DICT_WORD_BYTES;
 extern int ZCODE_HEADER_EXT_WORDS, ZCODE_HEADER_FLAGS_3;
 extern int NUM_ATTR_BYTES, GLULX_OBJECT_EXT_BYTES;
 extern int WARN_UNUSED_ROUTINES, OMIT_UNUSED_ROUTINES;
+extern int TRANSCRIPT_FORMAT;
 
 /* These macros define offsets that depend on the value of NUM_ATTR_BYTES.
    (Meaningful only for Glulx.) */

--- a/header.h
+++ b/header.h
@@ -1938,14 +1938,15 @@ typedef struct operator_s
                                         to find the opmode byte to modify. */
 
 /* ------------------------------------------------------------------------- */
-/*   "Line types", used for the transcript file (gametext.txt)               */
+/*   "String contexts"; the purpose for a given string. This info gets       */
+/*   written to the transcript file (gametext.txt).                          */
 /* ------------------------------------------------------------------------- */
 
-#define TRLN_INFO    0
-#define TRLN_GAME    1
-#define TRLN_VENEER  2
-#define TRLN_DICT    3
-#define TRLN_OBJNAME 4
+#define STRCTX_INFO    0
+#define STRCTX_GAME    1
+#define STRCTX_VENEER  2
+#define STRCTX_DICT    3
+#define STRCTX_OBJNAME 4
 
 /* ========================================================================= */
 /*   Initialisation extern definitions                                       */

--- a/header.h
+++ b/header.h
@@ -1942,11 +1942,15 @@ typedef struct operator_s
 /*   written to the transcript file (gametext.txt).                          */
 /* ------------------------------------------------------------------------- */
 
-#define STRCTX_INFO    0
-#define STRCTX_GAME    1
-#define STRCTX_VENEER  2
-#define STRCTX_DICT    3
-#define STRCTX_OBJNAME 4
+#define STRCTX_INFO      0
+#define STRCTX_GAME      1
+#define STRCTX_VENEER    2
+#define STRCTX_LOWSTRING 3
+#define STRCTX_ABBREV    4
+#define STRCTX_DICT      5
+#define STRCTX_OBJNAME   6
+#define STRCTX_SYMBOL    7
+#define STRCTX_INFIX     8
 
 /* ========================================================================= */
 /*   Initialisation extern definitions                                       */
@@ -2791,7 +2795,7 @@ extern void  compress_game_text(void);
 /* end of the Glulx string compression stuff */
 
 extern void  ao_free_arrays(void);
-extern int32 compile_string(char *b, int in_low_memory, int is_abbrev);
+extern int32 compile_string(char *b, int strctx);
 extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int is_abbrev);
 extern void  optimise_abbreviations(void);
 extern void  make_abbreviation(char *text);

--- a/header.h
+++ b/header.h
@@ -2796,7 +2796,7 @@ extern void  compress_game_text(void);
 
 extern void  ao_free_arrays(void);
 extern int32 compile_string(char *b, int strctx);
-extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int is_abbrev);
+extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx);
 extern void  optimise_abbreviations(void);
 extern void  make_abbreviation(char *text);
 extern void  show_dictionary(void);

--- a/header.h
+++ b/header.h
@@ -1942,15 +1942,17 @@ typedef struct operator_s
 /*   written to the transcript file (gametext.txt).                          */
 /* ------------------------------------------------------------------------- */
 
-#define STRCTX_INFO      0
-#define STRCTX_GAME      1
-#define STRCTX_VENEER    2
-#define STRCTX_LOWSTRING 3
-#define STRCTX_ABBREV    4
-#define STRCTX_DICT      5
-#define STRCTX_OBJNAME   6
-#define STRCTX_SYMBOL    7
-#define STRCTX_INFIX     8
+#define STRCTX_INFO      0  /* comment; not stored in game file */
+#define STRCTX_GAME      1  /* strings area */
+#define STRCTX_GAMEOPC   2  /* inline text in opcode (Z-code only) */
+#define STRCTX_VENEER    3  /* strings area, from veneer code */
+#define STRCTX_VENEEROPC 4  /* inline text, veneer code (Z-code only) */
+#define STRCTX_LOWSTRING 5  /* lowmem (Z-code); also dynamic-str literals */
+#define STRCTX_ABBREV    6  /* abbreviation */
+#define STRCTX_DICT      7  /* dictionary word */
+#define STRCTX_OBJNAME   8  /* object "hardware name" */
+#define STRCTX_SYMBOL    9  /* prop/attr/etc names */
+#define STRCTX_INFIX    10  /* text printed in asterisk traces */
 
 /* ========================================================================= */
 /*   Initialisation extern definitions                                       */

--- a/header.h
+++ b/header.h
@@ -2792,7 +2792,7 @@ extern void  compress_game_text(void);
 
 extern void  ao_free_arrays(void);
 extern int32 compile_string(char *b, int in_low_memory, int is_abbrev);
-extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text);
+extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int is_abbrev);
 extern void  optimise_abbreviations(void);
 extern void  make_abbreviation(char *text);
 extern void  show_dictionary(void);

--- a/linker.c
+++ b/linker.c
@@ -632,7 +632,7 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
             filename, module_size/1024);
         if (linker_trace_level >= 1) printf("%s\n", link_banner);
         if (transcript_switch)
-            write_to_transcript_file(link_banner, TRLN_INFO);
+            write_to_transcript_file(link_banner, STRCTX_INFO);
     }
 
     /* (4) Merge in the dictionary */

--- a/linker.c
+++ b/linker.c
@@ -632,7 +632,7 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
             filename, module_size/1024);
         if (linker_trace_level >= 1) printf("%s\n", link_banner);
         if (transcript_switch)
-            write_to_transcript_file(link_banner);
+            write_to_transcript_file(link_banner, TRLN_INFO);
     }
 
     /* (4) Merge in the dictionary */

--- a/memory.c
+++ b/memory.c
@@ -353,6 +353,7 @@ static void list_memory_sizes(void)
            (long int) MAX_STATIC_STRINGS);
     printf("|  %25s = %-7d |\n","MAX_SYMBOLS",MAX_SYMBOLS);
     printf("|  %25s = %-7d |\n","SYMBOLS_CHUNK_SIZE",SYMBOLS_CHUNK_SIZE);
+    printf("|  %25s = %-7d |\n","TRANSCRIPT_FORMAT",TRANSCRIPT_FORMAT);
     printf("|  %25s = %-7ld |\n","MAX_TRANSCRIPT_SIZE",
            (long int) MAX_TRANSCRIPT_SIZE);
     if (glulx_mode)
@@ -867,6 +868,13 @@ static void explain_parameter(char *command)
   memory after the game file. (Glulx only)\n");
         return;
     }
+    if (strcmp(command,"TRANSCRIPT_FORMAT")==0)
+    {
+        printf(
+"  TRANSCRIPT_FORMAT, if set to 1, adjusts the gametext.txt transcript for \n\
+  easier machine processing; each line will be prefixed by its context.\n");
+        return;
+    }
     if (strcmp(command,"WARN_UNUSED_ROUTINES")==0)
     {
         printf(
@@ -1102,6 +1110,12 @@ extern void memory_command(char *command)
                 MEMORY_MAP_EXTENSION=j, flag=1;
                 /* Adjust up to a 256-byte boundary. */
                 MEMORY_MAP_EXTENSION = (MEMORY_MAP_EXTENSION + 0xFF) & (~0xFF);
+            }
+            if (strcmp(command,"TRANSCRIPT_FORMAT")==0)
+            {
+                TRANSCRIPT_FORMAT=j, flag=1;
+                if (TRANSCRIPT_FORMAT > 1 || TRANSCRIPT_FORMAT < 0)
+                    TRANSCRIPT_FORMAT = 1;
             }
             if (strcmp(command,"WARN_UNUSED_ROUTINES")==0)
             {

--- a/memory.c
+++ b/memory.c
@@ -275,6 +275,7 @@ int32 MEMORY_MAP_EXTENSION;
 int ALLOC_CHUNK_SIZE;
 int WARN_UNUSED_ROUTINES; /* 0: no, 1: yes except in system files, 2: yes always */
 int OMIT_UNUSED_ROUTINES; /* 0: no, 1: yes */
+int TRANSCRIPT_FORMAT; /* 0: classic, 1: prefixed */
 
 /* The way memory sizes are set causes great nuisance for those parameters
    which have different defaults under Z-code and Glulx. We have to get
@@ -542,6 +543,7 @@ extern void set_memory_sizes(int size_flag)
     MAX_STACK_SIZE = 4096;
     OMIT_UNUSED_ROUTINES = 0;
     WARN_UNUSED_ROUTINES = 0;
+    TRANSCRIPT_FORMAT = 0;
 
     adjust_memory_sizes();
 }

--- a/objects.c
+++ b/objects.c
@@ -796,7 +796,7 @@ static int write_property_block_z(char *shortname)
     {   uchar *tmp;
         if (mark+1+510 >= MAX_PROP_TABLE_SIZE)
             memoryerror("MAX_PROP_TABLE_SIZE",MAX_PROP_TABLE_SIZE);
-        tmp = translate_text(p+mark+1,p+mark+1+510,shortname,FALSE);
+        tmp = translate_text(p+mark+1,p+mark+1+510,shortname,STRCTX_OBJNAME);
         if (!tmp) error ("Short name of object exceeded 765 Z-characters");
         i = subtract_pointers(tmp,(p+mark+1));
         p[mark] = i/2;

--- a/objects.c
+++ b/objects.c
@@ -989,7 +989,7 @@ static void manufacture_object_g(void)
     }
 
     objectsg[no_objects].shortname = compile_string(shortname_buffer,
-      FALSE, FALSE);
+      STRCTX_OBJNAME);
 
         /*  The properties table consists simply of a sequence of property
             blocks, one for each object in order of definition, exactly as

--- a/objects.c
+++ b/objects.c
@@ -796,7 +796,7 @@ static int write_property_block_z(char *shortname)
     {   uchar *tmp;
         if (mark+1+510 >= MAX_PROP_TABLE_SIZE)
             memoryerror("MAX_PROP_TABLE_SIZE",MAX_PROP_TABLE_SIZE);
-        tmp = translate_text(p+mark+1,p+mark+1+510,shortname);
+        tmp = translate_text(p+mark+1,p+mark+1+510,shortname,FALSE);
         if (!tmp) error ("Short name of object exceeded 765 Z-characters");
         i = subtract_pointers(tmp,(p+mark+1));
         p[mark] = i/2;

--- a/states.c
+++ b/states.c
@@ -295,7 +295,7 @@ static void parse_print_z(int finally_return)
               if (strlen(token_text) > 32)
               {   INITAOT(&AO, LONG_CONSTANT_OT);
                   AO.marker = STRING_MV;
-                  AO.value  = compile_string(token_text, FALSE, FALSE);
+                  AO.value  = compile_string(token_text, STRCTX_GAME);
                   assemblez_1(print_paddr_zc, AO);
                   if (finally_return)
                   {   get_next_token();
@@ -524,7 +524,7 @@ static void parse_print_g(int finally_return)
                  so this always goes into the string area. */
               {   INITAOT(&AO, CONSTANT_OT);
                   AO.marker = STRING_MV;
-                  AO.value  = compile_string(token_text, FALSE, FALSE);
+                  AO.value  = compile_string(token_text, STRCTX_GAME);
                   assembleg_1(streamstr_gc, AO);
                   if (finally_return)
                   {   get_next_token();
@@ -1596,7 +1596,7 @@ static void parse_statement_z(int break_label, int continue_label)
                  get_next_token();
                  if (token_type == DQ_TT)
                  {   INITAOT(&AO4, LONG_CONSTANT_OT);
-                     AO4.value = compile_string(token_text, TRUE, TRUE);
+                     AO4.value = compile_string(token_text, STRCTX_LOWSTRING);
                  }
                  else
                  {   put_token_back();
@@ -2533,7 +2533,7 @@ static void parse_statement_g(int break_label, int continue_label)
                  get_next_token();
                  if (token_type == DQ_TT)
                  {   INITAOT(&AO4, CONSTANT_OT);
-                     AO4.value = compile_string(token_text, TRUE, TRUE);
+                     AO4.value = compile_string(token_text, STRCTX_LOWSTRING);
                      AO4.marker = STRING_MV;
                  }
                  else

--- a/states.c
+++ b/states.c
@@ -1596,6 +1596,8 @@ static void parse_statement_z(int break_label, int continue_label)
                  get_next_token();
                  if (token_type == DQ_TT)
                  {   INITAOT(&AO4, LONG_CONSTANT_OT);
+                     /* This string must be in low memory so that the
+                        dynamic string table can refer to it. */
                      AO4.value = compile_string(token_text, STRCTX_LOWSTRING);
                  }
                  else
@@ -2533,6 +2535,9 @@ static void parse_statement_g(int break_label, int continue_label)
                  get_next_token();
                  if (token_type == DQ_TT)
                  {   INITAOT(&AO4, CONSTANT_OT);
+                     /* This is not actually placed in low memory; Glulx
+                        has no such concept. We use the LOWSTRING flag
+                        for compatibility with older compiler behavior. */
                      AO4.value = compile_string(token_text, STRCTX_LOWSTRING);
                      AO4.marker = STRING_MV;
                  }

--- a/symbols.c
+++ b/symbols.c
@@ -378,7 +378,7 @@ extern void write_the_identifier_names(void)
 
     veneer_mode = TRUE;
 
-    null_value = compile_string(unknown_attribute, FALSE, FALSE);
+    null_value = compile_string(unknown_attribute, STRCTX_SYMBOL);
     for (i=0; i<NUM_ATTR_BYTES*8; i++) attribute_name_strings[i] = null_value;
 
     for (i=0; i<no_symbols; i++)
@@ -398,14 +398,14 @@ extern void write_the_identifier_names(void)
                     }
 
                     individual_name_strings[svals[i]]
-                        = compile_string(idname_string, FALSE, FALSE);
+                        = compile_string(idname_string, STRCTX_SYMBOL);
                 }
             }
             else
             {   sprintf(idname_string, "%s", (char *) symbs[i]);
 
                 individual_name_strings[svals[i]]
-                    = compile_string(idname_string, FALSE, FALSE);
+                    = compile_string(idname_string, STRCTX_SYMBOL);
             }
         }
         if (t == ATTRIBUTE_T)
@@ -423,14 +423,14 @@ extern void write_the_identifier_names(void)
                     }
 
                     attribute_name_strings[svals[i]]
-                        = compile_string(idname_string, FALSE, FALSE);
+                        = compile_string(idname_string, STRCTX_SYMBOL);
                 }
             }
             else
             {   sprintf(idname_string, "%s", (char *) symbs[i]);
 
                 attribute_name_strings[svals[i]]
-                    = compile_string(idname_string, FALSE, FALSE);
+                    = compile_string(idname_string, STRCTX_SYMBOL);
             }
         }
         if (sflags[i] & ACTION_SFLAG)
@@ -446,7 +446,7 @@ extern void write_the_identifier_names(void)
             }
 
             action_name_strings[svals[i]]
-                = compile_string(idname_string, FALSE, FALSE);
+                = compile_string(idname_string, STRCTX_SYMBOL);
         }
     }
 
@@ -457,7 +457,7 @@ extern void write_the_identifier_names(void)
 
             action_name_strings[svals[i]
                     - ((grammar_version_number==1)?256:4096) + no_actions]
-                = compile_string(idname_string, FALSE, FALSE);
+                = compile_string(idname_string, STRCTX_SYMBOL);
         }
     }
 
@@ -466,21 +466,21 @@ extern void write_the_identifier_names(void)
         sprintf(idname_string, "%s", (char *) symbs[i]);
 
         array_name_strings[j]
-            = compile_string(idname_string, FALSE, FALSE);
+            = compile_string(idname_string, STRCTX_SYMBOL);
     }
   if (define_INFIX_switch)
   { for (i=0; i<no_symbols; i++)
     {   if (stypes[i] == GLOBAL_VARIABLE_T)
         {   sprintf(idname_string, "%s", (char *) symbs[i]);
             array_name_strings[no_arrays + svals[i] -16]
-                = compile_string(idname_string, FALSE, FALSE);
+                = compile_string(idname_string, STRCTX_SYMBOL);
         }
     }
 
     for (i=0; i<no_named_routines; i++)
     {   sprintf(idname_string, "%s", (char *) symbs[named_routine_symbols[i]]);
             array_name_strings[no_arrays + no_globals + i]
-                = compile_string(idname_string, FALSE, FALSE);
+                = compile_string(idname_string, STRCTX_SYMBOL);
     }
 
     for (i=0, no_named_constants=0; i<no_symbols; i++)
@@ -490,7 +490,7 @@ extern void write_the_identifier_names(void)
         {   sprintf(idname_string, "%s", (char *) symbs[i]);
             array_name_strings[no_arrays + no_globals + no_named_routines
                 + no_named_constants++]
-                = compile_string(idname_string, FALSE, FALSE);
+                = compile_string(idname_string, STRCTX_SYMBOL);
         }
     }
   }

--- a/tables.c
+++ b/tables.c
@@ -1229,7 +1229,7 @@ static void construct_storyfile_g(void)
             "array name strings");
 
     write_the_identifier_names();
-    threespaces = compile_string("   ", FALSE, FALSE);
+    threespaces = compile_string("   ", STRCTX_GAME);
 
     compress_game_text();
 

--- a/text.c
+++ b/text.c
@@ -217,8 +217,7 @@ extern int32 compile_string(char *b, int strctx)
 
     /* In Z-code, abbreviations go in the low memory pool (0x100). So
        do strings explicitly defined with the Lowstring directive.
-       (In Glulx, STRCTX_LOWSTRING is not used and the in_low_memory flag is
-       ignored.) */
+       (In Glulx, the in_low_memory flag is ignored.) */
     int in_low_memory = (strctx == STRCTX_ABBREV || strctx == STRCTX_LOWSTRING);
 
     /* In theory, this flag should only be set for STRCTX_ABBREV. However,

--- a/text.c
+++ b/text.c
@@ -409,7 +409,10 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text)
     }
 
     if (transcript_switch && (!veneer_mode))
-        write_to_transcript_file(s_text);
+        write_to_transcript_file(s_text, TRLN_GAME);
+    /* We only write veneer strings in the new format. */
+    if (transcript_switch && veneer_mode && TRANSCRIPT_FORMAT == 1)
+        write_to_transcript_file(s_text, TRLN_VENEER);
 
   if (!glulx_mode) {
 
@@ -2142,9 +2145,10 @@ static void recursively_show_z(int node)
         printf("\n");
     }
 
-    if (d_show_len >= 64)
+    /* Show five words per line in classic TRANSCRIPT_FORMAT; one per line in the new format. */
+    if (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1)
     {
-        write_to_transcript_file(d_show_buf);
+        write_to_transcript_file(d_show_buf, TRLN_DICT);
         d_show_len = 0;
     }
 
@@ -2186,9 +2190,10 @@ static void recursively_show_g(int node)
         printf("\n");
     }
 
-    if (d_show_len >= 64)
+    /* Show five words per line in classic TRANSCRIPT_FORMAT; one per line in the new format. */
+    if (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1)
     {
-        write_to_transcript_file(d_show_buf);
+        write_to_transcript_file(d_show_buf, TRLN_DICT);
         d_show_len = 0;
     }
 
@@ -2232,8 +2237,9 @@ extern void write_dictionary_to_transcript(void)
     d_show_size = 80; /* initial size */
     d_show_buf = my_malloc(d_show_size, "dictionary display buffer");
 
+    write_to_transcript_file("", TRLN_INFO);
     sprintf(d_show_buf, "[Dictionary contains %d entries:]", dict_entries);
-    write_to_transcript_file(d_show_buf);
+    write_to_transcript_file(d_show_buf, TRLN_INFO);
     
     d_show_len = 0;
 
@@ -2244,7 +2250,7 @@ extern void write_dictionary_to_transcript(void)
         else
             recursively_show_g(root);
     }
-    if (d_show_len != 0) write_to_transcript_file(d_show_buf);
+    if (d_show_len != 0) write_to_transcript_file(d_show_buf, TRLN_DICT);
 
     my_free(&d_show_buf, "dictionary display buffer");
 }

--- a/text.c
+++ b/text.c
@@ -2162,6 +2162,7 @@ static void recursively_show_g(int node)
     p = (uchar *)dictionary + 4 + DICT_ENTRY_BYTE_LENGTH*node;
 
     /*### this assumes DICT_CHAR_SIZE=1; doesn't work for 4 */
+    
     for (cprinted = 0; cprinted<DICT_WORD_SIZE && p[1+cprinted]; cprinted++)
         show_char(p[1+cprinted]);
     for (; cprinted<DICT_WORD_SIZE+4; cprinted++)
@@ -2169,7 +2170,19 @@ static void recursively_show_g(int node)
 
     if (d_show_buf == NULL)
     {   for (i=0; i<DICT_ENTRY_BYTE_LENGTH; i++) printf("%02x ",p[i]);
-        /* ### flags */
+        int flags = (p[DICT_WORD_SIZE+1] << 8) | (p[DICT_WORD_SIZE+2]);
+        int verbnum = (p[DICT_WORD_SIZE+3] << 8) | (p[DICT_WORD_SIZE+4]);
+        if (flags & 128)
+        {   printf("noun ");
+            if (flags & 4)  printf("p"); else printf(" ");
+            printf(" ");
+        }
+        else printf("       ");
+        if (flags & 8)
+        {   printf("preposition    ");
+        }
+        if ((flags & 3) == 3) printf("metaverb:%d  ", verbnum);
+        else if ((flags & 3) == 1) printf("verb:%d  ", verbnum);
         printf("\n");
     }
 

--- a/text.c
+++ b/text.c
@@ -2146,7 +2146,7 @@ static void recursively_show_z(int node)
     }
 
     /* Show five words per line in classic TRANSCRIPT_FORMAT; one per line in the new format. */
-    if (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1)
+    if (d_show_buf && (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1))
     {
         write_to_transcript_file(d_show_buf, TRLN_DICT);
         d_show_len = 0;
@@ -2191,7 +2191,7 @@ static void recursively_show_g(int node)
     }
 
     /* Show five words per line in classic TRANSCRIPT_FORMAT; one per line in the new format. */
-    if (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1)
+    if (d_show_buf && (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1))
     {
         write_to_transcript_file(d_show_buf, TRLN_DICT);
         d_show_len = 0;
@@ -2253,6 +2253,7 @@ extern void write_dictionary_to_transcript(void)
     if (d_show_len != 0) write_to_transcript_file(d_show_buf, TRLN_DICT);
 
     my_free(&d_show_buf, "dictionary display buffer");
+    d_show_len = 0; d_show_buf = NULL;
 }
 
 /* ========================================================================= */

--- a/text.c
+++ b/text.c
@@ -416,8 +416,12 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
         /* Omit veneer strings, unless we're using the new transcript format, which includes everything. */
         if ((!veneer_mode) || TRANSCRIPT_FORMAT == 1) {
             int label = strctx;
-            if (veneer_mode && label == STRCTX_GAME)
-                label = STRCTX_VENEER;
+            if (veneer_mode) {
+                if (label == STRCTX_GAME)
+                    label = STRCTX_VENEER;
+                else if (label == STRCTX_GAMEOPC)
+                    label = STRCTX_VENEEROPC;
+            }
             write_to_transcript_file(s_text, label);
         }
     }

--- a/text.c
+++ b/text.c
@@ -197,7 +197,7 @@ extern void make_abbreviation(char *text)
     strcpy((char *)abbreviations_at
             + no_abbreviations*MAX_ABBREV_LENGTH, text);
 
-    abbrev_values[no_abbreviations] = compile_string(text, TRUE, TRUE);
+    abbrev_values[no_abbreviations] = compile_string(text, STRCTX_ABBREV);
 
     /*   The quality is the number of Z-chars saved by using this            */
     /*   abbreviation: note that it takes 2 Z-chars to print it.             */
@@ -206,14 +206,26 @@ extern void make_abbreviation(char *text)
 }
 
 /* ------------------------------------------------------------------------- */
-/*   The front end routine for text translation                              */
+/*   The front end routine for text translation.                             */
+/*   strctx indicates the purpose of the string. This is mostly used for     */
+/*   informational output (gametext.txt), but we treat some string contexts  */
+/*   specially during compilation.                                           */
 /* ------------------------------------------------------------------------- */
 
-extern int32 compile_string(char *b, int in_low_memory, int is_abbreviation)
+extern int32 compile_string(char *b, int strctx)
 {   int i, j; uchar *c;
 
-    /* Put into the low memory pool (at 0x100 in the Z-machine) of strings   */
-    /* which may be wanted as possible entries in the abbreviations table    */
+    /* In Z-code, abbreviations go in the low memory pool (0x100). So
+       do strings explicitly defined with the Lowstring directive.
+       (In Glulx, STRCTX_LOWSTRING is not used and the in_low_memory flag is
+       ignored.) */
+    int in_low_memory = (strctx == STRCTX_ABBREV || strctx == STRCTX_LOWSTRING);
+
+    /* In theory, this flag should only be set for STRCTX_ABBREV. However,
+       the compiler has historically set it for the Lowstring directive
+       as well -- the in_low_memory and is_abbreviation flag were always
+       the same. I am preserving that convention. */
+    int is_abbreviation = (strctx == STRCTX_ABBREV || strctx == STRCTX_LOWSTRING);
 
     if (!glulx_mode && in_low_memory)
     {   j=subtract_pointers(low_strings_top,low_strings);

--- a/text.c
+++ b/text.c
@@ -2038,7 +2038,7 @@ extern void dictionary_set_verb_number(char *dword, int to)
 /* ------------------------------------------------------------------------- */
 
 /* In the dictionary-showing code, if d_show_buf is NULL, the text is
-   printed directly. (The "Trace Dictionary" directive does this.)
+   printed directly. (The "Trace dictionary" directive does this.)
    If d_show_buf is not NULL, we add words to it (reallocing if necessary)
    until it's a page-width. 
 */

--- a/text.c
+++ b/text.c
@@ -2182,8 +2182,9 @@ static void recursively_show_g(int node)
 
     if (d_show_buf == NULL)
     {   for (i=0; i<DICT_ENTRY_BYTE_LENGTH; i++) printf("%02x ",p[i]);
-        int flags = (p[DICT_WORD_SIZE+1] << 8) | (p[DICT_WORD_SIZE+2]);
-        int verbnum = (p[DICT_WORD_SIZE+3] << 8) | (p[DICT_WORD_SIZE+4]);
+        int flagpos = (DICT_CHAR_SIZE == 1) ? (DICT_WORD_SIZE+1) : (DICT_WORD_BYTES+4);
+        int flags = (p[flagpos+0] << 8) | (p[flagpos+1]);
+        int verbnum = (p[flagpos+2] << 8) | (p[flagpos+3]);
         if (flags & 128)
         {   printf("noun ");
             if (flags & 4)  printf("p"); else printf(" ");

--- a/text.c
+++ b/text.c
@@ -2142,7 +2142,7 @@ static void recursively_show_z(int node)
         printf("\n");
     }
 
-    if (d_show_len >= 70)
+    if (d_show_len >= 64)
     {
         write_to_transcript_file(d_show_buf);
         d_show_len = 0;
@@ -2173,7 +2173,7 @@ static void recursively_show_g(int node)
         printf("\n");
     }
 
-    if (d_show_len >= 70)
+    if (d_show_len >= 64)
     {
         write_to_transcript_file(d_show_buf);
         d_show_len = 0;

--- a/text.c
+++ b/text.c
@@ -409,10 +409,10 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text)
     }
 
     if (transcript_switch && (!veneer_mode))
-        write_to_transcript_file(s_text, TRLN_GAME);
+        write_to_transcript_file(s_text, STRCTX_GAME);
     /* We only write veneer strings in the new format. */
     if (transcript_switch && veneer_mode && TRANSCRIPT_FORMAT == 1)
-        write_to_transcript_file(s_text, TRLN_VENEER);
+        write_to_transcript_file(s_text, STRCTX_VENEER);
 
   if (!glulx_mode) {
 
@@ -2148,7 +2148,7 @@ static void recursively_show_z(int node)
     /* Show five words per line in classic TRANSCRIPT_FORMAT; one per line in the new format. */
     if (d_show_buf && (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1))
     {
-        write_to_transcript_file(d_show_buf, TRLN_DICT);
+        write_to_transcript_file(d_show_buf, STRCTX_DICT);
         d_show_len = 0;
     }
 
@@ -2193,7 +2193,7 @@ static void recursively_show_g(int node)
     /* Show five words per line in classic TRANSCRIPT_FORMAT; one per line in the new format. */
     if (d_show_buf && (d_show_len >= 64 || TRANSCRIPT_FORMAT == 1))
     {
-        write_to_transcript_file(d_show_buf, TRLN_DICT);
+        write_to_transcript_file(d_show_buf, STRCTX_DICT);
         d_show_len = 0;
     }
 
@@ -2237,9 +2237,9 @@ extern void write_dictionary_to_transcript(void)
     d_show_size = 80; /* initial size */
     d_show_buf = my_malloc(d_show_size, "dictionary display buffer");
 
-    write_to_transcript_file("", TRLN_INFO);
+    write_to_transcript_file("", STRCTX_INFO);
     sprintf(d_show_buf, "[Dictionary contains %d entries:]", dict_entries);
-    write_to_transcript_file(d_show_buf, TRLN_INFO);
+    write_to_transcript_file(d_show_buf, STRCTX_INFO);
     
     d_show_len = 0;
 
@@ -2250,7 +2250,7 @@ extern void write_dictionary_to_transcript(void)
         else
             recursively_show_g(root);
     }
-    if (d_show_len != 0) write_to_transcript_file(d_show_buf, TRLN_DICT);
+    if (d_show_len != 0) write_to_transcript_file(d_show_buf, STRCTX_DICT);
 
     my_free(&d_show_buf, "dictionary display buffer");
     d_show_len = 0; d_show_buf = NULL;

--- a/text.c
+++ b/text.c
@@ -413,7 +413,7 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
     }
 
     if (transcript_switch) {
-        /* Omit veneer strings, unless we're using the new transcript format. */
+        /* Omit veneer strings, unless we're using the new transcript format, which includes everything. */
         if ((!veneer_mode) || TRANSCRIPT_FORMAT == 1) {
             int label = strctx;
             if (veneer_mode && label == STRCTX_GAME)
@@ -2234,10 +2234,13 @@ extern void show_dictionary(void)
         else
             recursively_show_g(root);
     }
-    printf("\nZ-machine alphabet entries:\n");
-    show_alphabet(0);
-    show_alphabet(1);
-    show_alphabet(2);
+    if (!glulx_mode)
+    {
+        printf("\nZ-machine alphabet entries:\n");
+        show_alphabet(0);
+        show_alphabet(1);
+        show_alphabet(2);
+    }
 }
 
 extern void write_dictionary_to_transcript(void)

--- a/text.c
+++ b/text.c
@@ -412,12 +412,16 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
         all_text_top += strlen(all_text_top);
     }
 
-    if (transcript_switch && (!veneer_mode))
-        write_to_transcript_file(s_text, STRCTX_GAME);
-    /* We only write veneer strings in the new format. */
-    if (transcript_switch && veneer_mode && TRANSCRIPT_FORMAT == 1)
-        write_to_transcript_file(s_text, STRCTX_VENEER);
-
+    if (transcript_switch) {
+        /* Omit veneer strings, unless we're using the new transcript format. */
+        if ((!veneer_mode) || TRANSCRIPT_FORMAT == 1) {
+            int label = strctx;
+            if (veneer_mode && label == STRCTX_GAME)
+                label = STRCTX_VENEER;
+            write_to_transcript_file(s_text, label);
+        }
+    }
+    
   if (!glulx_mode) {
 
     /*  The empty string of Z-text is illegal, since it can't carry an end

--- a/text.c
+++ b/text.c
@@ -200,9 +200,7 @@ extern void make_abbreviation(char *text)
     strcpy((char *)abbreviations_at
             + no_abbreviations*MAX_ABBREV_LENGTH, text);
 
-    is_abbreviation = TRUE;
     abbrev_values[no_abbreviations] = compile_string(text, TRUE, TRUE);
-    is_abbreviation = FALSE;
 
     /*   The quality is the number of Z-chars saved by using this            */
     /*   abbreviation: note that it takes 2 Z-chars to print it.             */
@@ -217,7 +215,7 @@ extern void make_abbreviation(char *text)
 extern int32 compile_string(char *b, int in_low_memory, int is_abbrev)
 {   int i, j; uchar *c;
 
-    is_abbreviation = is_abbrev;
+    is_abbreviation = is_abbrev; /* Set FALSE before returning! */
 
     /* Put into the low memory pool (at 0x100 in the Z-machine) of strings   */
     /* which may be wanted as possible entries in the abbreviations table    */

--- a/text.c
+++ b/text.c
@@ -2115,6 +2115,7 @@ static void show_uchar(uint32 c)
         show_char(c);
         return;
     }
+    /* Supporting other character_set_setting is harder; not currently implemented. */
     
     /* Use the escaped form */
     sprintf(buf, "@{%x}", c);


### PR DESCRIPTION
We now have a `$TRANSCRIPT_FORMAT=1` setting. This changes the format of the `gametext.txt` file (`-r` option) to be more informative and machine-readable. The new format is better for, e.g., an abbreviation optimizer.

The classic setting `$TRANSCRIPT_FORMAT=0` remains the default. This format is better for a human proofreader.

The new format looks like:

```
I: Transcript of the text of "Advent.inf"
I: [From Inform 6.35 (in development)]
I: [I:info, G:game text, V:veneer text, L:lowmem string, A:abbreviation, D:dict word, O:object name, S:symbol, X:infix]
I: [H:game text inline in opcode, W:veneer text inline in opcode]
I: 
O: Class
O: Object
O: Routine
O: String
G: ADVENTURE
G: ^The Interactive Original^By Will Crowther (1973) and Don Woods (1977)^Reconstructed in three steps by:^Donald Ekman, David M. Baggett (1993) and Graham Nelson (1994)^[In memoriam Stephen Bishop (1820?-1857): GN]^
D: xyzzy
```

Every line has a prefix. The prefixes: (see STRCTX_* defs in header.h, files.c):

```
I: STRCTX_INFO       /* comment; not stored in game file */
G: STRCTX_GAME       /* strings area */
H: STRCTX_GAMEOPC    /* inline text in opcode (Z-code only) */
V: STRCTX_VENEER     /* strings area, from veneer code */
W: STRCTX_VENEEROPC  /* inline text, veneer code (Z-code only) */
L: STRCTX_LOWSTRING  /* lowmem (Z-code); also dynamic-str literals */
A: STRCTX_ABBREV     /* abbreviation */
D: STRCTX_DICT       /* dictionary word */
O: STRCTX_OBJNAME    /* object "hardware name" */
S: STRCTX_SYMBOL     /* prop/attr/etc names */
X: STRCTX_INFIX      /* text printed in asterisk traces */
```

Text from veneer code is included in the new format. (It is omitted in the classic format.)

By convention, the `gametext.txt` file uses the same encoding as the source text (determined by the `-C` option).

----

This involved a bit of refactoring, but the result is tidier code.

The high-level `compile_string()` routine used to take two boolean arguments (in_low_memory, is_abbrev). In fact, in the code, these arguments were always both true or both false. I have replaced these with a single strctx argument which encodes one of the values listed above. (To follow the original functionality, LOWSTRING and ABBREV behave the same.)

The strctx argument is then passed on to translate_text(). This is also called from a few other places in the code; these also pass an appropriate strctx.

This allows us to eliminate the global variable `is_abbreviation`. All the needed context comes from function arguments. ...Except for the question "is this veneer code?" which sneaks in from the `veneer_mode` global. Maybe we'll get rid of that someday too. In the meantime, enjoy the small victory.

Let's see, what else...

The `write_dictionary_to_transcript()` routine now works for both Z-code and Glulx. (The Glulx side has been missing up until now.) As a bonus, this also allows the `Trace dictionary;` directive to work in Glulx.

The underlying code for this (`show_char()`) uses a malloced buffer, realloced as necessary, rather than a fixed buffer.
