### PR TITLE
Mention -O2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The latest version of Inform is [Inform 7](http://inform7.com/), but Inform 6 st
 
 To use the compiler, you will need an executable. There are [pre-built executables](https://ifarchive.org/indexes/if-archive/infocom/compilers/inform6/executables/) available, or you can compile the source yourself. There is no makefile as compilation does not really need one: all that is required is a C compiler and for it to be invoked with something like
 
-      cc -o inform *.c
+      cc -O2 -o inform *.c
       
 To write a work of interactive fiction with Inform 6, you will also need a version of the Inform 6 library. [Stable versions](https://ifarchive.org/indexes/if-archive/infocom/compilers/inform6/library/) of the library are available, and development of the library continues in a [separate project](https://gitlab.com/DavidGriffith/inform6lib).
 


### PR DESCRIPTION
See https://github.com/DavidKinder/Inform6/issues/62 .

The original poster mentions the `-flto` option as well. However, a bit of experiment shows that `-flto` adds very little improvement over `-O2`. It's common for apps to mention `-O` or `-O2` in their standard config; getting into fancier options would, I think, generate more confusion than benefit.
