### PR TITLE
Array bounds checks and compiler warnings

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -281,7 +281,6 @@ extern void make_global(int array_flag, int name_only)
     assembly_operand AO;
     
     int extraspace;
-    int orig_area_size;
 
     int32 global_symbol;
     const char *global_name;
@@ -522,12 +521,10 @@ extern void make_global(int array_flag, int name_only)
         extraspace += WORDSIZE;
     
     if (!is_static) {
-        orig_area_size = dynamic_array_area_size;
         array_base = dynamic_array_area_size;
         dynamic_array_area_size += extraspace;
     }
     else {
-        orig_area_size = static_array_area_size;
         array_base = static_array_area_size;
         static_array_area_size += extraspace;
     }

--- a/directs.c
+++ b/directs.c
@@ -21,7 +21,8 @@ brief_location routine_starts_line; /* Source code location where the current
 
 static int constant_made_yet;      /* Have any constants been defined yet?   */
 
-static int ifdef_stack[32], ifdef_sp;
+#define MAX_IFDEF_STACK (32)
+static int ifdef_stack[MAX_IFDEF_STACK], ifdef_sp;
 
 /* ------------------------------------------------------------------------- */
 
@@ -483,6 +484,11 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         if (!((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)))
             return ebf_error_recover("semicolon after 'If...' condition", token_text);
 
+        if (ifdef_sp >= MAX_IFDEF_STACK) {
+            error("'If' directives nested too deeply");
+            panic_mode_error_recovery(); return FALSE;
+        }
+        
         if (flag)
         {   ifdef_stack[ifdef_sp++] = TRUE; return FALSE; }
         else

