### PR TITLE
Origsource info included in all error formats

### DIFF
--- a/errors.c
+++ b/errors.c
@@ -43,6 +43,7 @@ static void print_preamble(void)
 
             if (!(ErrorReport.main_flag)) printf("\"%s\", ", p);
             printf("line %d: ", ErrorReport.line_number);
+            
             if (ErrorReport.orig_file) {
                 char *op;
                 if (ErrorReport.orig_file <= 0 || ErrorReport.orig_file > total_files)
@@ -68,12 +69,48 @@ static void print_preamble(void)
             }
             printf("%s", p);
             if (with_extension_flag) printf("%s", Source_Extension);
-            printf("(%d): ", ErrorReport.line_number);
+            printf("(%d)", ErrorReport.line_number);
+            
+            if (ErrorReport.orig_file) {
+                char *op;
+                if (ErrorReport.orig_file <= 0 || ErrorReport.orig_file > total_files)
+                    op = ErrorReport.orig_source;
+                else
+                    op = InputFiles[ErrorReport.orig_file-1].filename;
+                printf("|%s", op);
+                if (ErrorReport.orig_line) {
+                    printf("(%d", ErrorReport.orig_line);
+                    if (ErrorReport.orig_char) {
+                        printf(":%d", ErrorReport.orig_char);
+                    }
+                    printf(")");
+                }
+            }
+            
+            printf(": ");
             break;
 
         case 2:  /* Macintosh Programmer's Workshop error message format */
 
-            printf("File \"%s\"; Line %d\t# ", p, ErrorReport.line_number);
+            printf("File \"%s\"; Line %d", p, ErrorReport.line_number);
+            
+            if (ErrorReport.orig_file) {
+                char *op;
+                if (ErrorReport.orig_file <= 0 || ErrorReport.orig_file > total_files)
+                    op = ErrorReport.orig_source;
+                else
+                    op = InputFiles[ErrorReport.orig_file-1].filename;
+                printf(": (\"%s\"", op);
+                if (ErrorReport.orig_line) {
+                    printf("; Line %d", ErrorReport.orig_line);
+                    if (ErrorReport.orig_char) {
+                        printf("; Char %d", ErrorReport.orig_char);
+                    }
+                }
+                printf(")");
+            }
+
+            printf("\t# ");
             break;
     }
 }


### PR DESCRIPTION
The Origsource directive can specify just a filename, or a filename and line number, or filename/line/char.

Errors now look like:

```
% ./inform -E0 test.inf
"test3.inf", line 2: Error:  Plain I6 error
"test3.inf", line 6: ("story.ni"): Error:  Specifying file
"test3.inf", line 10: ("story.ni", 16): Error:  Specifying file-line
"test3.inf", line 14: ("story.ni", 26:40): Error:  Specifying file-line-char
```

```
% ./inform -E1 test.inf
test3.inf(2): Error:  Plain I6 error
test3.inf(6)|story.ni: Error:  Specifying file
test3.inf(10)|story.ni(16): Error:  Specifying file-line
test3.inf(14)|story.ni(26:40): Error:  Specifying file-line-char
```

```
% ./inform -E2 test.inf
File "test3.inf"; Line 2	# Error:  Plain I6 error
File "test3.inf"; Line 6: ("story.ni")	# Error:  Specifying file
File "test3.inf"; Line 10: ("story.ni"; Line 16)	# Error:  Specifying file-line
File "test3.inf"; Line 14: ("story.ni"; Line 26; Char 40)	# Error:  Specifying file-line-char
```

(The plain-I6 error output has not changed.)
