### PR TITLE
Options: add -g3; -k no longer sets -D

### DIFF
--- a/inform.c
+++ b/inform.c
@@ -1331,8 +1331,9 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 
    printf("\
   f   frequencies mode: show how useful abbreviations are\n\
-  g   traces calls to functions (except in the library)\n\
-  g2  traces calls to all functions\n\
+  g   traces calls to all game functions\n\
+  g2  traces calls to all game and library functions\n\
+  g3  traces calls to all functions (including veneer)\n\
   h   print general help information\n\
   h1  print help information on filenames and path options\n\
   h2  print help information on switches (this page)\n");
@@ -1440,6 +1441,7 @@ extern void switches(char *p, int cmode)
         case 'g': switch(p[i+1])
                   {   case '1': trace_fns_setting=1; s=2; break;
                       case '2': trace_fns_setting=2; s=2; break;
+                      case '3': trace_fns_setting=3; s=2; break;
                       default: trace_fns_setting=1; break;
                   }
                   break;

--- a/inform.c
+++ b/inform.c
@@ -1341,7 +1341,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
    printf("\
   i   ignore default switches set within the file\n\
   j   list objects as constructed\n\
-  k   output Infix debugging information to \"%s\" (and switch -D on)\n\
+  k   output debugging information to \"%s\"\n\
   l   list every statement run through Inform (not implemented)\n\
   m   say how much memory has been allocated\n\
   n   print numbers of properties, attributes and actions\n",
@@ -1457,9 +1457,7 @@ extern void switches(char *p, int cmode)
         case 'k': if (cmode == 0)
                       error("The switch '-k' can't be set with 'Switches'");
                   else
-                  {   debugfile_switch = state;
-                      if (state) define_DEBUG_switch = TRUE;
-                  }
+                      debugfile_switch = state;
                   break;
         case 'l': listing_switch = state; break;
         case 'm': memout_switch = state; break;

--- a/inform.c
+++ b/inform.c
@@ -1279,10 +1279,10 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   ++dir         add this directory to Include_Path\n\
   +PATH=dir     change the PATH to this directory\n\
   ++PATH=dir    add this directory to the PATH\n\n\
-  $...          one of the following memory commands:\n");
+  $...          one of the following configuration commands:\n");
   
   printf(
-"     $list            list current memory allocation settings\n\
+"     $list            list current settings\n\
      $huge            make standard \"huge game\" settings %s\n\
      $large           make standard \"large game\" settings %s\n\
      $small           make standard \"small game\" settings %s\n\


### PR DESCRIPTION
Covers two issues:

https://github.com/DavidKinder/Inform6/issues/68

In 6.21, the `-g2` switch was modifed to only trace game and library routines, excluding veneer routines. Code was added to support level-3 tracing (all routines, including veneer) but there was no way to turn it on. You can now turn it on with `-g3`.

(Note that `-g2` and above will cause runtime errors in Glulx games, due to printing trace information when no output window is available.)

https://github.com/DavidKinder/Inform6/issues/72

The original purpose of the `-k` option (generate gameinfo.dbg) was for game-level debugging. So setting it turned on `-D`. (But you could get gameinfo.dbg without debug mode by writing `-k -~D`.)

I'd like to disentangle these two options. gameinfo.dbg has more uses these days than game debugging. One might want to use it while developing or debugging an interpreter. I also used it to create a customized interpreter for Hadean Lands -- this observes VM global variables to support a dynamic map and so on.

This changes the behavior of the compiler in a non-backwards-compatible way: you need to write `-k -D` to get the output that was previously produced by `-k`. However, I don't think this will have much real-world impact.

(The I7 toolchain compiles with `-kE2SDwG` for debug mode, `-kE2~S~DwG` for release mode. So this change will not affect it at all.)
