### PR TITLE
Fix for duplicate dict words (v3)

### DIFF
--- a/text.c
+++ b/text.c
@@ -1648,7 +1648,7 @@ apostrophe in", dword);
 
     for (; i<9; i++) wd[i]=5;
 
-    /* The array of Z-chars is converted to three 2-byte blocks              */
+    /* The array of Z-chars is converted to two or three 2-byte blocks       */
 
     tot = wd[2] + wd[1]*(1<<5) + wd[0]*(1<<10);
     prepared_sort[1]=tot%0x100;

--- a/text.c
+++ b/text.c
@@ -1656,7 +1656,10 @@ apostrophe in", dword);
     tot = wd[5] + wd[4]*(1<<5) + wd[3]*(1<<10);
     prepared_sort[3]=tot%0x100;
     prepared_sort[2]=(tot/0x100)%0x100;
-    tot = wd[8] + wd[7]*(1<<5) + wd[6]*(1<<10);
+    if (version_number==3)
+        tot = 0;
+    else
+        tot = wd[8] + wd[7]*(1<<5) + wd[6]*(1<<10);
     prepared_sort[5]=tot%0x100;
     prepared_sort[4]=(tot/0x100)%0x100;
 


### PR DESCRIPTION
Fixes https://github.com/DavidKinder/Inform6/issues/81 .

In v3 only, if two dict words differ only in Z-characters 7-9 (the chars that are not stored in v3), the compiler would generate two dict entries containing the same word. This fixes that.

Test: https://github.com/erkyrath/Inform6-Testing/blob/master/src/dict-cutoff-v3test.inf . This tests a bunch of cases for both v3 and v4+. No compiler bugs were found for v4+.

See also https://github.com/erkyrath/Inform6-Testing/blob/master/src/dict-cutoff-alttest.inf (v4+ only), which tests cases using a modified Z-character alphabet. 