--- a/expressc.c
+++ b/expressc.c
@@ -437,10 +437,12 @@ static void access_memory_z(int oc, assembly_operand AO1, assembly_operand AO2,
         index_ao;
     int x = 0, y = 0, byte_flag = FALSE, read_flag = FALSE, from_module = FALSE;
 
+    INITAO(&zero_ao);
+    INITAO(&size_ao);
+    INITAO(&type_ao);
+
     if (AO1.marker == ARRAY_MV || AO1.marker == STATIC_ARRAY_MV)
     {   
-        INITAO(&zero_ao);
-
         if ((oc == loadb_zc) || (oc == storeb_zc)) byte_flag=TRUE;
         else byte_flag = FALSE;
         if ((oc == loadb_zc) || (oc == loadw_zc)) read_flag=TRUE;
@@ -808,10 +810,12 @@ static void access_memory_g(int oc, assembly_operand AO1, assembly_operand AO2,
     else 
       read_flag = FALSE;
 
+    INITAO(&zero_ao);
+    INITAO(&size_ao);
+    INITAO(&type_ao);
+    
     if (AO1.marker == ARRAY_MV || AO1.marker == STATIC_ARRAY_MV)
     {   
-        INITAO(&zero_ao);
-
         size_ao = zero_ao; size_ao.value = -1;
         for (x=0; x<no_arrays; x++)
         {   if (((AO1.marker == ARRAY_MV) == (!array_locs[x]))

--- a/expressp.c
+++ b/expressp.c
@@ -54,6 +54,7 @@ static int comma_allowed, arrow_allowed, superclass_allowed,
 
 extern int *variable_usage;
 
+/* Must be at least as many as keyword_group system_functions (currently 12) */
 int system_function_usage[32];
 
 static int get_next_etoken(void)

--- a/inform.c
+++ b/inform.c
@@ -182,6 +182,12 @@ static void select_target(int targ)
     /* MAX_NUM_ATTR_BYTES can be increased in header.h without fear. */
   }
 
+  if (MAX_ADJECTIVES > 255) {
+    MAX_ADJECTIVES = 255;
+    warning("MAX_ADJECTIVES cannot exceed 255; resetting to 255");
+    /* Only used under Grammar__Version 1, which is obsolete. */
+  }
+    
   /* Set up a few more variables that depend on the above values */
 
   if (!targ) {

--- a/inform.c
+++ b/inform.c
@@ -1065,6 +1065,7 @@ extern void translate_temp_filename(int i)
     {   case 1: p=Temp1_Name; break;
         case 2: p=Temp2_Name; break;
         case 3: p=Temp3_Name; break;
+        default: return;
     }
     if (strlen(Temporary_Path)+strlen(Temporary_File)+6 >= PATHLEN) {
         printf ("Temporary_Path is too long.\n");

--- a/objects.c
+++ b/objects.c
@@ -1743,7 +1743,6 @@ extern void make_class(char * metaclass_name)
 {   int n, duplicates_to_make = 0, class_number = no_objects+1,
         metaclass_flag = (metaclass_name != NULL);
     char duplicate_name[128];
-    int class_symbol;
     debug_location_beginning beginning_debug_location =
         get_token_location_beginning();
 
@@ -1833,8 +1832,6 @@ inconvenience, please contact the maintainers.");
       full_object_g.propdata[0].type   = CONSTANT_OT;
       full_object_g.propdata[0].marker = OBJECT_MV;
     }
-
-    class_symbol = token_value;
 
     if (!metaclass_flag)
     {   get_next_token();

--- a/states.c
+++ b/states.c
@@ -961,6 +961,10 @@ static void parse_statement_z(int break_label, int continue_label)
                  get_next_token();
 
                  /*  Initialisation code  */
+                 AO.type = OMITTED_OT;
+                 spare_debug_location1 = statement_debug_location;
+                 AO2.type = OMITTED_OT; flag = 0;
+                 spare_debug_location2 = statement_debug_location;
 
                  if (!((token_type==SEP_TT)&&(token_value==COLON_SEP)))
                  {   put_token_back();
@@ -983,7 +987,6 @@ static void parse_statement_z(int break_label, int continue_label)
                              assemble_label_no(ln2);
                              return;
                          }
-                         AO.type = OMITTED_OT;
                          goto ParseUpdate;
                      }
                      put_token_back();
@@ -991,7 +994,6 @@ static void parse_statement_z(int break_label, int continue_label)
                  }
 
                  get_next_token();
-                 AO.type = OMITTED_OT;
                  if (!((token_type==SEP_TT)&&(token_value==COLON_SEP)))
                  {   put_token_back();
                      spare_debug_location1 = get_token_location();
@@ -1001,7 +1003,6 @@ static void parse_statement_z(int break_label, int continue_label)
                  get_next_token();
 
                  ParseUpdate:
-                 AO2.type = OMITTED_OT; flag = 0;
                  if (!((token_type==SEP_TT)&&(token_value==CLOSEB_SEP)))
                  {   put_token_back();
                      spare_debug_location2 = get_token_location();
@@ -1921,6 +1922,10 @@ static void parse_statement_g(int break_label, int continue_label)
                  get_next_token();
 
                  /*  Initialisation code  */
+                 AO.type = OMITTED_OT;
+                 spare_debug_location1 = statement_debug_location;
+                 AO2.type = OMITTED_OT; flag = 0;
+                 spare_debug_location2 = statement_debug_location;
 
                  if (!((token_type==SEP_TT)&&(token_value==COLON_SEP)))
                  {   put_token_back();
@@ -1943,7 +1948,6 @@ static void parse_statement_g(int break_label, int continue_label)
                              assemble_label_no(ln2);
                              return;
                          }
-                         AO.type = OMITTED_OT;
                          goto ParseUpdate;
                      }
                      put_token_back();
@@ -1951,7 +1955,6 @@ static void parse_statement_g(int break_label, int continue_label)
                  }
 
                  get_next_token();
-                 AO.type = OMITTED_OT;
                  if (!((token_type==SEP_TT)&&(token_value==COLON_SEP)))
                  {   put_token_back();
                      spare_debug_location1 = get_token_location();
@@ -1961,7 +1964,6 @@ static void parse_statement_g(int break_label, int continue_label)
                  get_next_token();
 
                  ParseUpdate:
-                 AO2.type = OMITTED_OT; flag = 0;
                  if (!((token_type==SEP_TT)&&(token_value==CLOSEB_SEP)))
                  {   put_token_back();
                      spare_debug_location2 = get_token_location();

--- a/symbols.c
+++ b/symbols.c
@@ -1039,8 +1039,10 @@ extern void locate_dead_functions(void)
        mark them as used. */
 
     func = df_functions_head;
-    if (!func || func->address != DF_NOT_IN_FUNCTION)
+    if (!func || func->address != DF_NOT_IN_FUNCTION) {
         compiler_error("DF: Global namespace entry is not at the head of the chain.");
+        return;
+    }
 
     for (ent = func->refs; ent; ent=ent->refsnext) {
         uint32 addr;

--- a/verbs.c
+++ b/verbs.c
@@ -80,6 +80,9 @@ static char *English_verb_list,        /* First byte of first record         */
 static int English_verb_list_size;     /* Size of the list in bytes
                                           (redundant but convenient)         */
 
+/* Maximum synonyms in a single Verb/Extend directive */
+#define MAX_VERB_SYNONYMS (32)
+
 /* ------------------------------------------------------------------------- */
 /*   Arrays used by this file                                                */
 /* ------------------------------------------------------------------------- */
@@ -715,7 +718,8 @@ extern void make_verb(void)
 
     int Inform_verb, meta_verb_flag=FALSE, verb_equals_form=FALSE;
 
-    char *English_verbs_given[32]; int no_given = 0, i;
+    char *English_verbs_given[MAX_VERB_SYNONYMS];
+    int no_given = 0, i;
 
     directive_keywords.enabled = TRUE;
 
@@ -727,7 +731,12 @@ extern void make_verb(void)
     }
 
     while ((token_type == DQ_TT) || (token_type == SQ_TT))
-    {   English_verbs_given[no_given++] = token_text;
+    {
+        if (no_given >= MAX_VERB_SYNONYMS) {
+            error("Too many synonyms in a Verb directive.");
+            panic_mode_error_recovery(); return;
+        }
+        English_verbs_given[no_given++] = token_text;
         get_next_token();
     }
 

--- a/verbs.c
+++ b/verbs.c
@@ -48,6 +48,8 @@ int no_adjectives;                     /* Number of adjectives made so far   */
 /*           for example the English verbs "take" and "drop" both normally   */
 /*           correspond in a game's dictionary to the same Inform verb.  An  */
 /*           Inform verb is essentially a list of grammar lines.             */
+/*           (Calling them "English verbs" is of course out of date. Read    */
+/*           this as jargon for "dict words which are verbs".                */
 /* ------------------------------------------------------------------------- */
 /*   Arrays defined below:                                                   */
 /*                                                                           */


### PR DESCRIPTION
This fixes a handful of compiler warnings generated by the latest clang "static analysis" mode.

- Removed some unused variables (set but never read).
- Initialized a few variables earlier in their functions. These were cases where the variables were set conditionally, and then read under the same conditions -- valid but you had to stare at it to figure out why. Earlier initialization makes it clearer.
- Added a couple of `return` statements in error paths.

I also added code to check against overflowing some arrays. These were real array overruns, although you wouldn't run into them unless you were specifically trying. Tests for these (specifically trying!) are in https://github.com/erkyrath/Inform6-Testing/tree/static-analyze .

I didn't create compiler settings for these; they're hardwired in the compiler, same as they were before. The only difference is that now there's a `#define` and bounds-checking code. 

- MAX_IFDEF_STACK
- MAX_VERB_SYNONYMS
- MAX_LINES_PER_VERB

Finally, I threw in a check to prevent MAX_ADJECTIVES (compiler setting) from exceeding 255. In Grammar_Version 1, adjective numbers are stored in a byte so they can't be larger than that. In Grammar_Version 2 (and always in Glulx), MAX_ADJECTIVES is not used at all.


