### PR TITLE
Undef constant errors

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -460,7 +460,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     case IFTRUE_CODE:
         {   assembly_operand AO;
             AO = parse_expression(CONSTANT_CONTEXT);
-            if (module_switch && (AO.marker != 0))
+            if (AO.marker != 0)
             {   error("This condition can't be determined");
                 flag = 0;
             }
@@ -471,7 +471,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     case IFFALSE_CODE:
         {   assembly_operand AO;
             AO = parse_expression(CONSTANT_CONTEXT);
-            if (module_switch && (AO.marker != 0))
+            if (AO.marker != 0)
             {   error("This condition can't be determined");
                 flag = 1;
             }

--- a/directs.c
+++ b/directs.c
@@ -1074,7 +1074,7 @@ the first constant definition");
               break;
             }
 
-            if (module_switch && (AO.marker != 0))
+            if (AO.marker != 0)
                 error("A definite value must be given as version number");
             else 
             if (glulx_mode) 

--- a/directs.c
+++ b/directs.c
@@ -760,7 +760,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     case RELEASE_CODE:
         {   assembly_operand AO;
             AO = parse_expression(CONSTANT_CONTEXT);
-            if (module_switch && (AO.marker != 0))
+            if (AO.marker != 0)
                 error("A definite value must be given as release number");
             else
                 release_number = AO.value;

--- a/directs.c
+++ b/directs.c
@@ -303,7 +303,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
                 assembly_operand AO;
                 put_token_back();
                 AO = parse_expression(CONSTANT_CONTEXT);
-                if (module_switch && (AO.marker != 0))
+                if (AO.marker != 0)
                     error("A definite value must be given as a Dictionary flag");
                 else
                     val1 = AO.value;
@@ -316,7 +316,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
                     assembly_operand AO;
                     put_token_back();
                     AO = parse_expression(CONSTANT_CONTEXT);
-                    if (module_switch && (AO.marker != 0))
+                    if (AO.marker != 0)
                         error("A definite value must be given as a Dictionary flag");
                     else
                         val3 = AO.value;


### PR DESCRIPTION
Several directives permit using a constant, but the constant must already be defined. (It can't be defined after the directive.) 

The compiler was not properly checking for this error. Now it does.

    Release CONST;
    Version CONST;
    Dictionary 'word' CONST CONST;
    Iftrue CONST;
    Iffalse CONST;

Tests at https://github.com/erkyrath/Inform6-Testing/tree/undef-constant-errors .
