### PR TITLE
Command-line option to set a (numeric) constant

### DIFF
--- a/errors.c
+++ b/errors.c
@@ -137,6 +137,12 @@ static char *location_text(brief_location report_line)
     if (j <= 0 || j > total_files) p = errpos.source;
     else p = InputFiles[j-1].filename;
     
+    if (!p && errpos.line_number == 0) {
+        /* Special case */
+        strcpy(other_pos_buff, "compiler setup");
+        return other_pos_buff;
+    }
+    
     if (!p) p = "";
 
     len = 0;

--- a/header.h
+++ b/header.h
@@ -2659,6 +2659,7 @@ extern void list_symbols(int level);
 extern void assign_marked_symbol(int index, int marker, int32 value, int type);
 extern void assign_symbol(int index, int32 value, int type);
 extern void issue_unused_warnings(void);
+extern void add_config_symbol_definition(char *symbol, int32 value);
 extern void add_symbol_replacement_mapping(int original, int renamed);
 extern int find_symbol_replacement(int *value);
 extern void df_note_function_start(char *name, uint32 address, 

--- a/inform.c
+++ b/inform.c
@@ -1287,7 +1287,8 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
      $large           make standard \"large game\" settings %s\n\
      $small           make standard \"small game\" settings %s\n\
      $?SETTING        explain briefly what SETTING is for\n\
-     $SETTING=number  change SETTING to given number\n\n",
+     $SETTING=number  change SETTING to given number\n\
+     $#SYMBOL=number  define SYMBOL as a constant in the story\n\n",
     (DEFAULT_MEMORY_SIZE==HUGE_SIZE)?"(default)":"",
     (DEFAULT_MEMORY_SIZE==LARGE_SIZE)?"(default)":"",
     (DEFAULT_MEMORY_SIZE==SMALL_SIZE)?"(default)":"");
@@ -1304,6 +1305,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   --size huge, --size large, --size small\n\
   --helpopt SETTING\n\
   --opt SETTING=number\n\
+  --define SETTING=number\n\
   --config filename      (setup file)\n\n");
 
 #ifndef PROMPT_INPUT
@@ -1848,6 +1850,15 @@ static int execute_dashdash_command(char *p, char *p2)
             return consumed2;
         }
         strcpy(cli_buff, "$?");
+        strcpyupper(cli_buff+2, p2, CMD_BUF_SIZE-2);
+    }
+    else if (!strcmp(p, "define")) {
+        consumed2 = TRUE;
+        if (!p2) {
+            printf("--define must be followed by \"symbol=number\"\n");
+            return consumed2;
+        }
+        strcpy(cli_buff, "$#");
         strcpyupper(cli_buff+2, p2, CMD_BUF_SIZE-2);
     }
     else if (!strcmp(p, "path")) {

--- a/memory.c
+++ b/memory.c
@@ -986,7 +986,7 @@ static void add_predefined_symbol(char *command)
         };
     }
 
-    printf("### %s = %d\n", command, value);
+    add_config_symbol_definition(command, value);
 }
 
 /* Handle a dollar-sign command option: $LIST, $FOO=VAL, and so on.

--- a/memory.c
+++ b/memory.c
@@ -957,6 +957,38 @@ static int parse_memory_setting(char *str, char *label, int32 *result)
     return 1;
 }
 
+static void add_predefined_symbol(char *command)
+{
+    int ix;
+    
+    int value = 0;
+    char *valpos = NULL;
+    
+    for (ix=0; command[ix]; ix++) {
+        if (command[ix] == '=') {
+            valpos = command+(ix+1);
+            command[ix] = '\0';
+            break;
+        }
+    }
+    
+    for (ix=0; command[ix]; ix++) {
+        if ((ix == 0 && isdigit(command[ix]))
+            || !(isalnum(command[ix]) || command[ix] == '_')) {
+            printf("Attempt to define invalid symbol: %s\n", command);
+            return;
+        }
+    }
+
+    if (valpos) {
+        if (!parse_memory_setting(valpos, command, &value)) {
+            return;
+        };
+    }
+
+    printf("### %s = %d\n", command, value);
+}
+
 extern void memory_command(char *command)
 {   int i, k, flag=0; int32 j;
 
@@ -964,6 +996,7 @@ extern void memory_command(char *command)
         if (islower(command[k])) command[k]=toupper(command[k]);
 
     if (command[0]=='?') { explain_parameter(command+1); return; }
+    if (command[0]=='#') { add_predefined_symbol(command+1); return; }
 
     if (strcmp(command, "HUGE")==0) { set_memory_sizes(HUGE_SIZE); return; }
     if (strcmp(command, "LARGE")==0) { set_memory_sizes(LARGE_SIZE); return; }

--- a/memory.c
+++ b/memory.c
@@ -989,6 +989,16 @@ static void add_predefined_symbol(char *command)
     printf("### %s = %d\n", command, value);
 }
 
+/* Handle a dollar-sign command option: $LIST, $FOO=VAL, and so on.
+   The option may come from the command line, an ICL file, or a header
+   comment.
+
+   (Unix-style command-line options are converted to dollar-sign format
+   before being sent here.)
+
+   The name of this function is outdated. Many of these settings are not
+   really about memory allocation.
+*/
 extern void memory_command(char *command)
 {   int i, k, flag=0; int32 j;
 

--- a/symbols.c
+++ b/symbols.c
@@ -76,6 +76,8 @@ static char** symbol_name_space_chunks; /* For chunks of memory used to hold
                                            the name strings of symbols       */
 static int no_symbol_name_space_chunks;
 
+/* Symbol replacements (used by the "Replace X Y" directive). */
+
 typedef struct value_pair_struct {
     int original_symbol;
     int renamed_symbol;
@@ -83,6 +85,18 @@ typedef struct value_pair_struct {
 static value_pair_t *symbol_replacements;
 static int symbol_replacements_count;
 static int symbol_replacements_size; /* calloced size */
+
+/* Symbol definitions requested at compile time. (There may not be any.)
+   These are set up at command-line parse time, not in init_symbols_vars().
+   Similarly, they are not cleaned up by symbols_free_arrays(). */
+
+typedef struct keyvalue_pair_struct {
+    char *symbol;
+    int32 value;
+} keyvalue_pair_t;
+static keyvalue_pair_t *symbol_definitions = NULL;
+static int symbol_definitions_count = 0;
+static int symbol_definitions_size = 0; /* calloced size */
 
 /* ------------------------------------------------------------------------- */
 /*   The symbols table is "hash-coded" into a disjoint union of linked       */
@@ -155,6 +169,28 @@ extern int strcmpcis(char *p, char *q)
     }
     qc = q[i]; if (isupper(qc)) qc = tolower(qc);
     return -qc;
+}
+
+/* ------------------------------------------------------------------------- */
+
+extern void add_config_symbol_definition(char *symbol, int32 value)
+{
+    if (symbol_definitions_count == symbol_definitions_size) {
+        int oldsize = symbol_definitions_size;
+        if (symbol_definitions_size == 0) 
+            symbol_definitions_size = 4;
+        else
+            symbol_definitions_size *= 2;
+        my_recalloc(&symbol_definitions, sizeof(keyvalue_pair_t), oldsize,
+            symbol_definitions_size, "symbol definition table");
+    }
+
+    char *str = my_malloc(strlen(symbol+1), "symbol name");
+    strcpy(str, symbol);
+    
+    symbol_definitions[symbol_definitions_count].symbol = str;
+    symbol_definitions[symbol_definitions_count].value = value;
+    symbol_definitions_count++;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -734,6 +770,17 @@ static void stockup_symbols(void)
         create_symbol("FLOAT_INFINITY",  0x7F800000, CONSTANT_T);
         create_symbol("FLOAT_NINFINITY", 0xFF800000, CONSTANT_T);
         create_symbol("FLOAT_NAN",       0x7FC00000, CONSTANT_T);
+    }
+
+    if (symbol_definitions && symbol_definitions_count) {
+        int ix;
+        for (ix=0; ix<symbol_definitions_count; ix++) {
+            char *str = symbol_definitions[ix].symbol;
+            int32 val = symbol_definitions[ix].value;
+            printf("### %s = %d\n", str, val);
+            //### check collision
+            create_symbol(str, val, CONSTANT_T);
+        }
     }
 }
 

