### PR TITLE
Verbose assembly trace; "Trace verbs"

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -223,7 +223,11 @@ static void print_operand_annotation(const assembly_operand *o)
         case INCON_MV:
             printf(": %s", name_of_system_constant(o->value));
             break;
-        /* DWORD_MV: Could print out dict word */
+        case DWORD_MV:
+            printf(": '");
+            print_dict_word(o->value);
+            printf("'");
+            break;
         }
     }
     if (o->symindex >= 0 && o->symindex < no_symbols) {

--- a/asm.c
+++ b/asm.c
@@ -219,6 +219,16 @@ static void print_operand_z(assembly_operand o)
         case OMITTED_OT: printf("<no value>"); return;
     }
     printf("%d", o.value);
+
+  if (o.symindex >= 0 && o.symindex < no_symbols) {
+    if (o.marker)
+      printf(" (%s: %s)", (char *)symbs[o.symindex], describe_mv(o.marker));
+    else
+      printf(" (%s: const)", (char *)symbs[o.symindex]);
+  }
+  else if (o.marker) {
+    printf(" (%s)", describe_mv(o.marker));
+  }
 }
 
 static void print_operand_g(assembly_operand o)
@@ -231,13 +241,13 @@ static void print_operand_g(assembly_operand o)
   case ZEROCONSTANT_OT: printf("zero_"); return;
   case DEREFERENCE_OT: printf("*"); break;
   case GLOBALVAR_OT: 
-    printf("%s (global_%d)", variable_name(o.value), o.value); 
+    printf("global_%d (%s)", o.value, variable_name(o.value)); 
     return;
   case LOCALVAR_OT: 
     if (o.value == 0)
       printf("stackptr"); 
     else
-      printf("%s (local_%d)", variable_name(o.value), o.value-1); 
+      printf("local_%d (%s)", o.value-1, variable_name(o.value)); 
     return;
   case SYSFUN_OT:
     if (o.value >= 0 && o.value < NUMBER_SYSTEM_FUNCTIONS)
@@ -249,14 +259,15 @@ static void print_operand_g(assembly_operand o)
   default: printf("???_"); break; 
   }
   printf("%d", o.value);
+
   if (o.symindex >= 0 && o.symindex < no_symbols) {
-      if (o.marker)
-          printf(" (%s \"%s\")", describe_mv(o.marker), (char *)symbs[o.symindex]);
-      else
-          printf(" (const \"%s\")", (char *)symbs[o.symindex]);
+    if (o.marker)
+      printf(" (%s: %s)", (char *)symbs[o.symindex], describe_mv(o.marker));
+    else
+      printf(" (%s: const)", (char *)symbs[o.symindex]);
   }
   else if (o.marker) {
-      printf(" (%s)", describe_mv(o.marker));
+    printf(" (%s)", describe_mv(o.marker));
   }
 }
 

--- a/asm.c
+++ b/asm.c
@@ -249,6 +249,15 @@ static void print_operand_g(assembly_operand o)
   default: printf("???_"); break; 
   }
   printf("%d", o.value);
+  if (o.symindex >= 0 && o.symindex < no_symbols) {
+      if (o.marker)
+          printf(" (%s \"%s\")", describe_mv(o.marker), (char *)symbs[o.symindex]);
+      else
+          printf(" (const \"%s\")", (char *)symbs[o.symindex]);
+  }
+  else if (o.marker) {
+      printf(" (%s)", describe_mv(o.marker));
+  }
 }
 
 extern void print_operand(assembly_operand o)

--- a/asm.c
+++ b/asm.c
@@ -208,6 +208,7 @@ extern char *variable_name(int32 i)
     return ((char *) symbs[variable_tokens[i]]);
 }
 
