### PR TITLE
Mention -v7 in the -h2 docs

### DIFF
--- a/inform.c
+++ b/inform.c
@@ -1356,10 +1356,11 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 
    printf("\
   u   work out most useful abbreviations (very very slowly)\n\
-  v3  compile to version-3 (\"Standard\") story file\n\
-  v4  compile to version-4 (\"Plus\") story file\n\
-  v5  compile to version-5 (\"Advanced\") story file: the default\n\
-  v6  compile to version-6 (graphical) story file\n\
+  v3  compile to version-3 (\"Standard\"/\"ZIP\") story file\n\
+  v4  compile to version-4 (\"Plus\"/\"EZIP\") story file\n\
+  v5  compile to version-5 (\"Advanced\"/\"XZIP\") story file: the default\n\
+  v6  compile to version-6 (graphical/\"YZIP\") story file\n\
+  v7  compile to version-7 (expanded \"Advanced\") story file\n\
   v8  compile to version-8 (expanded \"Advanced\") story file\n\
   w   disable warning messages\n\
   x   print # for every 100 lines compiled\n\


### PR DESCRIPTION
```
  v3  compile to version-3 ("Standard"/"ZIP") story file
  v4  compile to version-4 ("Plus"/"EZIP") story file
  v5  compile to version-5 ("Advanced"/"XZIP") story file: the default
  v6  compile to version-6 (graphical/"YZIP") story file
  v7  compile to version-7 (expanded "Advanced") story file
  v8  compile to version-8 (expanded "Advanced") story file
```

Fixes https://github.com/DavidKinder/Inform6/issues/65 .