--- a/symbols.c
+++ b/symbols.c
@@ -620,6 +620,18 @@ static void emit_debug_information_for_predefined_symbol
 
 static void create_symbol(char *p, int32 value, int type)
 {   int i = symbol_index(p, -1);
+    if (!(sflags[i] & UNKNOWN_SFLAG)) {
+        /* Symbol already defined! */
+        if (svals[i] == value && stypes[i] == type) {
+            /* Special case: the symbol was already defined with this same
+               value. We allow it. */
+            return;
+        }
+        else {
+            ebf_symbol_error("new symbol", p, typename(stypes[i]), slines[i]);
+            return;
+        }
+    }
     svals[i] = value; stypes[i] = type; slines[i] = blank_brief_location;
     sflags[i] = USED_SFLAG + SYSTEM_SFLAG;
     emit_debug_information_for_predefined_symbol(p, i, value, type);

--- a/symbols.c
+++ b/symbols.c
@@ -185,7 +185,7 @@ extern void add_config_symbol_definition(char *symbol, int32 value)
             symbol_definitions_size, "symbol definition table");
     }
 
-    char *str = my_malloc(strlen(symbol+1), "symbol name");
+    char *str = my_malloc(strlen(symbol)+1, "symbol name");
     strcpy(str, symbol);
     
     symbol_definitions[symbol_definitions_count].symbol = str;


### PR DESCRIPTION
Fixes https://github.com/DavidKinder/Inform6/issues/69 .

This adds support for a new argument format:

    $#SYMBOL
    $#SYMBOL=NUM

Or, on the command line:

    --define SYMBOL
    --define SYMBOL=NUM

This defines SYMBOL as a constant, just like the `Constant` directive. Like that directive, if no value is supplied, it defaults to zero.

These symbols are defined after builtins like `true`, `false`, and `WORDSIZE`. Trying to change the value of a builtin constant is an error. Trying to define two values for the same constant is also an error.

Special cases:

Saying `--define DEBUG` (or `--define DEBUG=0`, or `$#DEBUG`, or `$#DEBUG=0`) is now exactly the same as the `-D` option.

Inform symbols are case-insensitive, so `--define debug` (etc) is also the same as `-D`.

We check for and reject invalid symbols like `9tails` or `FOO/BAR`.

If you try to redefine a constant with the *same* value (e.g. `--define true=1`), the compiler will accept it without complaint.

Inform has a notion of "redefinable constants". (There are only a few: `Grammar__Version, DEBUG, INFIX, MODULE_MODE, STRICT_MODE, USE_MODULES`. I think only `Grammar__Version` has any real utility -- the standard library redefines it from its default.) The new feature is compatible with this idea, for what it's worth.

A small improvement in error messages: the compiler can now say

> "", line 0: Error:  "TRUE" is a name already in use and may not be used as a new symbol (Defined constant "TRUE" was defined at compiler setup)

...rather than...

> ...(Defined constant "TRUE" was defined at "", line 0)