+/* Print symbolic information about the AO, if there is any. */
 static void print_operand_annotation(const assembly_operand *o)
 {
     int any = FALSE;
@@ -302,7 +303,7 @@ static void byteout(int32 i, int mv)
 
 /* ------------------------------------------------------------------------- */
 /*   A database of the 115 canonical Infocom opcodes in Versions 3 to 6      */
-/*   And of the however-many-there-are Glulx opcode                          */
+/*   And of the however-many-there-are Glulx opcodes                         */
 /* ------------------------------------------------------------------------- */
 
 typedef struct opcodez

--- a/asm.c
+++ b/asm.c
@@ -221,13 +221,16 @@ static void print_operand_z(const assembly_operand *o)
     printf("%d", o->value);
 
   if (o->symindex >= 0 && o->symindex < no_symbols) {
-    if (o->marker)
-      printf(" (%s: %s)", (char *)symbs[o->symindex], describe_mv(o->marker));
-    else
-      printf(" (%s: const)", (char *)symbs[o->symindex]);
+    printf(" (%s)", (char *)symbs[o->symindex]);
   }
-  else if (o->marker) {
-    printf(" (%s)", describe_mv(o->marker));
+  if (o->marker) {
+    printf(" (%s", describe_mv(o->marker));
+    switch (o->marker) {
+    case VROUTINE_MV:
+      printf(" %s", veneer_routine_name(o->value));
+      break;
+    }
+    printf(")");       
   }
 }
 
@@ -261,13 +264,16 @@ static void print_operand_g(const assembly_operand *o)
   printf("%d", o->value);
 
   if (o->symindex >= 0 && o->symindex < no_symbols) {
-    if (o->marker)
-      printf(" (%s: %s)", (char *)symbs[o->symindex], describe_mv(o->marker));
-    else
-      printf(" (%s: const)", (char *)symbs[o->symindex]);
+    printf(" (%s)", (char *)symbs[o->symindex]);
   }
-  else if (o->marker) {
-    printf(" (%s)", describe_mv(o->marker));
+  if (o->marker) {
+    printf(" (%s", describe_mv(o->marker));
+    switch (o->marker) {
+    case VROUTINE_MV:
+      printf(" %s", veneer_routine_name(o->value));
+      break;
+    }
+    printf(")");       
   }
 }
 

--- a/asm.c
+++ b/asm.c
@@ -210,11 +210,11 @@ extern char *variable_name(int32 i)
 
 static void print_operand_annotation(const assembly_operand *o)
 {
-    if (o->symindex >= 0 && o->symindex < no_symbols) {
-        printf(" (%s)", (char *)symbs[o->symindex]);
-    }
+    int any = FALSE;
     if (o->marker) {
-        printf(" (%s", describe_mv(o->marker));
+        printf((!any) ? " (" : ": ");
+        any = TRUE;
+        printf("%s", describe_mv(o->marker));
         switch (o->marker) {
         case VROUTINE_MV:
             printf(": %s", veneer_routine_name(o->value));
@@ -222,9 +222,15 @@ static void print_operand_annotation(const assembly_operand *o)
         case INCON_MV:
             printf(": %s", name_of_system_constant(o->value));
             break;
+        /* DWORD_MV: Could print out dict word */
         }
-        printf(")");       
     }
+    if (o->symindex >= 0 && o->symindex < no_symbols) {
+        printf((!any) ? " (" : ": ");
+        any = TRUE;
+        printf("%s", (char *)symbs[o->symindex]);
+    }
+    if (any) printf(")");       
 }
 
 static void print_operand_z(const assembly_operand *o, int annotate)

--- a/asm.c
+++ b/asm.c
@@ -227,7 +227,10 @@ static void print_operand_z(const assembly_operand *o)
     printf(" (%s", describe_mv(o->marker));
     switch (o->marker) {
     case VROUTINE_MV:
-      printf(" %s", veneer_routine_name(o->value));
+      printf(": %s", veneer_routine_name(o->value));
+      break;
+    case INCON_MV:
+      printf(": %s", name_of_system_constant(o->value));
       break;
     }
     printf(")");       
@@ -270,7 +273,10 @@ static void print_operand_g(const assembly_operand *o)
     printf(" (%s", describe_mv(o->marker));
     switch (o->marker) {
     case VROUTINE_MV:
-      printf(" %s", veneer_routine_name(o->value));
+      printf(": %s", veneer_routine_name(o->value));
+      break;
+    case INCON_MV:
+      printf(": %s", name_of_system_constant(o->value));
       break;
     }
     printf(")");       

--- a/asm.c
+++ b/asm.c
@@ -208,32 +208,32 @@ extern char *variable_name(int32 i)
     return ((char *) symbs[variable_tokens[i]]);
 }
 
-static void print_operand_z(assembly_operand o)
-{   switch(o.type)
+static void print_operand_z(const assembly_operand *o)
+{   switch(o->type)
     {   case EXPRESSION_OT: printf("expr_"); break;
         case LONG_CONSTANT_OT: printf("long_"); break;
         case SHORT_CONSTANT_OT: printf("short_"); break;
         case VARIABLE_OT:
-             if (o.value==0) { printf("sp"); return; }
-             printf("%s", variable_name(o.value)); return;
+             if (o->value==0) { printf("sp"); return; }
+             printf("%s", variable_name(o->value)); return;
         case OMITTED_OT: printf("<no value>"); return;
     }
-    printf("%d", o.value);
+    printf("%d", o->value);
 
-  if (o.symindex >= 0 && o.symindex < no_symbols) {
-    if (o.marker)
-      printf(" (%s: %s)", (char *)symbs[o.symindex], describe_mv(o.marker));
+  if (o->symindex >= 0 && o->symindex < no_symbols) {
+    if (o->marker)
+      printf(" (%s: %s)", (char *)symbs[o->symindex], describe_mv(o->marker));
     else
-      printf(" (%s: const)", (char *)symbs[o.symindex]);
+      printf(" (%s: const)", (char *)symbs[o->symindex]);
   }
-  else if (o.marker) {
-    printf(" (%s)", describe_mv(o.marker));
+  else if (o->marker) {
+    printf(" (%s)", describe_mv(o->marker));
   }
 }
 
-static void print_operand_g(assembly_operand o)
+static void print_operand_g(const assembly_operand *o)
 {
-  switch (o.type) {
+  switch (o->type) {
   case EXPRESSION_OT: printf("expr_"); break;
   case CONSTANT_OT: printf("long_"); break;
   case HALFCONSTANT_OT: printf("short_"); break;
@@ -241,37 +241,37 @@ static void print_operand_g(assembly_operand o)
   case ZEROCONSTANT_OT: printf("zero_"); return;
   case DEREFERENCE_OT: printf("*"); break;
   case GLOBALVAR_OT: 
-    printf("global_%d (%s)", o.value, variable_name(o.value)); 
+    printf("global_%d (%s)", o->value, variable_name(o->value)); 
     return;
   case LOCALVAR_OT: 
-    if (o.value == 0)
+    if (o->value == 0)
       printf("stackptr"); 
     else
-      printf("local_%d (%s)", o.value-1, variable_name(o.value)); 
+      printf("local_%d (%s)", o->value-1, variable_name(o->value)); 
     return;
   case SYSFUN_OT:
-    if (o.value >= 0 && o.value < NUMBER_SYSTEM_FUNCTIONS)
-      printf("%s", system_functions.keywords[o.value]);
+    if (o->value >= 0 && o->value < NUMBER_SYSTEM_FUNCTIONS)
+      printf("%s", system_functions.keywords[o->value]);
     else
       printf("<unnamed system function>");
     return;
   case OMITTED_OT: printf("<no value>"); return;
   default: printf("???_"); break; 
   }
-  printf("%d", o.value);
+  printf("%d", o->value);
 
-  if (o.symindex >= 0 && o.symindex < no_symbols) {
-    if (o.marker)
-      printf(" (%s: %s)", (char *)symbs[o.symindex], describe_mv(o.marker));
+  if (o->symindex >= 0 && o->symindex < no_symbols) {
+    if (o->marker)
+      printf(" (%s: %s)", (char *)symbs[o->symindex], describe_mv(o->marker));
     else
-      printf(" (%s: const)", (char *)symbs[o.symindex]);
+      printf(" (%s: const)", (char *)symbs[o->symindex]);
   }
-  else if (o.marker) {
-    printf(" (%s)", describe_mv(o.marker));
+  else if (o->marker) {
+    printf(" (%s)", describe_mv(o->marker));
   }
 }
 
-extern void print_operand(assembly_operand o)
+extern void print_operand(const assembly_operand *o)
 {
   if (!glulx_mode)
     print_operand_z(o);
@@ -1001,7 +1001,7 @@ extern void assemblez_instruction(assembly_instruction *AI)
         for (i=0; i<AI->operand_count; i++)
         {   if ((i==0) && (opco.op_rules == VARIAB))
             {   if ((AI->operand[0]).type == VARIABLE_OT)
-                {   printf("["); print_operand_z(AI->operand[i]); }
+                {   printf("["); print_operand_z(&AI->operand[i]); }
                 else
                     printf("%s", variable_name((AI->operand[0]).value));
             }
@@ -1009,14 +1009,14 @@ extern void assemblez_instruction(assembly_instruction *AI)
             if ((i==0) && (opco.op_rules == LABEL))
             {   printf("L%d", AI->operand[0].value);
             }
-            else print_operand_z(AI->operand[i]);
+            else print_operand_z(&AI->operand[i]);
             printf(" ");
         }
         if (AI->store_variable_number != -1)
         {   assembly_operand AO;
             printf("-> ");
             AO.type = VARIABLE_OT; AO.value = AI->store_variable_number;
-            print_operand_z(AO); printf(" ");
+            print_operand_z(&AO); printf(" ");
         }
 
         switch(AI->branch_label_number)
@@ -1366,7 +1366,7 @@ extern void assembleg_instruction(assembly_instruction *AI)
                 printf("to L%d", AI->operand[i].value);
             }
           else {
-            print_operand_g(AI->operand[i]);
+            print_operand_g(&AI->operand[i]);
           }
           printf(" ");
       }

--- a/expressp.c
+++ b/expressp.c
@@ -753,6 +753,14 @@ extern int32 value_of_system_constant(int t)
     return value_of_system_constant_g(t);    
 }
 
+extern char *name_of_system_constant(int t)
+{
+  if (t < 0 || t >= NO_SYSTEM_CONSTANTS) {
+    return "???";
+  }
+  return system_constants.keywords[t];
+}
+
 static int evaluate_term(token_data t, assembly_operand *o)
 {
     /*  If the given token is a constant, evaluate it into the operand.

--- a/expressp.c
+++ b/expressp.c
@@ -974,7 +974,7 @@ static void mark_top_of_emitter_stack(int marker, token_data t)
     }
     if (expr_trace_level >= 2)
     {   printf("Marking top of emitter stack (which is ");
-        print_operand(emitter_stack[emitter_sp-1]);
+        print_operand(&emitter_stack[emitter_sp-1]);
         printf(") as ");
         switch(marker)
         {
@@ -1038,7 +1038,7 @@ static void emit_token(token_data t)
     if (expr_trace_level >= 2)
     {   printf("Output: %-19s%21s ", t.text, "");
         for (i=0; i<emitter_sp; i++)
-        {   print_operand(emitter_stack[i]); printf(" ");
+        {   print_operand(&emitter_stack[i]); printf(" ");
             if (emitter_markers[i] == FUNCTION_VALUE_MARKER) printf(":FUNCTION ");
             if (emitter_markers[i] == ARGUMENT_VALUE_MARKER) printf(":ARGUMENT ");
             if (emitter_markers[i] == OR_VALUE_MARKER) printf(":OR ");
@@ -1392,7 +1392,7 @@ the range -32768 to +32767:", folding_error);
 
     if (expr_trace_level >= 2)
     {   printf("Folding constant to: ");
-        print_operand(emitter_stack[emitter_sp - 1]);
+        print_operand(&emitter_stack[emitter_sp - 1]);
         printf("\n");
     }
 
@@ -1408,7 +1408,7 @@ static void show_node(int n, int depth, int annotate)
     for (j=0; j<2*depth+2; j++) printf(" ");
 
     if (ET[n].down == -1)
-    {   print_operand(ET[n].value);
+    {   print_operand(&ET[n].value);
         if (annotate && (ET[n].value.marker != 0))
             printf(" [%s]", describe_mv(ET[n].value.marker));
         printf("\n");
@@ -1432,7 +1432,7 @@ static void show_node(int n, int depth, int annotate)
 extern void show_tree(assembly_operand AO, int annotate)
 {   if (AO.type == EXPRESSION_OT) show_node(AO.value, 0, annotate);
     else
-    {   printf("Constant: "); print_operand(AO);
+    {   printf("Constant: "); print_operand(&AO);
         if (annotate && (AO.marker != 0))
             printf(" [%s]", describe_mv(AO.marker));
         printf("\n");

--- a/expressp.c
+++ b/expressp.c
@@ -72,6 +72,7 @@ static int get_next_etoken(void)
         current_token.value = token_value;
         current_token.type = token_type;
         current_token.marker = 0;
+        current_token.symindex = -1;
         current_token.symtype = 0;
         current_token.symflags = -1;
     }
@@ -124,6 +125,7 @@ but not used as a value:", unicode);
 
             v = svals[symbol];
 
+            current_token.symindex = symbol;
             current_token.symtype = stypes[symbol];
             current_token.symflags = sflags[symbol];
             switch(stypes[symbol])
@@ -761,6 +763,7 @@ static int evaluate_term(token_data t, assembly_operand *o)
     int32 v;
 
     o->marker = t.marker;
+    o->symindex = t.symindex;
     o->symtype = t.symtype;
     o->symflags = t.symflags;
 

--- a/expressp.c
+++ b/expressp.c
@@ -982,7 +982,7 @@ static void mark_top_of_emitter_stack(int marker, token_data t)
     }
     if (expr_trace_level >= 2)
     {   printf("Marking top of emitter stack (which is ");
-        print_operand(&emitter_stack[emitter_sp-1]);
+        print_operand(&emitter_stack[emitter_sp-1], FALSE);
         printf(") as ");
         switch(marker)
         {
@@ -1046,7 +1046,7 @@ static void emit_token(token_data t)
     if (expr_trace_level >= 2)
     {   printf("Output: %-19s%21s ", t.text, "");
         for (i=0; i<emitter_sp; i++)
-        {   print_operand(&emitter_stack[i]); printf(" ");
+        {   print_operand(&emitter_stack[i], FALSE); printf(" ");
             if (emitter_markers[i] == FUNCTION_VALUE_MARKER) printf(":FUNCTION ");
             if (emitter_markers[i] == ARGUMENT_VALUE_MARKER) printf(":ARGUMENT ");
             if (emitter_markers[i] == OR_VALUE_MARKER) printf(":OR ");
@@ -1400,7 +1400,7 @@ the range -32768 to +32767:", folding_error);
 
     if (expr_trace_level >= 2)
     {   printf("Folding constant to: ");
-        print_operand(&emitter_stack[emitter_sp - 1]);
+        print_operand(&emitter_stack[emitter_sp - 1], FALSE);
         printf("\n");
     }
 
@@ -1416,9 +1416,7 @@ static void show_node(int n, int depth, int annotate)
     for (j=0; j<2*depth+2; j++) printf(" ");
 
     if (ET[n].down == -1)
-    {   print_operand(&ET[n].value);
-        if (annotate && (ET[n].value.marker != 0))
-            printf(" [%s]", describe_mv(ET[n].value.marker));
+    {   print_operand(&ET[n].value, annotate);
         printf("\n");
     }
     else
@@ -1440,9 +1438,7 @@ static void show_node(int n, int depth, int annotate)
 extern void show_tree(assembly_operand AO, int annotate)
 {   if (AO.type == EXPRESSION_OT) show_node(AO.value, 0, annotate);
     else
-    {   printf("Constant: "); print_operand(&AO);
-        if (annotate && (AO.marker != 0))
-            printf(" [%s]", describe_mv(AO.marker));
+    {   printf("Constant: "); print_operand(&AO, annotate);
         printf("\n");
     }
 }

--- a/header.h
+++ b/header.h
@@ -2822,6 +2822,7 @@ extern int32 veneer_routine_address[];
 
 extern void compile_initial_routine(void);
 extern assembly_operand veneer_routine(int code);
+extern char *veneer_routine_name(int code);
 extern void compile_veneer(void);
 
 /* ------------------------------------------------------------------------- */

--- a/header.h
+++ b/header.h
@@ -2118,7 +2118,7 @@ extern int32 *variable_tokens;
 extern assembly_instruction AI;
 extern int32 *named_routine_symbols;
 
-extern void print_operand(assembly_operand o);
+extern void print_operand(const assembly_operand *o);
 extern char *variable_name(int32 i);
 extern void set_constant_ot(assembly_operand *AO);
 extern int  is_constant_ot(int otval);

--- a/header.h
+++ b/header.h
@@ -2118,7 +2118,7 @@ extern int32 *variable_tokens;
 extern assembly_instruction AI;
 extern int32 *named_routine_symbols;
 
-extern void print_operand(const assembly_operand *o);
+extern void print_operand(const assembly_operand *o, int annotate);
 extern char *variable_name(int32 i);
 extern void set_constant_ot(assembly_operand *AO);
 extern int  is_constant_ot(int otval);

--- a/header.h
+++ b/header.h
@@ -2345,6 +2345,7 @@ extern int z_system_constant_list[];
 extern int glulx_system_constant_list[];
 
 extern int32 value_of_system_constant(int t);
+extern char *name_of_system_constant(int t);
 extern void clear_expression_space(void);
 extern void show_tree(assembly_operand AO, int annotate);
 extern assembly_operand parse_expression(int context);

--- a/header.h
+++ b/header.h
@@ -2807,6 +2807,7 @@ extern void  optimise_abbreviations(void);
 extern void  make_abbreviation(char *text);
 extern void  show_dictionary(void);
 extern void  word_to_ascii(uchar *p, char *result);
+extern void  print_dict_word(int node);
 extern void  write_dictionary_to_transcript(void);
 extern void  sort_dictionary(void);
 extern void  dictionary_prepare(char *dword, uchar *optresult);

--- a/header.h
+++ b/header.h
@@ -721,12 +721,13 @@ static int32 unique_task_id(void)
 typedef struct assembly_operand_t
 {   int   type;
     int32 value;
-    int   symtype;   /* 6.30 */
-    int   symflags;  /* 6.30 */
+    int   symindex;
+    int   symtype;
+    int   symflags;
     int   marker;
 } assembly_operand;
 
-#define INITAOTV(aop, typ, val) ((aop)->type=(typ), (aop)->value=(val), (aop)->marker=0, (aop)->symtype=0, (aop)->symflags=0)
+#define INITAOTV(aop, typ, val) ((aop)->type=(typ), (aop)->value=(val), (aop)->marker=0, (aop)->symindex=-1, (aop)->symtype=0, (aop)->symflags=0)
 #define INITAOT(aop, typ) INITAOTV(aop, typ, 0)
 #define INITAO(aop) INITAOTV(aop, 0, 0)
 
@@ -833,8 +834,9 @@ typedef struct token_data_s
 {   char *text;
     int32 value; /* ###-long */
     int type;
-    int symtype;  /* 6.30 */
-    int symflags;   /* 6.30 */
+    int symindex;
+    int symtype;
+    int symflags;
     int marker;
     debug_location location;
 } token_data;

--- a/states.c
+++ b/states.c
@@ -420,11 +420,17 @@ static void parse_print_z(int finally_return)
                           {   INITAOT(&AO, LONG_CONSTANT_OT);
                               AO.value = token_value;
                               AO.marker = SYMBOL_MV;
+                              AO.symindex = token_value;
+                              AO.symtype = stypes[token_value];
+                              AO.symflags = sflags[token_value];
                           }
                           else
                           {   INITAOT(&AO, LONG_CONSTANT_OT);
                               AO.value = svals[token_value];
                               AO.marker = IROUTINE_MV;
+                              AO.symindex = token_value;
+                              AO.symtype = stypes[token_value];
+                              AO.symflags = sflags[token_value];
                               if (stypes[token_value] != ROUTINE_T)
                                 ebf_error("printing routine name", token_text);
                           }
@@ -655,11 +661,17 @@ static void parse_print_g(int finally_return)
                           {   INITAOT(&AO, CONSTANT_OT);
                               AO.value = token_value;
                               AO.marker = SYMBOL_MV;
+                              AO.symindex = token_value;
+                              AO.symtype = stypes[token_value];
+                              AO.symflags = sflags[token_value];
                           }
                           else
                           {   INITAOT(&AO, CONSTANT_OT);
                               AO.value = svals[token_value];
                               AO.marker = IROUTINE_MV;
+                              AO.symindex = token_value;
+                              AO.symtype = stypes[token_value];
+                              AO.symflags = sflags[token_value];
                               if (stypes[token_value] != ROUTINE_T)
                                 ebf_error("printing routine name", token_text);
                           }

--- a/text.c
+++ b/text.c
@@ -2169,6 +2169,41 @@ extern void word_to_ascii(uchar *p, char *results)
     results[cc] = 0;
 }
 
+/* Print a dictionary word to stdout. 
+   (This assumes that d_show_buf is null.)
+ */
+void print_dict_word(int node)
+{
+    uchar *p;
+    int cprinted;
+    
+    if (!glulx_mode) {
+        char textual_form[32];
+        int res = (version_number == 3)?4:6; /* byte length of encoded text */
+        p = (uchar *)dictionary + 7 + (3+res)*node;
+        
+        word_to_ascii(p, textual_form);
+        
+        for (cprinted = 0; textual_form[cprinted]!=0; cprinted++)
+            show_char(textual_form[cprinted]);
+    }
+    else {
+        p = (uchar *)dictionary + 4 + DICT_ENTRY_BYTE_LENGTH*node;
+        
+        for (cprinted = 0; cprinted<DICT_WORD_SIZE; cprinted++)
+        {
+            uint32 ch;
+            if (DICT_CHAR_SIZE == 1)
+                ch = p[1+cprinted];
+            else
+                ch = (p[4*cprinted+4] << 24) + (p[4*cprinted+5] << 16) + (p[4*cprinted+6] << 8) + (p[4*cprinted+7]);
+            if (!ch)
+                break;
+            show_uchar(ch);
+        }
+    }
+}
+
 static void recursively_show_z(int node)
 {   int i, cprinted, flags; uchar *p;
     char textual_form[32];

--- a/veneer.c
+++ b/veneer.c
@@ -2169,6 +2169,19 @@ extern assembly_operand veneer_routine(int code)
     return(AO);
 }
 
+extern char *veneer_routine_name(int code)
+{
+    if (code < 0 || code >= VENEER_ROUTINES) {
+        return "???";
+    }
+    if (!glulx_mode) {
+        return VRs_z[code].name;
+    }
+    else {
+        return VRs_g[code].name;
+    }
+}
+
 static void compile_symbol_table_routine(void)
 {   int32 j, nl, arrays_l, routines_l, constants_l;
     assembly_operand AO, AO2, AO3;

--- a/verbs.c
+++ b/verbs.c
@@ -508,6 +508,7 @@ static int find_or_renumber_verb(char *English_verb, int *new_number)
 
 static char *find_verb_by_number(int num)
 {
+    /*  Find the English verb string with the given verb number. */
     char *p;
     p=English_verb_list;
     while (p < English_verb_list_top)

--- a/verbs.c
+++ b/verbs.c
@@ -99,93 +99,184 @@ static int English_verb_list_size;     /* Size of the list in bytes
 
 static char *find_verb_by_number(int num);
 
+static void list_grammar_line_v1(int mark)
+{
+    int action, actsym;
+    int ix, len;
+    char *str;
+
+    /* There is no GV1 for Glulx. */
+    if (glulx_mode)
+        return;
+    
+    action = (grammar_lines[mark] << 8) | (grammar_lines[mark+1]);
+    mark += 2;
+    
+    printf("  *");
+    while (grammar_lines[mark] != 15) {
+        uchar tok = grammar_lines[mark];
+        mark += 3;
+        
+        switch (tok) {
+        case 0:
+            printf(" noun");
+            break;
+        case 1:
+            printf(" held");
+            break;
+        case 2:
+            printf(" multi");
+            break;
+        case 3:
+            printf(" multiheld");
+            break;
+        case 4:
+            printf(" multiexcept");
+            break;
+        case 5:
+            printf(" multiinside");
+            break;
+        case 6:
+            printf(" creature");
+            break;
+        case 7:
+            printf(" special");
+            break;
+        case 8:
+            printf(" number");
+            break;
+        default:
+            if (tok >= 16 && tok < 48) {
+                printf(" noun=%d", tok-16);
+            }
+            else if (tok >= 48 && tok < 80) {
+                printf(" routine=%d", tok-48);
+            }
+            else if (tok >= 80 && tok < 128) {
+                printf(" scope=%d", tok-80);
+            }
+            else if (tok >= 128 && tok < 160) {
+                printf(" attr=%d", tok-128);
+            }
+            else if (tok >= 160) {
+                printf(" prep=%d", tok);
+            }
+            else {
+                printf(" ???");
+            }
+        }
+    }
+
+    printf(" -> ");
+    actsym = action_symbol[action];
+    str = (char *)(symbs[actsym]);
+    len = strlen(str) - 3;   /* remove "__A" */
+    for (ix=0; ix<len; ix++) putchar(str[ix]);
+    printf("\n");
+}
+
+static void list_grammar_line_v2(int mark)
+{
+    int action, flags, actsym;
+    int ix, len;
+    char *str;
+    
+    if (!glulx_mode) {
+        action = (grammar_lines[mark] << 8) | (grammar_lines[mark+1]);
+        flags = (action & 0x400);
+        action &= 0x3FF;
+        mark += 2;
+    }
+    else {
+        action = (grammar_lines[mark] << 8) | (grammar_lines[mark+1]);
+        mark += 2;
+        flags = grammar_lines[mark++];
+    }
+    
+    printf("  *");
+    while (grammar_lines[mark] != 15) {
+        int toktype, tokdat, tokalt;
+        if (!glulx_mode) {
+            toktype = grammar_lines[mark] & 0x0F;
+            tokalt = (grammar_lines[mark] >> 4) & 0x03;
+            mark += 1;
+            tokdat = (grammar_lines[mark] << 8) | (grammar_lines[mark+1]);
+            mark += 2;
+        }
+        else {
+            toktype = grammar_lines[mark] & 0x0F;
+            tokalt = (grammar_lines[mark] >> 4) & 0x03;
+            mark += 1;
+            tokdat = (grammar_lines[mark] << 24) | (grammar_lines[mark+1] << 16) | (grammar_lines[mark+2] << 8) | (grammar_lines[mark+3]);
+            mark += 4;
+        }
+
+        if (tokalt == 3 || tokalt == 1)
+            printf(" /");
+                
+        switch (toktype) {
+        case 1:
+            switch (tokdat) {
+            case 0: printf(" noun"); break;
+            case 1: printf(" held"); break;
+            case 2: printf(" multi"); break;
+            case 3: printf(" multiheld"); break;
+            case 4: printf(" multiexcept"); break;
+            case 5: printf(" multiinside"); break;
+            case 6: printf(" creature"); break;
+            case 7: printf(" special"); break;
+            case 8: printf(" number"); break;
+            case 9: printf(" topic"); break;
+            default: printf(" ???"); break;
+            }
+            break;
+        case 2:
+            printf(" '");
+            print_dict_word(tokdat);
+            printf("'");
+            break;
+        case 3:
+            printf(" noun=%d", tokdat);
+            break;
+        case 4:
+            printf(" attr=%d", tokdat);
+            break;
+        case 5:
+            printf(" scope=%d", tokdat);
+            break;
+        case 6:
+            printf(" routine=%d", tokdat);
+            break;
+        default:
+            printf(" ???%d:%d", toktype, tokdat);
+            break;
+        }
+    }
+    printf(" -> ");
+    actsym = action_symbol[action];
+    str = (char *)(symbs[actsym]);
+    len = strlen(str) - 3;   /* remove "__A" */
+    for (ix=0; ix<len; ix++) putchar(str[ix]);
+    if (flags) printf(" (reversed)");
+    printf("\n");
+}
+
 extern void list_verb_table(void)
 {
-    int verb, lx, ix, len;
-    char *str;
+    int verb, lx;
     for (verb=0; verb<no_Inform_verbs; verb++) {
         char *verbword = find_verb_by_number(verb);
         printf("Verb '%s'\n", verbword);
         for (lx=0; lx<Inform_verbs[verb].lines; lx++) {
             int mark = Inform_verbs[verb].l[lx];
-            int action, flags, actsym;
-            if (!glulx_mode) {
-                action = (grammar_lines[mark] << 8) | (grammar_lines[mark+1]);
-                flags = (action & 0x400);
-                action &= 0x3FF;
-                mark += 2;
+            switch (grammar_version_number) {
+            case 1:
+                list_grammar_line_v1(mark);
+                break;
+            case 2:
+                list_grammar_line_v2(mark);
+                break;
             }
-            else {
-                action = (grammar_lines[mark] << 8) | (grammar_lines[mark+1]);
-                mark += 2;
-                flags = grammar_lines[mark++];
-            }
-            printf("  *");
-            while (grammar_lines[mark] != 15) {
-                int toktype, tokdat, tokalt;
-                if (!glulx_mode) {
-                    toktype = grammar_lines[mark] & 0x0F;
-                    tokalt = (grammar_lines[mark] >> 4) & 0x03;
-                    mark += 1;
-                    tokdat = (grammar_lines[mark] << 8) | (grammar_lines[mark+1]);
-                    mark += 2;
-                }
-                else {
-                    toktype = grammar_lines[mark] & 0x0F;
-                    tokalt = (grammar_lines[mark] >> 4) & 0x03;
-                    mark += 1;
-                    tokdat = (grammar_lines[mark] << 24) | (grammar_lines[mark+1] << 16) | (grammar_lines[mark+2] << 8) | (grammar_lines[mark+3]);
-                    mark += 4;
-                }
-
-                if (tokalt == 3 || tokalt == 1)
-                    printf(" /");
-                
-                switch (toktype) {
-                case 1:
-                    switch (tokdat) {
-                    case 0: printf(" noun"); break;
-                    case 1: printf(" held"); break;
-                    case 2: printf(" multi"); break;
-                    case 3: printf(" multiheld"); break;
-                    case 4: printf(" multiexcept"); break;
-                    case 5: printf(" multiinside"); break;
-                    case 6: printf(" creature"); break;
-                    case 7: printf(" special"); break;
-                    case 8: printf(" number"); break;
-                    case 9: printf(" topic"); break;
-                    default: printf(" ???"); break;
-                    }
-                    break;
-                case 2:
-                    printf(" '");
-                    print_dict_word(tokdat);
-                    printf("'");
-                    break;
-                case 3:
-                    printf(" noun=%d", tokdat);
-                    break;
-                case 4:
-                    printf(" attr=%d", tokdat);
-                    break;
-                case 5:
-                    printf(" scope=%d", tokdat);
-                    break;
-                case 6:
-                    printf(" routine=%d", tokdat);
-                    break;
-                default:
-                    printf(" ???%d:%d", toktype, tokdat);
-                    break;
-                }
-            }
-            printf(" -> ");
-            actsym = action_symbol[action];
-            str = (char *)(symbs[actsym]);
-            len = strlen(str) - 3;   /* remove "__A" */
-            for (ix=0; ix<len; ix++) putchar(str[ix]);
-            if (flags) printf(" (reversed)");
-            printf("\n");
         }
     }
 }


### PR DESCRIPTION
Two features here. (Fixes https://github.com/DavidKinder/Inform6/issues/74.)

Assembly output (`-a` mode) now shows symbolic information for each assembly operand, if possible.

    ! Compiling with -G -~S -a:
    print (name) obj.owner;

    11  +00017 <*> callfii      long_10 (veneer routine: RV__Pr) long_5 (internal object: obj) byte_4 (owner) stackptr 
    11  +00024     callfi       long_6 (veneer routine: PrintShortName) stackptr zero_ 

The parenthesized bits are new. This makes it much easier to follow the assembly output.

Second, the `Trace verbs` directive now prints out the entire grammar table (as of that point in the code). It used to just print a big list of

    Verb 1 has 1 lines

...which is not very informative. It now shows

```
Verb 'answer'
  * topic 'to' creature -> Answer
Verb 'ask'
  * creature 'about' topic -> Ask
  * creature 'for' noun -> AskFor
  * creature 'to' topic -> AskTo
  * 'that' creature topic -> AskTo
Verb 'attack'
  * noun -> Attack
```

...and so on.

As with gametext.txt output, the grammar trace shows words in whatever character set was set with `-Cn`.
