### PR TITLE
Dynalloc: Remove MAX_SYMBOLS, SYMBOLS_CHUNK_SIZE

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -294,12 +294,12 @@ extern void make_global(int array_flag, int name_only)
     global_name = token_text;
 
     if (!glulx_mode) {
-        if ((token_type==SYMBOL_TT) && (stypes[i]==GLOBAL_VARIABLE_T)
-            && (svals[i] >= LOWEST_SYSTEM_VAR_NUMBER))
+        if ((token_type==SYMBOL_TT) && (symbols[i].type==GLOBAL_VARIABLE_T)
+            && (symbols[i].value >= LOWEST_SYSTEM_VAR_NUMBER))
             goto RedefinitionOfSystemVar;
     }
     else {
-        if ((token_type==SYMBOL_TT) && (stypes[i]==GLOBAL_VARIABLE_T))
+        if ((token_type==SYMBOL_TT) && (symbols[i].type==GLOBAL_VARIABLE_T))
             goto RedefinitionOfSystemVar;
     }
 
@@ -311,15 +311,15 @@ extern void make_global(int array_flag, int name_only)
         panic_mode_error_recovery(); return;
     }
 
-    if (!(sflags[i] & UNKNOWN_SFLAG))
+    if (!(symbols[i].flags & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
         if (array_flag)
-            ebf_symbol_error("new array name", token_text, typename(stypes[i]), slines[i]);
-        else ebf_symbol_error("new global variable name", token_text, typename(stypes[i]), slines[i]);
+            ebf_symbol_error("new array name", token_text, typename(symbols[i].type), symbols[i].line);
+        else ebf_symbol_error("new global variable name", token_text, typename(symbols[i].type), symbols[i].line);
         panic_mode_error_recovery(); return;
     }
 
-    if ((!array_flag) && (sflags[i] & USED_SFLAG))
+    if ((!array_flag) && (symbols[i].flags & USED_SFLAG))
         error_named("Variable must be defined before use:", token_text);
 
     directive_keywords.enabled = TRUE;
@@ -368,7 +368,7 @@ extern void make_global(int array_flag, int name_only)
 
         variable_tokens[MAX_LOCAL_VARIABLES+no_globals] = i;
         assign_symbol(i, MAX_LOCAL_VARIABLES+no_globals, GLOBAL_VARIABLE_T);
-        variable_tokens[svals[i]] = i;
+        variable_tokens[symbols[i].value] = i;
 
         if (name_only) import_symbol(i);
         else global_initial_value[no_globals++]=0;
@@ -395,7 +395,7 @@ extern void make_global(int array_flag, int name_only)
         {   debug_file_printf("<global-variable>");
             debug_file_printf("<identifier>%s</identifier>", global_name);
             debug_file_printf("<address>");
-            write_debug_global_backpatch(svals[global_symbol]);
+            write_debug_global_backpatch(symbols[global_symbol].value);
             debug_file_printf("</address>");
             write_debug_locations
                 (get_token_location_end(beginning_debug_location));
@@ -424,7 +424,7 @@ extern void make_global(int array_flag, int name_only)
             {   debug_file_printf("<global-variable>");
                 debug_file_printf("<identifier>%s</identifier>", global_name);
                 debug_file_printf("<address>");
-                write_debug_global_backpatch(svals[global_symbol]);
+                write_debug_global_backpatch(symbols[global_symbol].value);
                 debug_file_printf("</address>");
                 write_debug_locations
                     (get_token_location_end(beginning_debug_location));
@@ -683,7 +683,7 @@ advance as part of 'Zcharacter table':", unicode);
         debug_file_printf("<array>");
         debug_file_printf("<identifier>%s</identifier>", global_name);
         debug_file_printf("<value>");
-        write_debug_array_backpatch(svals[global_symbol]);
+        write_debug_array_backpatch(symbols[global_symbol].value);
         debug_file_printf("</value>");
         new_area_size = (!is_static ? dynamic_array_area_size : static_array_area_size);
         debug_file_printf

--- a/asm.c
+++ b/asm.c
@@ -205,7 +205,7 @@ extern char *variable_name(int32 i)
       }
     }
 
-    return ((char *) symbs[variable_tokens[i]]);
+    return (symbs[variable_tokens[i]]);
 }
 
 /* Print symbolic information about the AO, if there is any. */
@@ -233,7 +233,7 @@ static void print_operand_annotation(const assembly_operand *o)
     if (o->symindex >= 0 && o->symindex < no_symbols) {
         printf((!any) ? " (" : ": ");
         any = TRUE;
-        printf("%s", (char *)symbs[o->symindex]);
+        printf("%s", symbs[o->symindex]);
     }
     if (any) printf(")");       
 }
@@ -1780,10 +1780,10 @@ void assemble_routine_end(int embedded_flag, debug_locations locations)
         if (j != -1)
         {   if (sflags[j] & CHANGE_SFLAG)
                 error_named_at("Routine contains no such label as",
-                    (char *) symbs[j], slines[j]);
+                    symbs[j], slines[j]);
             else
                 if ((sflags[j] & USED_SFLAG) == 0)
-                    dbnu_warning("Label", (char *) symbs[j], slines[j]);
+                    dbnu_warning("Label", symbs[j], slines[j]);
             stypes[j] = CONSTANT_T;
             sflags[j] = UNKNOWN_SFLAG;
         }

--- a/asm.c
+++ b/asm.c
@@ -205,7 +205,7 @@ extern char *variable_name(int32 i)
       }
     }
 
-    return (symbs[variable_tokens[i]]);
+    return (symbols[variable_tokens[i]].name);
 }
 
 /* Print symbolic information about the AO, if there is any. */
@@ -233,7 +233,7 @@ static void print_operand_annotation(const assembly_operand *o)
     if (o->symindex >= 0 && o->symindex < no_symbols) {
         printf((!any) ? " (" : ": ");
         any = TRUE;
-        printf("%s", symbs[o->symindex]);
+        printf("%s", symbols[o->symindex].name);
     }
     if (any) printf(")");       
 }
@@ -1424,7 +1424,7 @@ extern void assemble_label_no(int n)
 }
 
 extern void define_symbol_label(int symbol)
-{   label_symbols[svals[symbol]] = symbol;
+{   label_symbols[symbols[symbol].value] = symbol;
 }
 
 extern int32 assemble_routine_header(int no_locals,
@@ -1706,19 +1706,19 @@ void assemble_routine_end(int embedded_flag, debug_locations locations)
                 ("<identifier artificial=\"true\">%s</identifier>",
                  routine_name);
         }
-        else if (sflags[routine_symbol] & REPLACE_SFLAG)
+        else if (symbols[routine_symbol].flags & REPLACE_SFLAG)
         {   /* The symbol type will be set to ROUTINE_T once the replaced
                version has been given; if it is already set, we must be dealing
                with a replacement, and we can use the routine name as-is.
                Otherwise we look for a rename.  And if that doesn't work, we
                fall back to an artificial identifier. */
-            if (stypes[routine_symbol] == ROUTINE_T)
+            if (symbols[routine_symbol].type == ROUTINE_T)
             {   /* Optional because there may be further replacements. */
                 write_debug_optional_identifier(routine_symbol);
             }
             else if (find_symbol_replacement(&routine_symbol))
             {   debug_file_printf
-                    ("<identifier>%s</identifier>", symbs[routine_symbol]);
+                    ("<identifier>%s</identifier>", symbols[routine_symbol].name);
             }
             else
             {   debug_file_printf
@@ -1778,14 +1778,14 @@ void assemble_routine_end(int embedded_flag, debug_locations locations)
     for (i=0; i<next_label; i++)
     {   int j = label_symbols[i];
         if (j != -1)
-        {   if (sflags[j] & CHANGE_SFLAG)
+        {   if (symbols[j].flags & CHANGE_SFLAG)
                 error_named_at("Routine contains no such label as",
-                    symbs[j], slines[j]);
+                    symbols[j].name, symbols[j].line);
             else
-                if ((sflags[j] & USED_SFLAG) == 0)
-                    dbnu_warning("Label", symbs[j], slines[j]);
-            stypes[j] = CONSTANT_T;
-            sflags[j] = UNKNOWN_SFLAG;
+                if ((symbols[j].flags & USED_SFLAG) == 0)
+                    dbnu_warning("Label", symbols[j].name, symbols[j].line);
+            symbols[j].type = CONSTANT_T;
+            symbols[j].flags = UNKNOWN_SFLAG;
         }
     }
     no_sequence_points += next_sequence_point;
@@ -2824,11 +2824,11 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             else
             {   if (strcmp(token_text, "sp") == 0) n = 0;
                 else
-                {   if (stypes[token_value] != GLOBAL_VARIABLE_T)
+                {   if (symbols[token_value].type != GLOBAL_VARIABLE_T)
                         error_named(
                             "Store '->' destination not 'sp' or a variable:",
                             token_text);
-                    else n = svals[token_value];
+                    else n = symbols[token_value].value;
                 }
             }
             AI.store_variable_number = n;

--- a/bpatch.c
+++ b/bpatch.c
@@ -92,10 +92,10 @@ static int32 backpatch_value_z(int32 value)
             break;
         case MAIN_MV:
             value = symbol_index("Main", -1);
-            if (stypes[value] != ROUTINE_T)
+            if (symbols[value].type != ROUTINE_T)
                 error("No 'Main' routine has been defined");
-            sflags[value] |= USED_SFLAG;
-            value = svals[value];
+            symbols[value].flags |= USED_SFLAG;
+            value = symbols[value].value;
             if (OMIT_UNUSED_ROUTINES)
                 value = df_stripped_address_for_address(value);
             value += code_offset/scale_factor;
@@ -110,34 +110,34 @@ static int32 backpatch_value_z(int32 value)
                 value = 0;
                 break;
             }
-            if (sflags[value] & UNKNOWN_SFLAG)
-            {   if (!(sflags[value] & UERROR_SFLAG))
-                {   sflags[value] |= UERROR_SFLAG;
+            if (symbols[value].flags & UNKNOWN_SFLAG)
+            {   if (!(symbols[value].flags & UERROR_SFLAG))
+                {   symbols[value].flags |= UERROR_SFLAG;
                     error_named_at("No such constant as",
-                        symbs[value], slines[value]);
+                        symbols[value].name, symbols[value].line);
                 }
             }
             else
-            if (sflags[value] & CHANGE_SFLAG)
-            {   sflags[value] &= (~(CHANGE_SFLAG));
-                backpatch_marker = (svals[value]/0x10000);
+            if (symbols[value].flags & CHANGE_SFLAG)
+            {   symbols[value].flags &= (~(CHANGE_SFLAG));
+                backpatch_marker = (symbols[value].value/0x10000);
                 if ((backpatch_marker < 0)
                     || (backpatch_marker > LARGEST_BPATCH_MV))
                 {
                     if (no_link_errors == 0)
                     {   compiler_error_named(
                         "Illegal backpatch marker attached to symbol",
-                        symbs[value]);
+                        symbols[value].name);
                         backpatch_error_flag = TRUE;
                     }
                 }
                 else
-                    svals[value] = backpatch_value_z((svals[value]) % 0x10000);
+                    symbols[value].value = backpatch_value_z((symbols[value].value) % 0x10000);
             }
 
-            sflags[value] |= USED_SFLAG;
-            {   int t = stypes[value];
-                value = svals[value];
+            symbols[value].flags |= USED_SFLAG;
+            {   int t = symbols[value].type;
+                value = symbols[value].value;
                 switch(t)
                 {   case ROUTINE_T: 
                         if (OMIT_UNUSED_ROUTINES)
@@ -242,10 +242,10 @@ static int32 backpatch_value_g(int32 value)
             break;
         case MAIN_MV:
             value = symbol_index("Main", -1);
-            if (stypes[value] != ROUTINE_T)
+            if (symbols[value].type != ROUTINE_T)
                 error("No 'Main' routine has been defined");
-            sflags[value] |= USED_SFLAG;
-            value = svals[value];
+            symbols[value].flags |= USED_SFLAG;
+            value = symbols[value].value;
             if (OMIT_UNUSED_ROUTINES)
                 value = df_stripped_address_for_address(value);
             value += code_offset;
@@ -260,34 +260,34 @@ static int32 backpatch_value_g(int32 value)
                 value = 0;
                 break;
             }
-            if (sflags[value] & UNKNOWN_SFLAG)
-            {   if (!(sflags[value] & UERROR_SFLAG))
-                {   sflags[value] |= UERROR_SFLAG;
+            if (symbols[value].flags & UNKNOWN_SFLAG)
+            {   if (!(symbols[value].flags & UERROR_SFLAG))
+                {   symbols[value].flags |= UERROR_SFLAG;
                     error_named_at("No such constant as",
-                        symbs[value], slines[value]);
+                        symbols[value].name, symbols[value].line);
                 }
             }
             else
-            if (sflags[value] & CHANGE_SFLAG)
-            {   sflags[value] &= (~(CHANGE_SFLAG));
-                backpatch_marker = smarks[value];
+            if (symbols[value].flags & CHANGE_SFLAG)
+            {   symbols[value].flags &= (~(CHANGE_SFLAG));
+                backpatch_marker = symbols[value].marker;
                 if ((backpatch_marker < 0)
                     || (backpatch_marker > LARGEST_BPATCH_MV))
                 {
                     if (no_link_errors == 0)
                     {   compiler_error_named(
                         "Illegal backpatch marker attached to symbol",
-                        symbs[value]);
+                        symbols[value].name);
                         backpatch_error_flag = TRUE;
                     }
                 }
                 else
-                    svals[value] = backpatch_value_g(svals[value]);
+                    symbols[value].value = backpatch_value_g(symbols[value].value);
             }
 
-            sflags[value] |= USED_SFLAG;
-            {   int t = stypes[value];
-                value = svals[value];
+            symbols[value].flags |= USED_SFLAG;
+            {   int t = symbols[value].type;
+                value = symbols[value].value;
                 switch(t)
                 {
                     case ROUTINE_T:

--- a/bpatch.c
+++ b/bpatch.c
@@ -114,7 +114,7 @@ static int32 backpatch_value_z(int32 value)
             {   if (!(sflags[value] & UERROR_SFLAG))
                 {   sflags[value] |= UERROR_SFLAG;
                     error_named_at("No such constant as",
-                        (char *) symbs[value], slines[value]);
+                        symbs[value], slines[value]);
                 }
             }
             else
@@ -127,7 +127,7 @@ static int32 backpatch_value_z(int32 value)
                     if (no_link_errors == 0)
                     {   compiler_error_named(
                         "Illegal backpatch marker attached to symbol",
-                        (char *) symbs[value]);
+                        symbs[value]);
                         backpatch_error_flag = TRUE;
                     }
                 }
@@ -264,7 +264,7 @@ static int32 backpatch_value_g(int32 value)
             {   if (!(sflags[value] & UERROR_SFLAG))
                 {   sflags[value] |= UERROR_SFLAG;
                     error_named_at("No such constant as",
-                        (char *) symbs[value], slines[value]);
+                        symbs[value], slines[value]);
                 }
             }
             else
@@ -277,7 +277,7 @@ static int32 backpatch_value_g(int32 value)
                     if (no_link_errors == 0)
                     {   compiler_error_named(
                         "Illegal backpatch marker attached to symbol",
-                        (char *) symbs[value]);
+                        symbs[value]);
                         backpatch_error_flag = TRUE;
                     }
                 }

--- a/directs.c
+++ b/directs.c
@@ -160,9 +160,9 @@ extern int parse_given_directive(int internal_flag)
             return ebf_error_recover("new constant name", token_text);
         }
 
-        if (!(sflags[i] & (UNKNOWN_SFLAG + REDEFINABLE_SFLAG)))
+        if (!(symbols[i].flags & (UNKNOWN_SFLAG + REDEFINABLE_SFLAG)))
         {   discard_token_location(beginning_debug_location);
-            return ebf_symbol_error_recover("new constant name", token_text, typename(stypes[i]), slines[i]);
+            return ebf_symbol_error_recover("new constant name", token_text, typename(symbols[i].type), symbols[i].line);
         }
 
         assign_symbol(i, 0, CONSTANT_T);
@@ -171,7 +171,7 @@ extern int parse_given_directive(int internal_flag)
         get_next_token();
 
         if ((token_type == SEP_TT) && (token_value == COMMA_SEP))
-        {   if (debugfile_switch && !(sflags[i] & REDEFINABLE_SFLAG))
+        {   if (debugfile_switch && !(symbols[i].flags & REDEFINABLE_SFLAG))
             {   debug_file_printf("<constant>");
                 debug_file_printf("<identifier>%s</identifier>", constant_name);
                 write_debug_symbol_optional_backpatch(i);
@@ -182,7 +182,7 @@ extern int parse_given_directive(int internal_flag)
         }
 
         if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
-        {   if (debugfile_switch && !(sflags[i] & REDEFINABLE_SFLAG))
+        {   if (debugfile_switch && !(symbols[i].flags & REDEFINABLE_SFLAG))
             {   debug_file_printf("<constant>");
                 debug_file_printf("<identifier>%s</identifier>", constant_name);
                 write_debug_symbol_optional_backpatch(i);
@@ -199,7 +199,7 @@ extern int parse_given_directive(int internal_flag)
             if (AO.marker != 0)
             {   assign_marked_symbol(i, AO.marker, AO.value,
                     CONSTANT_T);
-                sflags[i] |= CHANGE_SFLAG;
+                symbols[i].flags |= CHANGE_SFLAG;
                 if (i == grammar_version_symbol)
                     error(
                 "Grammar__Version must be given an explicit constant value");
@@ -218,7 +218,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
             }
         }
 
-        if (debugfile_switch && !(sflags[i] & REDEFINABLE_SFLAG))
+        if (debugfile_switch && !(symbols[i].flags & REDEFINABLE_SFLAG))
         {   debug_file_printf("<constant>");
             debug_file_printf("<identifier>%s</identifier>", constant_name);
             write_debug_symbol_optional_backpatch(i);
@@ -248,9 +248,9 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
             return ebf_error_recover("name", token_text);
 
         i = -1;
-        if (sflags[token_value] & UNKNOWN_SFLAG)
+        if (symbols[token_value].flags & UNKNOWN_SFLAG)
         {   i = token_value;
-            sflags[i] |= DEFCON_SFLAG;
+            symbols[i].flags |= DEFCON_SFLAG;
         }
 
         get_next_token();
@@ -263,7 +263,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
             {   if (AO.marker != 0)
                 {   assign_marked_symbol(i, AO.marker, AO.value,
                         CONSTANT_T);
-                    sflags[i] |= CHANGE_SFLAG;
+                    symbols[i].flags |= CHANGE_SFLAG;
                 }
                 else assign_symbol(i, AO.value, CONSTANT_T);
             }
@@ -404,8 +404,8 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
             goto HashIfCondition;
         }
 
-        if (sflags[token_value] & UNKNOWN_SFLAG) flag = (flag)?FALSE:TRUE;
-        else sflags[token_value] |= USED_SFLAG;
+        if (symbols[token_value].flags & UNKNOWN_SFLAG) flag = (flag)?FALSE:TRUE;
+        else symbols[token_value].flags |= USED_SFLAG;
         goto HashIfCondition;
 
     case IFNOT_CODE:
@@ -610,8 +610,8 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         get_next_token(); i = token_value;
         if (token_type != SYMBOL_TT)
             return ebf_error_recover("new low string name", token_text);
-        if (!(sflags[i] & UNKNOWN_SFLAG))
-            return ebf_symbol_error_recover("new low string name", token_text, typename(stypes[i]), slines[i]);
+        if (!(symbols[i].flags & UNKNOWN_SFLAG))
+            return ebf_symbol_error_recover("new low string name", token_text, typename(symbols[i].type), symbols[i].line);
 
         get_next_token();
         if (token_type != DQ_TT)
@@ -802,10 +802,10 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
 
         if (token_type != SYMBOL_TT)
             return ebf_error_recover("name of routine to replace", token_text);
-        if (!(sflags[token_value] & UNKNOWN_SFLAG))
+        if (!(symbols[token_value].flags & UNKNOWN_SFLAG))
             return ebf_error_recover("name of routine not yet defined", token_text);
 
-        sflags[token_value] |= REPLACE_SFLAG;
+        symbols[token_value].flags |= REPLACE_SFLAG;
 
         /* If a second symbol is provided, it will refer to the
            original (replaced) definition of the routine. */
@@ -819,7 +819,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         {   return FALSE;
         }
 
-        if (token_type != SYMBOL_TT || !(sflags[token_value] & UNKNOWN_SFLAG))
+        if (token_type != SYMBOL_TT || !(symbols[token_value].flags & UNKNOWN_SFLAG))
             return ebf_error_recover("semicolon ';' or new routine name", token_text);
 
         /* Define the original-form symbol as a zero constant. Its
@@ -881,8 +881,8 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
 
         i = token_value; flag = FALSE;
 
-        if (sflags[i] & UNKNOWN_SFLAG)
-        {   sflags[i] |= STUB_SFLAG;
+        if (symbols[i].flags & UNKNOWN_SFLAG)
+        {   symbols[i].flags |= STUB_SFLAG;
             flag = TRUE;
         }
 
@@ -906,7 +906,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
             local_variable_texts[3] = "dummy4";
 
             assign_symbol(i,
-                assemble_routine_header(k, FALSE, symbs[i], FALSE, i),
+                assemble_routine_header(k, FALSE, symbols[i].name, FALSE, i),
                 ROUTINE_T);
 
             /*  Ensure the return value of a stubbed routine is false,
@@ -1039,12 +1039,12 @@ the first constant definition");
         if (token_type != SYMBOL_TT)
             return ebf_error_recover("symbol name", token_text);
 
-        if (sflags[token_value] & UNKNOWN_SFLAG)
+        if (symbols[token_value].flags & UNKNOWN_SFLAG)
         {   break; /* undef'ing an undefined constant is okay */
         }
 
-        if (stypes[token_value] != CONSTANT_T)
-        {   error_named("Cannot Undef a symbol which is not a defined constant:", symbs[token_value]);
+        if (symbols[token_value].type != CONSTANT_T)
+        {   error_named("Cannot Undef a symbol which is not a defined constant:", symbols[token_value].name);
             break;
         }
 
@@ -1052,7 +1052,7 @@ the first constant definition");
         {   write_debug_undef(token_value);
         }
         end_symbol_scope(token_value);
-        sflags[token_value] |= USED_SFLAG;
+        symbols[token_value].flags |= USED_SFLAG;
         break;
 
     /* --------------------------------------------------------------------- */

--- a/directs.c
+++ b/directs.c
@@ -906,7 +906,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
             local_variable_texts[3] = "dummy4";
 
             assign_symbol(i,
-                assemble_routine_header(k, FALSE, (char *) symbs[i], FALSE, i),
+                assemble_routine_header(k, FALSE, symbs[i], FALSE, i),
                 ROUTINE_T);
 
             /*  Ensure the return value of a stubbed routine is false,
@@ -1044,7 +1044,7 @@ the first constant definition");
         }
 
         if (stypes[token_value] != CONSTANT_T)
-        {   error_named("Cannot Undef a symbol which is not a defined constant:", (char *)symbs[token_value]);
+        {   error_named("Cannot Undef a symbol which is not a defined constant:", symbs[token_value]);
             break;
         }
 

--- a/expressc.c
+++ b/expressc.c
@@ -390,7 +390,7 @@ static void value_in_void_context_z(assembly_operand AO)
         case SHORT_CONSTANT_OT:
             t = "<constant>";
             if (AO.marker == SYMBOL_MV)
-                t = (char *) (symbs[AO.value]);
+                t = (symbs[AO.value]);
             break;
         case VARIABLE_OT:
             t = variable_name(AO.value);
@@ -772,7 +772,7 @@ static void value_in_void_context_g(assembly_operand AO)
         case ZEROCONSTANT_OT:
             t = "<constant>";
             if (AO.marker == SYMBOL_MV)
-                t = (char *) (symbs[AO.value]);
+                t = (symbs[AO.value]);
             break;
         case GLOBALVAR_OT:
         case LOCALVAR_OT:

--- a/expressc.c
+++ b/expressc.c
@@ -390,7 +390,7 @@ static void value_in_void_context_z(assembly_operand AO)
         case SHORT_CONSTANT_OT:
             t = "<constant>";
             if (AO.marker == SYMBOL_MV)
-                t = (symbs[AO.value]);
+                t = (symbols[AO.value].name);
             break;
         case VARIABLE_OT:
             t = variable_name(AO.value);
@@ -454,7 +454,7 @@ static void access_memory_z(int oc, assembly_operand AO1, assembly_operand AO2,
         size_ao = zero_ao; size_ao.value = -1;
         for (x=0; x<no_arrays; x++)
         {   if (((AO1.marker == ARRAY_MV) == (!array_locs[x]))
-                && (AO1.value == svals[array_symbols[x]]))
+                && (AO1.value == symbols[array_symbols[x]].value))
             {   size_ao.value = array_sizes[x]; y=x;
             }
         }
@@ -772,7 +772,7 @@ static void value_in_void_context_g(assembly_operand AO)
         case ZEROCONSTANT_OT:
             t = "<constant>";
             if (AO.marker == SYMBOL_MV)
-                t = (symbs[AO.value]);
+                t = (symbols[AO.value].name);
             break;
         case GLOBALVAR_OT:
         case LOCALVAR_OT:
@@ -819,7 +819,7 @@ static void access_memory_g(int oc, assembly_operand AO1, assembly_operand AO2,
         size_ao = zero_ao; size_ao.value = -1;
         for (x=0; x<no_arrays; x++)
         {   if (((AO1.marker == ARRAY_MV) == (!array_locs[x]))
-                && (AO1.value == svals[array_symbols[x]]))
+                && (AO1.value == symbols[array_symbols[x]].value))
             {   size_ao.value = array_sizes[x]; y=x;
             }
         }
@@ -1044,7 +1044,7 @@ static assembly_operand check_nonzero_at_runtime_g(assembly_operand AO1,
     INITAOTV(&AO3, BYTECONSTANT_OT, GOBJFIELD_PARENT());
     assembleg_3(aload_gc, AO, AO3, stack_pointer);
     ln = symbol_index("Class", -1);
-    AO3.value = svals[ln];
+    AO3.value = symbols[ln].value;
     AO3.marker = OBJECT_MV;
     AO3.type = CONSTANT_OT;
     assembleg_2_branch(jne_gc, stack_pointer, AO3, passed_label);
@@ -1065,7 +1065,7 @@ static assembly_operand check_nonzero_at_runtime_g(assembly_operand AO1,
   else {
     /* Build the symbol for "Object" */
     ln = symbol_index("Object", -1);
-    AO2.value = svals[ln];
+    AO2.value = symbols[ln].value;
     AO2.marker = OBJECT_MV;
     AO2.type = CONSTANT_OT;
     if (check_sp) {

--- a/expressp.c
+++ b/expressp.c
@@ -124,16 +124,16 @@ but not used as a value:", unicode);
 
             mark_symbol_as_used = TRUE;
 
-            v = svals[symbol];
+            v = symbols[symbol].value;
 
             current_token.symindex = symbol;
-            current_token.symtype = stypes[symbol];
-            current_token.symflags = sflags[symbol];
-            switch(stypes[symbol])
+            current_token.symtype = symbols[symbol].type;
+            current_token.symflags = symbols[symbol].flags;
+            switch(symbols[symbol].type)
             {   case ROUTINE_T:
                     /* Replaced functions must always be backpatched
                        because there could be another definition coming. */
-                    if (sflags[symbol] & REPLACE_SFLAG)
+                    if (symbols[symbol].flags & REPLACE_SFLAG)
                     {   current_token.marker = SYMBOL_MV;
                         if (module_switch) import_symbol(symbol);
                         v = symbol;
@@ -160,7 +160,7 @@ but not used as a value:", unicode);
                     if (module_switch) current_token.marker = IDENT_MV;
                     break;
                 case CONSTANT_T:
-                    if (sflags[symbol] & (UNKNOWN_SFLAG + CHANGE_SFLAG))
+                    if (symbols[symbol].flags & (UNKNOWN_SFLAG + CHANGE_SFLAG))
                     {   current_token.marker = SYMBOL_MV;
                         if (module_switch) import_symbol(symbol);
                         v = symbol;
@@ -174,7 +174,7 @@ but not used as a value:", unicode);
                     current_token.marker = 0;
                     break;
             }
-            if (sflags[symbol] & SYSTEM_SFLAG)
+            if (symbols[symbol].flags & SYSTEM_SFLAG)
                 current_token.marker = 0;
 
             current_token.value = v;
@@ -194,7 +194,7 @@ but not used as a value:", unicode);
                 else current_token.type = SMALL_NUMBER_TT;
             }
 
-            if (stypes[symbol] == GLOBAL_VARIABLE_T)
+            if (symbols[symbol].type == GLOBAL_VARIABLE_T)
             {   current_token.type = VARIABLE_TT;
                 variable_usage[current_token.value] = TRUE;
             }
@@ -318,7 +318,7 @@ but not used as a value:", unicode);
                     current_token.text += 3;
                     current_token.type = SYMBOL_TT;
                     symbol = symbol_index(current_token.text, -1);
-                    if (stypes[symbol] != GLOBAL_VARIABLE_T) {
+                    if (symbols[symbol].type != GLOBAL_VARIABLE_T) {
                         ebf_error(
                         "global variable name after '#g$'",
                         current_token.text);
@@ -328,7 +328,7 @@ but not used as a value:", unicode);
                         break;
                     }
                     mark_symbol_as_used = TRUE;
-                    current_token.value = svals[symbol] - MAX_LOCAL_VARIABLES;
+                    current_token.value = symbols[symbol].value - MAX_LOCAL_VARIABLES;
                     current_token.marker = 0;
                     if (!glulx_mode) {
                         if (current_token.value >= 0x100)
@@ -449,7 +449,7 @@ but not used as a value:", unicode);
         current_token.type = ENDEXP_TT;
     }
     else
-    {   if (mark_symbol_as_used) sflags[symbol] |= USED_SFLAG;
+    {   if (mark_symbol_as_used) symbols[symbol].flags |= USED_SFLAG;
         if (expr_trace_level >= 3)
         {   printf("Expr token = '%s' ", current_token.text);
             describe_token(current_token);

--- a/files.c
+++ b/files.c
@@ -1554,7 +1554,7 @@ extern void write_debug_locations(debug_locations locations)
 }
 
 extern void write_debug_optional_identifier(int32 symbol_index)
-{   if (stypes[symbol_index] != ROUTINE_T)
+{   if (symbols[symbol_index].type != ROUTINE_T)
     {   compiler_error
             ("Attempt to write a replaceable identifier for a non-routine");
     }
@@ -1567,7 +1567,7 @@ extern void write_debug_optional_identifier(int32 symbol_index)
         debug_file_printf
             ("<identifier artificial=\"true\">%s "
                  "(superseded replacement)</identifier>",
-             symbs[symbol_index]);
+             symbols[symbol_index].name);
         if (fseek(Debug_fp, 0L, SEEK_END))
         {   fatalerror("I/O failure: can't seek in debugging information file");
         }
@@ -1575,7 +1575,7 @@ extern void write_debug_optional_identifier(int32 symbol_index)
     fgetpos
       (Debug_fp, &symbol_debug_info[symbol_index].replacement_backpatch_pos.position);
     symbol_debug_info[symbol_index].replacement_backpatch_pos.valid = TRUE;
-    debug_file_printf("<identifier>%s</identifier>", symbs[symbol_index]);
+    debug_file_printf("<identifier>%s</identifier>", symbols[symbol_index].name);
     /* Space for:       artificial="true" (superseded replacement) */
     debug_file_printf("                                           ");
 }
@@ -1723,7 +1723,7 @@ extern void write_debug_undef(int32 symbol_index)
             ("Attempt to erase debugging information never written or since "
                 "erased");
     }
-    if (stypes[symbol_index] != CONSTANT_T)
+    if (symbols[symbol_index].type != CONSTANT_T)
     {   compiler_error
             ("Attempt to erase debugging information for a non-constant "
              "because of an #undef");
@@ -1776,7 +1776,7 @@ static void apply_debug_information_symbol_backpatches()
             {   fatalerror
                     ("I/O failure: can't seek in debugging information file");
             }
-            debug_file_printf("%11d", svals[backpatch_symbol]);
+            debug_file_printf("%11d", symbols[backpatch_symbol].value);
         }
     }
 }

--- a/files.c
+++ b/files.c
@@ -1558,10 +1558,10 @@ extern void write_debug_optional_identifier(int32 symbol_index)
     {   compiler_error
             ("Attempt to write a replaceable identifier for a non-routine");
     }
-    if (replacement_debug_backpatch_positions[symbol_index].valid)
+    if (symbol_debug_info[symbol_index].replacement_backpatch_pos.valid)
     {   if (fsetpos
                 (Debug_fp,
-                 &replacement_debug_backpatch_positions[symbol_index].position))
+                 &symbol_debug_info[symbol_index].replacement_backpatch_pos.position))
         {   fatalerror("I/O failure: can't seek in debugging information file");
         }
         debug_file_printf
@@ -1573,26 +1573,26 @@ extern void write_debug_optional_identifier(int32 symbol_index)
         }
     }
     fgetpos
-      (Debug_fp, &replacement_debug_backpatch_positions[symbol_index].position);
-    replacement_debug_backpatch_positions[symbol_index].valid = TRUE;
+      (Debug_fp, &symbol_debug_info[symbol_index].replacement_backpatch_pos.position);
+    symbol_debug_info[symbol_index].replacement_backpatch_pos.valid = TRUE;
     debug_file_printf("<identifier>%s</identifier>", symbs[symbol_index]);
     /* Space for:       artificial="true" (superseded replacement) */
     debug_file_printf("                                           ");
 }
 
 extern void write_debug_symbol_backpatch(int32 symbol_index)
-{   if (symbol_debug_backpatch_positions[symbol_index].valid) {
+{   if (symbol_debug_info[symbol_index].backpatch_pos.valid) {
         compiler_error("Symbol entry incorrectly reused in debug information "
                        "file backpatching");
     }
-    fgetpos(Debug_fp, &symbol_debug_backpatch_positions[symbol_index].position);
-    symbol_debug_backpatch_positions[symbol_index].valid = TRUE;
+    fgetpos(Debug_fp, &symbol_debug_info[symbol_index].backpatch_pos.position);
+    symbol_debug_info[symbol_index].backpatch_pos.valid = TRUE;
     /* Reserve space for up to 10 digits plus a negative sign. */
     debug_file_printf("*BACKPATCH*");
 }
 
 extern void write_debug_symbol_optional_backpatch(int32 symbol_index)
-{   if (symbol_debug_backpatch_positions[symbol_index].valid) {
+{   if (symbol_debug_info[symbol_index].backpatch_pos.valid) {
         compiler_error("Symbol entry incorrectly reused in debug information "
                        "file backpatching");
     }
@@ -1601,8 +1601,8 @@ extern void write_debug_symbol_optional_backpatch(int32 symbol_index)
        so that we'll be in the same case as above if the symbol is eventually
        defined. */
     debug_file_printf("<value>");
-    fgetpos(Debug_fp, &symbol_debug_backpatch_positions[symbol_index].position);
-    symbol_debug_backpatch_positions[symbol_index].valid = TRUE;
+    fgetpos(Debug_fp, &symbol_debug_info[symbol_index].backpatch_pos.position);
+    symbol_debug_info[symbol_index].backpatch_pos.valid = TRUE;
     debug_file_printf("*BACKPATCH*</value>");
 }
 
@@ -1718,7 +1718,7 @@ extern void end_writing_debug_sections(int32 end_address)
 }
 
 extern void write_debug_undef(int32 symbol_index)
-{   if (!symbol_debug_backpatch_positions[symbol_index].valid)
+{   if (!symbol_debug_info[symbol_index].backpatch_pos.valid)
     {   compiler_error
             ("Attempt to erase debugging information never written or since "
                 "erased");
@@ -1729,7 +1729,7 @@ extern void write_debug_undef(int32 symbol_index)
              "because of an #undef");
     }
     if (fsetpos
-         (Debug_fp, &symbol_debug_backpatch_positions[symbol_index].position))
+         (Debug_fp, &symbol_debug_info[symbol_index].backpatch_pos.position))
     {   fatalerror("I/O failure: can't seek in debugging information file");
     }
     /* There are 7 characters in ``<value>''. */
@@ -1739,7 +1739,7 @@ extern void write_debug_undef(int32 symbol_index)
     /* Overwrite:      <value>*BACKPATCH*</value> */
     debug_file_printf("                          ");
     nullify_debug_file_position
-        (&symbol_debug_backpatch_positions[symbol_index]);
+        (&symbol_debug_info[symbol_index].backpatch_pos);
     if (fseek(Debug_fp, 0L, SEEK_END))
     {   fatalerror("I/O failure: can't seek in debugging information file");
     }
@@ -1770,10 +1770,9 @@ static void apply_debug_information_backpatches
 static void apply_debug_information_symbol_backpatches()
 {   int backpatch_symbol;
     for (backpatch_symbol = no_symbols; backpatch_symbol--;)
-    {   if (symbol_debug_backpatch_positions[backpatch_symbol].valid)
+    {   if (symbol_debug_info[backpatch_symbol].backpatch_pos.valid)
         {   if (fsetpos(Debug_fp,
-                        &symbol_debug_backpatch_positions
-                            [backpatch_symbol].position))
+                        &symbol_debug_info[backpatch_symbol].backpatch_pos.position))
             {   fatalerror
                     ("I/O failure: can't seek in debugging information file");
             }

--- a/header.h
+++ b/header.h
@@ -2591,7 +2591,7 @@ extern void  link_module(char *filename);
 /*   Extern definitions for "memory"                                         */
 /* ------------------------------------------------------------------------- */
 
-extern int32 malloced_bytes;
+extern size_t malloced_bytes;
 
 extern int MAX_QTEXT_SIZE,       HASH_TAB_SIZE,   MAX_DICT_ENTRIES,
            MAX_ACTIONS,    MAX_ADJECTIVES,   MAX_ABBREVS,

--- a/header.h
+++ b/header.h
@@ -862,12 +862,15 @@ typedef struct token_data_s
 } token_data;
 
 typedef struct symbolinfo_s {
-    char *symbol; /* the name; points at a symbol_name_space_chunk */
+    char *symbol; /* The name; points at a symbol_name_space_chunk */
+    /* In Z-code, the value field encodes value and marker (and the marker
+       field is unused). In Glulx they're separate. */
     int32 value;
-    int marker; /* only used in Glulx */
+    int marker;
     brief_location line;
     int flags;  /* ?_SFLAGS bitmask */
     uchar type; /* ?_T value */
+    int next_entry; /* Linked list for symbol hash table */
 } symbolinfo;
 
 typedef struct symboldebuginfo_s {
@@ -2686,7 +2689,7 @@ extern char **symbs;
 extern int32 *svals;
 extern int   *smarks;
 extern brief_location *slines;
-extern int   *sflags;
+extern unsigned int   *sflags;
 extern uchar *stypes;
 extern symboldebuginfo *symbol_debug_info;
 extern int32 *individual_name_strings;

--- a/header.h
+++ b/header.h
@@ -903,7 +903,7 @@ typedef struct ErrorPosition_s
     as needed on write. */
 typedef struct memory_block_s
 {
-    int count;
+    size_t count;
     uchar **chunks; /* array of count chunks, each ALLOC_CHUNK_SIZE bytes */
 } memory_block;
 
@@ -918,8 +918,8 @@ typedef struct memory_list_s
     char *whatfor;   /* must be a static string */
     void *data;      /* allocated array of count*itemsize bytes */
     void **extpointer;  /* pointer to keep in sync */
-    int itemsize;    /* item size in bytes */
-    int count;       /* number of items allocated */
+    size_t itemsize;    /* item size in bytes */
+    size_t count;       /* number of items allocated */
 } memory_list;
 
 /* This serves for both Z-code and Glulx instructions. Glulx doesn't use
@@ -2624,12 +2624,12 @@ extern int TRANSCRIPT_FORMAT;
 #define GOBJFIELD_SIBLING()  (5+((NUM_ATTR_BYTES)/4))
 #define GOBJFIELD_CHILD()    (6+((NUM_ATTR_BYTES)/4))
 
-extern void *my_malloc(int32 size, char *whatfor);
-extern void my_realloc(void *pointer, int32 oldsize, int32 size, 
+extern void *my_malloc(size_t size, char *whatfor);
+extern void my_realloc(void *pointer, size_t oldsize, size_t size, 
     char *whatfor);
-extern void *my_calloc(int32 size, int32 howmany, char *whatfor);
-extern void my_recalloc(void *pointer, int32 size, int32 oldhowmany, 
-    int32 howmany, char *whatfor);
+extern void *my_calloc(size_t size, size_t howmany, char *whatfor);
+extern void my_recalloc(void *pointer, size_t size, size_t oldhowmany, 
+    size_t howmany, char *whatfor);
 extern void my_free(void *pointer, char *whatitwas);
 
 extern void set_memory_sizes(int size_flag);
@@ -2639,13 +2639,13 @@ extern void print_memory_usage(void);
 
 extern void initialise_memory_block(memory_block *MB);
 extern void deallocate_memory_block(memory_block *MB);
-extern int  read_byte_from_memory_block(memory_block *MB, int32 index);
+extern int  read_byte_from_memory_block(memory_block *MB, size_t index);
 extern void write_byte_to_memory_block(memory_block *MB,
-    int32 index, int value);
+    size_t index, int value);
 
-extern void initialise_memory_list(memory_list *ML, int itemsize, int initalloc, void **extpointer, char *whatfor);
+extern void initialise_memory_list(memory_list *ML, size_t itemsize, size_t initalloc, void **extpointer, char *whatfor);
 extern void deallocate_memory_list(memory_list *ML);
-extern void ensure_memory_list_available(memory_list *ML, int count);
+extern void ensure_memory_list_available(memory_list *ML, size_t count);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "objects"                                        */

--- a/header.h
+++ b/header.h
@@ -2595,7 +2595,7 @@ extern int32 malloced_bytes;
 
 extern int MAX_QTEXT_SIZE,       HASH_TAB_SIZE,   MAX_DICT_ENTRIES,
            MAX_ACTIONS,    MAX_ADJECTIVES,   MAX_ABBREVS,
-           MAX_STATIC_DATA,      MAX_PROP_TABLE_SIZE,   SYMBOLS_CHUNK_SIZE,
+           MAX_STATIC_DATA,      MAX_PROP_TABLE_SIZE,
            MAX_EXPRESSION_NODES, MAX_LABELS,            MAX_LINESPACE,
            MAX_LOW_STRINGS,      MAX_VERBS,
            MAX_VERBSPACE,        MAX_ARRAYS,            MAX_INCLUSION_DEPTH,

--- a/header.h
+++ b/header.h
@@ -861,6 +861,20 @@ typedef struct token_data_s
     debug_location location;
 } token_data;
 
+typedef struct symbolinfo_s {
+    char *symbol; /* the name; points at a symbol_name_space_chunk */
+    int32 value;
+    int mark; /* only used in Glulx */
+    brief_location line;
+    int flags;  /* ?_SFLAGS bitmask */
+    uchar type; /* ?_T value */
+} symbolinfo;
+
+typedef struct symboldebuginfo_s {
+    maybe_file_position symbol_backpatch_position;
+    maybe_file_position replacement_backpatch_position;
+} symboldebuginfo;
+
 typedef struct FileId_s                 /*  Source code file identifier:     */
 {   char *filename;                     /*  The filename (after translation) */
     FILE *handle;                       /*  Handle of file (when open), or
@@ -2673,11 +2687,7 @@ extern int32 *svals;
 extern int   *smarks;
 extern brief_location *slines;
 extern int   *sflags;
-#ifdef VAX
-  extern char *stypes;
-#else
-  extern signed char *stypes;
-#endif
+extern uchar *stypes;
 extern maybe_file_position *symbol_debug_backpatch_positions;
 extern maybe_file_position *replacement_debug_backpatch_positions;
 extern int32 *individual_name_strings;

--- a/header.h
+++ b/header.h
@@ -2593,7 +2593,7 @@ extern void  link_module(char *filename);
 
 extern int32 malloced_bytes;
 
-extern int MAX_QTEXT_SIZE,  MAX_SYMBOLS,    HASH_TAB_SIZE,   MAX_DICT_ENTRIES,
+extern int MAX_QTEXT_SIZE,       HASH_TAB_SIZE,   MAX_DICT_ENTRIES,
            MAX_ACTIONS,    MAX_ADJECTIVES,   MAX_ABBREVS,
            MAX_STATIC_DATA,      MAX_PROP_TABLE_SIZE,   SYMBOLS_CHUNK_SIZE,
            MAX_EXPRESSION_NODES, MAX_LABELS,            MAX_LINESPACE,

--- a/header.h
+++ b/header.h
@@ -864,7 +864,7 @@ typedef struct token_data_s
 typedef struct symbolinfo_s {
     char *symbol; /* the name; points at a symbol_name_space_chunk */
     int32 value;
-    int mark; /* only used in Glulx */
+    int marker; /* only used in Glulx */
     brief_location line;
     int flags;  /* ?_SFLAGS bitmask */
     uchar type; /* ?_T value */

--- a/header.h
+++ b/header.h
@@ -862,7 +862,7 @@ typedef struct token_data_s
 } token_data;
 
 typedef struct symbolinfo_s {
-    char *symbol; /* The name; points at a symbol_name_space_chunk */
+    char *name; /* Points into a symbol_name_space_chunk */
     /* In Z-code, the value field encodes value and marker (and the marker
        field is unused). In Glulx they're separate. */
     int32 value;
@@ -2685,12 +2685,6 @@ extern void write_the_identifier_names(void);
 
 extern int no_named_constants;
 extern int no_symbols;
-extern char **symbs;
-extern int32 *svals;
-extern int   *smarks;
-extern brief_location *slines;
-extern unsigned int   *sflags;
-extern uchar *stypes;
 extern symbolinfo *symbols;
 extern symboldebuginfo *symbol_debug_info;
 extern int32 *individual_name_strings;

--- a/header.h
+++ b/header.h
@@ -868,7 +868,7 @@ typedef struct symbolinfo_s {
     int32 value;
     int marker;
     brief_location line;
-    int flags;  /* ?_SFLAGS bitmask */
+    unsigned int flags;  /* ?_SFLAGS bitmask */
     uchar type; /* ?_T value */
     int next_entry; /* Linked list for symbol hash table */
 } symbolinfo;
@@ -2691,6 +2691,7 @@ extern int   *smarks;
 extern brief_location *slines;
 extern unsigned int   *sflags;
 extern uchar *stypes;
+extern symbolinfo *symbols;
 extern symboldebuginfo *symbol_debug_info;
 extern int32 *individual_name_strings;
 extern int32 *attribute_name_strings;

--- a/header.h
+++ b/header.h
@@ -2682,7 +2682,7 @@ extern void write_the_identifier_names(void);
 
 extern int no_named_constants;
 extern int no_symbols;
-extern int32 **symbs;
+extern char **symbs;
 extern int32 *svals;
 extern int   *smarks;
 extern brief_location *slines;

--- a/header.h
+++ b/header.h
@@ -871,8 +871,8 @@ typedef struct symbolinfo_s {
 } symbolinfo;
 
 typedef struct symboldebuginfo_s {
-    maybe_file_position symbol_backpatch_position;
-    maybe_file_position replacement_backpatch_position;
+    maybe_file_position backpatch_pos;
+    maybe_file_position replacement_backpatch_pos;
 } symboldebuginfo;
 
 typedef struct FileId_s                 /*  Source code file identifier:     */
@@ -2688,8 +2688,7 @@ extern int   *smarks;
 extern brief_location *slines;
 extern int   *sflags;
 extern uchar *stypes;
-extern maybe_file_position *symbol_debug_backpatch_positions;
-extern maybe_file_position *replacement_debug_backpatch_positions;
+extern symboldebuginfo *symbol_debug_info;
 extern int32 *individual_name_strings;
 extern int32 *attribute_name_strings;
 extern int32 *action_name_strings;

--- a/linker.c
+++ b/linker.c
@@ -207,28 +207,28 @@ static void accept_export(void)
 
     xref_table[IE.symbol_number] = index;
 
-    if (!(sflags[index] & UNKNOWN_SFLAG))
+    if (!(symbols[index].flags & UNKNOWN_SFLAG))
     {   if (IE.module_value == EXPORTAC_MV)
-        {   if ((!(sflags[index] & ACTION_SFLAG))
-                && (stypes[index] != FAKE_ACTION_T))
+        {   if ((!(symbols[index].flags & ACTION_SFLAG))
+                && (symbols[index].type != FAKE_ACTION_T))
                 link_error_named(
 "action name clash with", IE.symbol_name);
         }
         else
-        if (stypes[index] == IE.symbol_type)
+        if (symbols[index].type == IE.symbol_type)
         {   switch(IE.symbol_type)
             {   case CONSTANT_T:
-                    if ((!(svals[index] == IE.symbol_value))
+                    if ((!(symbols[index].value == IE.symbol_value))
                         || (IE.backpatch != 0))
                         link_error_named(
 "program and module give differing values of", IE.symbol_name);
                     break;
                 case INDIVIDUAL_PROPERTY_T:
-                    property_identifier_map[IE.symbol_value] = svals[index];
+                    property_identifier_map[IE.symbol_value] = symbols[index].value;
                     break;
                 case ROUTINE_T:
                     if ((IE.module_value == EXPORTSF_MV)
-                        && (sflags[index] & REPLACE_SFLAG))
+                        && (symbols[index].flags & REPLACE_SFLAG))
                     break;
                 default:
                     sprintf(link_errorm,
@@ -241,7 +241,7 @@ static void accept_export(void)
         else
         {   sprintf(link_errorm,
                     "'%s' has type %s in program but type %s in module",
-                    IE.symbol_name, typename(stypes[index]),
+                    IE.symbol_name, typename(symbols[index].type),
                     typename(IE.symbol_type));
             link_error(link_errorm);
         }
@@ -251,13 +251,13 @@ static void accept_export(void)
         {   IE.symbol_value = no_actions;
             action_symbol[no_actions++] = index;
             if (linker_trace_level >= 4)
-                printf("Creating action ##%s\n", symbs[index]);
+                printf("Creating action ##%s\n", symbols[index].name);
         }
         else
         switch(IE.symbol_type)
         {   case ROUTINE_T:
                 if ((IE.module_value == EXPORTSF_MV)
-                    && (sflags[index] & REPLACE_SFLAG))
+                    && (symbols[index].flags & REPLACE_SFLAG))
                 {   routine_replace[no_rr] = IE.symbol_value;
                     routine_replace_with[no_rr++] = index;
                     return;
@@ -299,19 +299,19 @@ static void accept_export(void)
         }
         assign_symbol(index, IE.backpatch*0x10000 + IE.symbol_value,
             IE.symbol_type);
-        if (IE.backpatch != 0) sflags[index] |= CHANGE_SFLAG;
-        sflags[index] |= EXPORT_SFLAG;
+        if (IE.backpatch != 0) symbols[index].flags |= CHANGE_SFLAG;
+        symbols[index].flags |= EXPORT_SFLAG;
         if (IE.module_value == EXPORTSF_MV)
-            sflags[index] |= INSF_SFLAG;
+            symbols[index].flags |= INSF_SFLAG;
         if (IE.module_value == EXPORTAC_MV)
-            sflags[index] |= ACTION_SFLAG;
+            symbols[index].flags |= ACTION_SFLAG;
     }
 
     if (IE.module_value == EXPORTAC_MV)
     {   if (linker_trace_level >= 4)
             printf("Map %d '%s' to %d\n",
-                IE.symbol_value, (symbs[index]), svals[index]);
-        actions_map[map_to] = svals[index];
+                IE.symbol_value, (symbols[index].name), symbols[index].value);
+        actions_map[map_to] = symbols[index].value;
     }
 }
 
@@ -319,22 +319,22 @@ static void accept_import(void)
 {   int32 index;
 
     index = symbol_index(IE.symbol_name, -1);
-    sflags[index] |= USED_SFLAG;
+    symbols[index].flags |= USED_SFLAG;
     xref_table[IE.symbol_number] = index;
 
-    if (!(sflags[index] & UNKNOWN_SFLAG))
+    if (!(symbols[index].flags & UNKNOWN_SFLAG))
     {   switch (IE.symbol_type)
         {
             case GLOBAL_VARIABLE_T:
-                if (stypes[index] != GLOBAL_VARIABLE_T)
+                if (symbols[index].type != GLOBAL_VARIABLE_T)
                     link_error_named(
 "module (wrongly) declared this a variable:", IE.symbol_name);
-                variables_map[IE.symbol_value] = svals[index];
+                variables_map[IE.symbol_value] = symbols[index].value;
                 if (IE.symbol_value < lowest_imported_global_no)
                     lowest_imported_global_no = IE.symbol_value;
                 break;
             default:
-                switch(stypes[index])
+                switch(symbols[index].type)
                 {   case ATTRIBUTE_T:
                         link_error_named(
 "this attribute is undeclared within module:", IE.symbol_name);; break;
@@ -361,7 +361,7 @@ static void accept_import(void)
     {   switch (IE.symbol_type)
         {
             case GLOBAL_VARIABLE_T:
-                if (stypes[index] != GLOBAL_VARIABLE_T)
+                if (symbols[index].type != GLOBAL_VARIABLE_T)
                     link_error_named(
                 "Module tried to import a Global variable not defined here:",
                         IE.symbol_name);
@@ -668,7 +668,7 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
         if (((record_type == EXPORT_MV) || (record_type == EXPORTSF_MV))
             && (IE.symbol_type == INDIVIDUAL_PROPERTY_T))
         {   int32 si = symbol_index(IE.symbol_name, -1);
-            property_identifier_map[IE.symbol_value] = svals[si];
+            property_identifier_map[IE.symbol_value] = symbols[si].value;
         }
         switch(record_type)
         {   case EXPORT_MV:
@@ -693,7 +693,7 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
         for (i=0; i<module_map[6]; i++)
         {   if (xref_table[i] != -1)
                 printf("module %4d -> story file '%s'\n", i,
-                    symbs[xref_table[i]]);
+                    symbols[xref_table[i]].name);
         }
     }
 
@@ -715,14 +715,14 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
     /* (6) Backpatch the backpatch markers attached to exported symbols  */
 
     for (i=symbols_base; i<no_symbols; i++)
-    {   if ((sflags[i] & CHANGE_SFLAG) && (sflags[i] & EXPORT_SFLAG))
-        {   backpatch_marker = svals[i]/0x10000;
-            j = svals[i] % 0x10000;
+    {   if ((symbols[i].flags & CHANGE_SFLAG) && (symbols[i].flags & EXPORT_SFLAG))
+        {   backpatch_marker = symbols[i].value/0x10000;
+            j = symbols[i].value % 0x10000;
 
             j = backpatch_backpatch(j);
 
-            svals[i] = backpatch_marker*0x10000 + j;
-            if (backpatch_marker == 0) sflags[i] &= (~(CHANGE_SFLAG));
+            symbols[i].value = backpatch_marker*0x10000 + j;
+            if (backpatch_marker == 0) symbols[i].flags &= (~(CHANGE_SFLAG));
         }
     }
 
@@ -1017,23 +1017,23 @@ static void export_symbols(void)
     for (symbol_number = 0; symbol_number < no_symbols; symbol_number++)
     {   int export_flag = FALSE, import_flag = FALSE;
 
-        if (stypes[symbol_number]==GLOBAL_VARIABLE_T)
-        {   if (svals[symbol_number] < LOWEST_SYSTEM_VAR_NUMBER)
-            {   if (sflags[symbol_number] & IMPORT_SFLAG)
+        if (symbols[symbol_number].type==GLOBAL_VARIABLE_T)
+        {   if (symbols[symbol_number].value < LOWEST_SYSTEM_VAR_NUMBER)
+            {   if (symbols[symbol_number].flags & IMPORT_SFLAG)
                     import_flag = TRUE;
                 else
-                    if (!(sflags[symbol_number] & SYSTEM_SFLAG))
+                    if (!(symbols[symbol_number].flags & SYSTEM_SFLAG))
                         export_flag = TRUE;
             }
         }
         else
-        {   if (!(sflags[symbol_number] & SYSTEM_SFLAG))
-            {   if (sflags[symbol_number] & UNKNOWN_SFLAG)
-                {   if (sflags[symbol_number] & IMPORT_SFLAG)
+        {   if (!(symbols[symbol_number].flags & SYSTEM_SFLAG))
+            {   if (symbols[symbol_number].flags & UNKNOWN_SFLAG)
+                {   if (symbols[symbol_number].flags & IMPORT_SFLAG)
                         import_flag = TRUE;
                 }
                 else
-                switch(stypes[symbol_number])
+                switch(symbols[symbol_number].type)
                 {   case LABEL_T:
                     case ATTRIBUTE_T:
                     case PROPERTY_T:
@@ -1049,27 +1049,27 @@ static void export_symbols(void)
         {   if (linker_trace_level >= 1)
             {   IE.module_value = EXPORT_MV;
                 IE.symbol_number = symbol_number;
-                IE.symbol_type = stypes[symbol_number];
-                IE.symbol_value = svals[symbol_number];
-                IE.symbol_name = (symbs[symbol_number]);
+                IE.symbol_type = symbols[symbol_number].type;
+                IE.symbol_value = symbols[symbol_number].value;
+                IE.symbol_name = (symbols[symbol_number].name);
                 describe_importexport(&IE);
             }
 
-            if (sflags[symbol_number] & ACTION_SFLAG)
+            if (symbols[symbol_number].flags & ACTION_SFLAG)
                 write_link_byte(EXPORTAC_MV);
             else
-            if (sflags[symbol_number] & INSF_SFLAG)
+            if (symbols[symbol_number].flags & INSF_SFLAG)
                 write_link_byte(EXPORTSF_MV);
             else
                 write_link_byte(EXPORT_MV);
 
             write_link_word(symbol_number);
-            write_link_byte(stypes[symbol_number]);
-            if (sflags[symbol_number] & CHANGE_SFLAG)
-                 write_link_byte(svals[symbol_number] / 0x10000);
+            write_link_byte(symbols[symbol_number].type);
+            if (symbols[symbol_number].flags & CHANGE_SFLAG)
+                 write_link_byte(symbols[symbol_number].value / 0x10000);
             else write_link_byte(0);
-            write_link_word(svals[symbol_number] % 0x10000);
-            write_link_string((symbs[symbol_number]));
+            write_link_word(symbols[symbol_number].value % 0x10000);
+            write_link_string((symbols[symbol_number].name));
             flush_link_data();
         }
 
@@ -1077,17 +1077,17 @@ static void export_symbols(void)
         {   if (linker_trace_level >= 1)
             {   IE.module_value = IMPORT_MV;
                 IE.symbol_number = symbol_number;
-                IE.symbol_type = stypes[symbol_number];
-                IE.symbol_value = svals[symbol_number];
-                IE.symbol_name = (symbs[symbol_number]);
+                IE.symbol_type = symbols[symbol_number].type;
+                IE.symbol_value = symbols[symbol_number].value;
+                IE.symbol_name = (symbols[symbol_number].name);
                 describe_importexport(&IE);
             }
 
             write_link_byte(IMPORT_MV);
             write_link_word(symbol_number);
-            write_link_byte(stypes[symbol_number]);
-            write_link_word(svals[symbol_number]);
-            write_link_string((symbs[symbol_number]));
+            write_link_byte(symbols[symbol_number].type);
+            write_link_word(symbols[symbol_number].value);
+            write_link_string((symbols[symbol_number].name));
             flush_link_data();
         }
     }
@@ -1100,10 +1100,10 @@ static void export_symbols(void)
 int mv_vref=LOWEST_SYSTEM_VAR_NUMBER-1;
 
 void import_symbol(int32 symbol_number)
-{   sflags[symbol_number] |= IMPORT_SFLAG;
-    switch(stypes[symbol_number])
+{   symbols[symbol_number].flags |= IMPORT_SFLAG;
+    switch(symbols[symbol_number].type)
     {   case GLOBAL_VARIABLE_T:
-            assign_symbol(symbol_number, mv_vref--, stypes[symbol_number]);
+            assign_symbol(symbol_number, mv_vref--, symbols[symbol_number].type);
             break;
     }
 }

--- a/linker.c
+++ b/linker.c
@@ -251,7 +251,7 @@ static void accept_export(void)
         {   IE.symbol_value = no_actions;
             action_symbol[no_actions++] = index;
             if (linker_trace_level >= 4)
-                printf("Creating action ##%s\n", (char *) symbs[index]);
+                printf("Creating action ##%s\n", symbs[index]);
         }
         else
         switch(IE.symbol_type)
@@ -310,7 +310,7 @@ static void accept_export(void)
     if (IE.module_value == EXPORTAC_MV)
     {   if (linker_trace_level >= 4)
             printf("Map %d '%s' to %d\n",
-                IE.symbol_value, (char *) (symbs[index]), svals[index]);
+                IE.symbol_value, (symbs[index]), svals[index]);
         actions_map[map_to] = svals[index];
     }
 }
@@ -693,7 +693,7 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
         for (i=0; i<module_map[6]; i++)
         {   if (xref_table[i] != -1)
                 printf("module %4d -> story file '%s'\n", i,
-                    (char *) symbs[xref_table[i]]);
+                    symbs[xref_table[i]]);
         }
     }
 
@@ -1051,7 +1051,7 @@ static void export_symbols(void)
                 IE.symbol_number = symbol_number;
                 IE.symbol_type = stypes[symbol_number];
                 IE.symbol_value = svals[symbol_number];
-                IE.symbol_name = (char *) (symbs[symbol_number]);
+                IE.symbol_name = (symbs[symbol_number]);
                 describe_importexport(&IE);
             }
 
@@ -1069,7 +1069,7 @@ static void export_symbols(void)
                  write_link_byte(svals[symbol_number] / 0x10000);
             else write_link_byte(0);
             write_link_word(svals[symbol_number] % 0x10000);
-            write_link_string((char *) (symbs[symbol_number]));
+            write_link_string((symbs[symbol_number]));
             flush_link_data();
         }
 
@@ -1079,7 +1079,7 @@ static void export_symbols(void)
                 IE.symbol_number = symbol_number;
                 IE.symbol_type = stypes[symbol_number];
                 IE.symbol_value = svals[symbol_number];
-                IE.symbol_name = (char *) (symbs[symbol_number]);
+                IE.symbol_name = (symbs[symbol_number]);
                 describe_importexport(&IE);
             }
 
@@ -1087,7 +1087,7 @@ static void export_symbols(void)
             write_link_word(symbol_number);
             write_link_byte(stypes[symbol_number]);
             write_link_word(svals[symbol_number]);
-            write_link_string((char *) (symbs[symbol_number]));
+            write_link_string((symbs[symbol_number]));
             flush_link_data();
         }
     }

--- a/memory.c
+++ b/memory.c
@@ -357,7 +357,6 @@ void ensure_memory_list_available(memory_list *ML, int count)
 /* ------------------------------------------------------------------------- */
 
 int MAX_QTEXT_SIZE;
-int MAX_SYMBOLS;
 int SYMBOLS_CHUNK_SIZE;
 int HASH_TAB_SIZE;
 int MAX_ARRAYS;
@@ -470,7 +469,6 @@ static void list_memory_sizes(void)
     printf("|  %25s = %-7d |\n","MAX_STATIC_DATA",MAX_STATIC_DATA);
     printf("|  %25s = %-7ld |\n","MAX_STATIC_STRINGS",
            (long int) MAX_STATIC_STRINGS);
-    printf("|  %25s = %-7d |\n","MAX_SYMBOLS",MAX_SYMBOLS);
     printf("|  %25s = %-7d |\n","SYMBOLS_CHUNK_SIZE",SYMBOLS_CHUNK_SIZE);
     printf("|  %25s = %-7d |\n","TRANSCRIPT_FORMAT",TRANSCRIPT_FORMAT);
     printf("|  %25s = %-7ld |\n","MAX_TRANSCRIPT_SIZE",
@@ -492,7 +490,6 @@ extern void set_memory_sizes(int size_flag)
     if (size_flag == HUGE_SIZE)
     {
         MAX_QTEXT_SIZE  = 4000;
-        MAX_SYMBOLS     = 10000;
 
         SYMBOLS_CHUNK_SIZE = 5000;
         HASH_TAB_SIZE      = 512;
@@ -533,7 +530,6 @@ extern void set_memory_sizes(int size_flag)
     if (size_flag == LARGE_SIZE)
     {
         MAX_QTEXT_SIZE  = 4000;
-        MAX_SYMBOLS     = 6400;
 
         SYMBOLS_CHUNK_SIZE = 5000;
         HASH_TAB_SIZE      = 512;
@@ -574,7 +570,6 @@ extern void set_memory_sizes(int size_flag)
     if (size_flag == SMALL_SIZE)
     {
         MAX_QTEXT_SIZE  = 4000;
-        MAX_SYMBOLS     = 3000;
 
         SYMBOLS_CHUNK_SIZE = 2500;
         HASH_TAB_SIZE      = 512;
@@ -678,12 +673,6 @@ static void explain_parameter(char *command)
 "  MAX_QTEXT_SIZE is the maximum length of a quoted string.  Increasing\n\
    by 1 costs 5 bytes (for lexical analysis memory).  Inform automatically\n\
    ensures that MAX_STATIC_STRINGS is at least twice the size of this.");
-        return;
-    }
-    if (strcmp(command,"MAX_SYMBOLS")==0)
-    {   printf(
-"  MAX_SYMBOLS is the maximum number of symbols - names of variables, \n\
-  objects, routines, the many internal Inform-generated names and so on.\n");
         return;
     }
     if (strcmp(command,"SYMBOLS_CHUNK_SIZE")==0)
@@ -1104,7 +1093,7 @@ extern void memory_command(char *command)
                     MAX_STATIC_STRINGS = 2*MAX_QTEXT_SIZE;
             }
             if (strcmp(command,"MAX_SYMBOLS")==0)
-                MAX_SYMBOLS=j, flag=1;
+                flag=3;
             if (strcmp(command,"MAX_BANK_SIZE")==0)
                 flag=2;
             if (strcmp(command,"SYMBOLS_CHUNK_SIZE")==0)

--- a/memory.c
+++ b/memory.c
@@ -9,7 +9,7 @@
 
 #include "header.h"
 
-int32 malloced_bytes=0;                /* Total amount of memory allocated   */
+size_t malloced_bytes=0;               /* Total amount of memory allocated   */
 
 /* Wrappers for malloc(), realloc(), etc.
 

--- a/memory.c
+++ b/memory.c
@@ -357,7 +357,6 @@ void ensure_memory_list_available(memory_list *ML, int count)
 /* ------------------------------------------------------------------------- */
 
 int MAX_QTEXT_SIZE;
-int SYMBOLS_CHUNK_SIZE;
 int HASH_TAB_SIZE;
 int MAX_ARRAYS;
 int MAX_ACTIONS;
@@ -469,7 +468,6 @@ static void list_memory_sizes(void)
     printf("|  %25s = %-7d |\n","MAX_STATIC_DATA",MAX_STATIC_DATA);
     printf("|  %25s = %-7ld |\n","MAX_STATIC_STRINGS",
            (long int) MAX_STATIC_STRINGS);
-    printf("|  %25s = %-7d |\n","SYMBOLS_CHUNK_SIZE",SYMBOLS_CHUNK_SIZE);
     printf("|  %25s = %-7d |\n","TRANSCRIPT_FORMAT",TRANSCRIPT_FORMAT);
     printf("|  %25s = %-7ld |\n","MAX_TRANSCRIPT_SIZE",
            (long int) MAX_TRANSCRIPT_SIZE);
@@ -491,7 +489,6 @@ extern void set_memory_sizes(int size_flag)
     {
         MAX_QTEXT_SIZE  = 4000;
 
-        SYMBOLS_CHUNK_SIZE = 5000;
         HASH_TAB_SIZE      = 512;
 
         MAX_ACTIONS      = 200;
@@ -531,7 +528,6 @@ extern void set_memory_sizes(int size_flag)
     {
         MAX_QTEXT_SIZE  = 4000;
 
-        SYMBOLS_CHUNK_SIZE = 5000;
         HASH_TAB_SIZE      = 512;
 
         MAX_ACTIONS      = 200;
@@ -571,7 +567,6 @@ extern void set_memory_sizes(int size_flag)
     {
         MAX_QTEXT_SIZE  = 4000;
 
-        SYMBOLS_CHUNK_SIZE = 2500;
         HASH_TAB_SIZE      = 512;
 
         MAX_ACTIONS      = 200;
@@ -673,12 +668,6 @@ static void explain_parameter(char *command)
 "  MAX_QTEXT_SIZE is the maximum length of a quoted string.  Increasing\n\
    by 1 costs 5 bytes (for lexical analysis memory).  Inform automatically\n\
    ensures that MAX_STATIC_STRINGS is at least twice the size of this.");
-        return;
-    }
-    if (strcmp(command,"SYMBOLS_CHUNK_SIZE")==0)
-    {   printf(
-"  The symbols names are stored in memory which is allocated in chunks \n\
-  of size SYMBOLS_CHUNK_SIZE.\n");
         return;
     }
     if (strcmp(command,"HASH_TAB_SIZE")==0)
@@ -1097,7 +1086,7 @@ extern void memory_command(char *command)
             if (strcmp(command,"MAX_BANK_SIZE")==0)
                 flag=2;
             if (strcmp(command,"SYMBOLS_CHUNK_SIZE")==0)
-                SYMBOLS_CHUNK_SIZE=j, flag=1;
+                flag=3;
             if (strcmp(command,"BANK_CHUNK_SIZE")==0)
                 flag=2;
             if (strcmp(command,"HASH_TAB_SIZE")==0)

--- a/memory.c
+++ b/memory.c
@@ -20,7 +20,7 @@ int32 malloced_bytes=0;                /* Total amount of memory allocated   */
 
 #ifdef PC_QUICKC
 
-extern void *my_malloc(int32 size, char *whatfor)
+extern void *my_malloc(size_t size, char *whatfor)
 {   char _huge *c;
     if (memout_switch)
         printf("Allocating %ld bytes for %s\n",size,whatfor);
@@ -30,7 +30,7 @@ extern void *my_malloc(int32 size, char *whatfor)
     return(c);
 }
 
-extern void my_realloc(void *pointer, int32 oldsize, int32 size, 
+extern void my_realloc(void *pointer, size_t oldsize, size_t size, 
     char *whatfor)
 {   char _huge *c;
     if (size==0) {
@@ -49,7 +49,7 @@ now (%08lx)\n",
     *(int **)pointer = c;
 }
 
-extern void *my_calloc(int32 size, int32 howmany, char *whatfor)
+extern void *my_calloc(size_t size, size_t howmany, char *whatfor)
 {   void _huge *c;
     if (memout_switch)
         printf("Allocating %d bytes: array (%ld entries size %ld) for %s\n",
@@ -60,7 +60,7 @@ extern void *my_calloc(int32 size, int32 howmany, char *whatfor)
     return(c);
 }
 
-extern void my_recalloc(void *pointer, int32 size, int32 oldhowmany, 
+extern void my_recalloc(void *pointer, size_t size, size_t oldhowmany, 
     int32 howmany, char *whatfor)
 {   void _huge *c;
     if (size*howmany==0) {
@@ -82,10 +82,10 @@ for %s was (%08lx) now (%08lx)\n",
 
 #else
 
-extern void *my_malloc(int32 size, char *whatfor)
+extern void *my_malloc(size_t size, char *whatfor)
 {   char *c;
     if (size==0) return(NULL);
-    c=malloc((size_t) size); malloced_bytes+=size;
+    c=malloc(size); malloced_bytes+=size;
     if (c==0) memory_out_error(size, 1, whatfor);
     if (memout_switch)
         printf("Allocating %ld bytes for %s at (%08lx)\n",
@@ -93,14 +93,14 @@ extern void *my_malloc(int32 size, char *whatfor)
     return(c);
 }
 
-extern void my_realloc(void *pointer, int32 oldsize, int32 size, 
+extern void my_realloc(void *pointer, size_t oldsize, size_t size, 
     char *whatfor)
 {   void *c;
     if (size==0) {
         my_free(pointer, whatfor);
         return;
     }
-    c=realloc(*(int **)pointer, (size_t) size); malloced_bytes+=size;
+    c=realloc(*(int **)pointer,  size); malloced_bytes+=size;
     if (c==0) memory_out_error(size, 1, whatfor);
     if (memout_switch)
         printf("Increasing allocation to %ld bytes for %s was (%08lx) \
@@ -110,10 +110,10 @@ now (%08lx)\n",
     *(int **)pointer = c;
 }
 
-extern void *my_calloc(int32 size, int32 howmany, char *whatfor)
+extern void *my_calloc(size_t size, size_t howmany, char *whatfor)
 {   void *c;
     if (size*howmany==0) return(NULL);
-    c=calloc(howmany,(size_t) size); malloced_bytes+=size*howmany;
+    c=calloc(howmany, size); malloced_bytes+=size*howmany;
     if (c==0) memory_out_error(size, howmany, whatfor);
     if (memout_switch)
         printf("Allocating %ld bytes: array (%ld entries size %ld) \
@@ -124,14 +124,14 @@ for %s at (%08lx)\n",
     return(c);
 }
 
-extern void my_recalloc(void *pointer, int32 size, int32 oldhowmany, 
-    int32 howmany, char *whatfor)
+extern void my_recalloc(void *pointer, size_t size, size_t oldhowmany, 
+    size_t howmany, char *whatfor)
 {   void *c;
     if (size*howmany==0) {
         my_free(pointer, whatfor);
         return;
     }
-    c=realloc(*(int **)pointer, (size_t)size*(size_t)howmany); 
+    c=realloc(*(int **)pointer, size*howmany); 
     malloced_bytes+=size*howmany;
     if (c==0) memory_out_error(size, howmany, whatfor);
     if (memout_switch)
@@ -197,7 +197,7 @@ static char *chunk_name(memory_block *MB, int no)
 }
 
 extern void initialise_memory_block(memory_block *MB)
-{   int i;
+{   size_t i;
     /* Begin with space for 64 chunks of ALLOC_BLOCK_SIZE (130kb total).
        We can increase that later if needed. In any case, we don't allocate
        the chunks themselves yet. */
@@ -208,7 +208,7 @@ extern void initialise_memory_block(memory_block *MB)
 }
 
 extern void deallocate_memory_block(memory_block *MB)
-{   int i;
+{   size_t i;
     if (MB->chunks == NULL)
         return;
     for (i=0; i<MB->count; i++)
@@ -220,9 +220,9 @@ extern void deallocate_memory_block(memory_block *MB)
     MB->count = 0;
 }
 
-extern int read_byte_from_memory_block(memory_block *MB, int32 index)
+extern int read_byte_from_memory_block(memory_block *MB, size_t index)
 {   uchar *p = NULL;
-    int ch;
+    size_t ch;
     if (MB->chunks == NULL) {
         compiler_error_named("memory: read from uninitialized block",
             chunk_name(MB, -1));
@@ -240,9 +240,9 @@ extern int read_byte_from_memory_block(memory_block *MB, int32 index)
     return p[index % ALLOC_CHUNK_SIZE];
 }
 
-extern void write_byte_to_memory_block(memory_block *MB, int32 index, int value)
+extern void write_byte_to_memory_block(memory_block *MB, size_t index, int value)
 {   uchar *p = NULL;
-    int ch;
+    size_t ch;
     if (MB->chunks == NULL) {
         compiler_error_named("memory: write to uninitialized block",
             chunk_name(MB, -1));
@@ -258,9 +258,9 @@ extern void write_byte_to_memory_block(memory_block *MB, int32 index, int value)
     {
         /* We need to extend the chunks array. Note that we don't allocate
            new chunks yet; the extended array contains NULLs. */
-        int i;
+        size_t i;
         /* Bump up the chunk count to the next higher multiple of 16. */
-        int newcount = ((MB->count | 15) + 1) + 16;
+        size_t newcount = ((MB->count | 15) + 1) + 16;
         my_realloc(&(MB->chunks), MB->count * sizeof(uchar *), newcount * sizeof(uchar *), chunk_name(MB, -1));
         if (MB->chunks == NULL) return;
         for (i=MB->count; i<newcount; i++) MB->chunks[i] = NULL;
@@ -292,7 +292,7 @@ extern void write_byte_to_memory_block(memory_block *MB, int32 index, int value)
 /*   external array will be updated to refer to the new data.                */
 /* ------------------------------------------------------------------------- */
 
-void initialise_memory_list(memory_list *ML, int itemsize, int initalloc, void **extpointer, char *whatfor)
+void initialise_memory_list(memory_list *ML, size_t itemsize, size_t initalloc, void **extpointer, char *whatfor)
 {
     ML->whatfor = whatfor;
     ML->itemsize = itemsize;
@@ -325,9 +325,9 @@ void deallocate_memory_list(memory_list *ML)
 
 /* After this is called, at least count items will be available in the list.
    That is, you can freely access array[0] through array[count-1]. */
-void ensure_memory_list_available(memory_list *ML, int count)
+void ensure_memory_list_available(memory_list *ML, size_t count)
 {
-    int oldcount;
+    size_t oldcount;
     
     if (ML->itemsize == 0) {
         /* whatfor is also null! */

--- a/memory.c
+++ b/memory.c
@@ -1239,11 +1239,10 @@ extern void memory_command(char *command)
 
             if (flag==0)
                 printf("No such memory setting as \"%s\"\n", command);
-            if (flag==2)
-            printf("The Inform 5 memory setting \"%s\" has been withdrawn.\n\
-It should be safe to omit it (putting nothing in its place).\n", command);
-            if (flag==3)
-            printf("The Inform 6 memory setting \"%s\" is no longer needed and has been withdrawn.\n", command);
+            if (flag==2 && !nowarnings_switch)
+                printf("The Inform 5 memory setting \"%s\" has been withdrawn.\n", command);
+            if (flag==3 && !nowarnings_switch)
+                printf("The Inform 6 memory setting \"%s\" is no longer needed and has been withdrawn.\n", command);
             return;
         }
     }

--- a/objects.c
+++ b/objects.c
@@ -124,9 +124,9 @@ more than",
         put_token_back();
         return;
     }
-    if (!(sflags[i] & UNKNOWN_SFLAG))
+    if (!(symbols[i].flags & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
-        ebf_symbol_error("new attribute name", token_text, typename(stypes[i]), slines[i]);
+        ebf_symbol_error("new attribute name", token_text, typename(symbols[i].type), symbols[i].line);
         panic_mode_error_recovery(); 
         put_token_back();
         return;
@@ -139,7 +139,7 @@ more than",
     if ((token_type == DIR_KEYWORD_TT) && (token_value == ALIAS_DK))
     {   get_next_token();
         if (!((token_type == SYMBOL_TT)
-              && (stypes[token_value] == ATTRIBUTE_T)))
+              && (symbols[token_value].type == ATTRIBUTE_T)))
         {   discard_token_location(beginning_debug_location);
             ebf_error("an existing attribute name after 'alias'",
                 token_text);
@@ -147,9 +147,9 @@ more than",
             put_token_back();
             return;
         }
-        assign_symbol(i, svals[token_value], ATTRIBUTE_T);
-        sflags[token_value] |= ALIASED_SFLAG;
-        sflags[i] |= ALIASED_SFLAG;
+        assign_symbol(i, symbols[token_value].value, ATTRIBUTE_T);
+        symbols[token_value].flags |= ALIASED_SFLAG;
+        symbols[i].flags |= ALIASED_SFLAG;
     }
     else
     {   assign_symbol(i, no_attributes++, ATTRIBUTE_T);
@@ -159,12 +159,12 @@ more than",
     if (debugfile_switch)
     {   debug_file_printf("<attribute>");
         debug_file_printf("<identifier>%s</identifier>", name);
-        debug_file_printf("<value>%d</value>", svals[i]);
+        debug_file_printf("<value>%d</value>", symbols[i].value);
         write_debug_locations(get_token_location_end(beginning_debug_location));
         debug_file_printf("</attribute>");
     }
 
-    trace_s(name, svals[i], 0);
+    trace_s(name, symbols[i].value, 0);
     return;
 }
 
@@ -222,9 +222,9 @@ Advanced game to get an extra 62)");
         put_token_back();
         return;
     }
-    if (!(sflags[i] & UNKNOWN_SFLAG))
+    if (!(symbols[i].flags & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
-        ebf_symbol_error("new property name", token_text, typename(stypes[i]), slines[i]);
+        ebf_symbol_error("new property name", token_text, typename(symbols[i].type), symbols[i].line);
         panic_mode_error_recovery();
         put_token_back();
         return;
@@ -234,7 +234,7 @@ Advanced game to get an extra 62)");
     get_next_token();
     directive_keywords.enabled = FALSE;
 
-    if (strcmp(name+strlen(name)-3, "_to") == 0) sflags[i] |= STAR_SFLAG;
+    if (strcmp(name+strlen(name)-3, "_to") == 0) symbols[i].flags |= STAR_SFLAG;
 
     if ((token_type == DIR_KEYWORD_TT) && (token_value == ALIAS_DK))
     {   discard_token_location(beginning_debug_location);
@@ -246,7 +246,7 @@ Advanced game to get an extra 62)");
         }
         get_next_token();
         if (!((token_type == SYMBOL_TT)
-            && (stypes[token_value] == PROPERTY_T)))
+            && (symbols[token_value].type == PROPERTY_T)))
         {   ebf_error("an existing property name after 'alias'",
                 token_text);
             panic_mode_error_recovery();
@@ -254,10 +254,10 @@ Advanced game to get an extra 62)");
             return;
         }
 
-        assign_symbol(i, svals[token_value], PROPERTY_T);
-        trace_s(name, svals[i], 1);
-        sflags[token_value] |= ALIASED_SFLAG;
-        sflags[i] |= ALIASED_SFLAG;
+        assign_symbol(i, symbols[token_value].value, PROPERTY_T);
+        trace_s(name, symbols[i].value, 1);
+        symbols[token_value].flags |= ALIASED_SFLAG;
+        symbols[i].flags |= ALIASED_SFLAG;
         return;
     }
 
@@ -281,13 +281,13 @@ Advanced game to get an extra 62)");
     if (debugfile_switch)
     {   debug_file_printf("<property>");
         debug_file_printf("<identifier>%s</identifier>", name);
-        debug_file_printf("<value>%d</value>", svals[i]);
+        debug_file_printf("<value>%d</value>", symbols[i].value);
         write_debug_locations
             (get_token_location_end(beginning_debug_location));
         debug_file_printf("</property>");
     }
 
-    trace_s(name, svals[i], 1);
+    trace_s(name, symbols[i].value, 1);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -1065,10 +1065,10 @@ static void properties_segment_z(int this_segment)
             return;
         }
 
-        individual_property = (stypes[token_value] != PROPERTY_T);
+        individual_property = (symbols[token_value].type != PROPERTY_T);
 
         if (individual_property)
-        {   if (sflags[token_value] & UNKNOWN_SFLAG)
+        {   if (symbols[token_value].flags & UNKNOWN_SFLAG)
             {   this_identifier_number = no_individual_properties++;
                 assign_symbol(token_value, this_identifier_number,
                     INDIVIDUAL_PROPERTY_T);
@@ -1084,10 +1084,10 @@ static void properties_segment_z(int this_segment)
 
             }
             else
-            {   if (stypes[token_value]==INDIVIDUAL_PROPERTY_T)
-                    this_identifier_number = svals[token_value];
+            {   if (symbols[token_value].type==INDIVIDUAL_PROPERTY_T)
+                    this_identifier_number = symbols[token_value].value;
                 else
-                {   ebf_symbol_error("property name", token_text, typename(stypes[token_value]), slines[token_value]);
+                {   ebf_symbol_error("property name", token_text, typename(symbols[token_value].type), symbols[token_value].line);
                     return;
                 }
             }
@@ -1116,7 +1116,7 @@ static void properties_segment_z(int this_segment)
             individuals_table[i_m+2] = 0;
         }
         else
-        {   if (sflags[token_value] & UNKNOWN_SFLAG)
+        {   if (symbols[token_value].flags & UNKNOWN_SFLAG)
             {   error_named("No such property name as", token_text);
                 return;
             }
@@ -1126,7 +1126,7 @@ not 'private':", token_text);
             if (def_t_s >= defined_this_segment_size)
                 ensure_defined_this_segment(def_t_s*2);
             defined_this_segment[def_t_s++] = token_value;
-            property_number = svals[token_value];
+            property_number = symbols[token_value].value;
 
             next_prop=full_object.l++;
             full_object.pp[next_prop].num = property_number;
@@ -1135,21 +1135,21 @@ not 'private':", token_text);
         for (i=0; i<(def_t_s-1); i++)
             if (defined_this_segment[i] == token_value)
             {   error_named("Property given twice in the same declaration:",
-                    symbs[token_value]);
+                    symbols[token_value].name);
             }
             else
-            if (svals[defined_this_segment[i]] == svals[token_value])
+            if (symbols[defined_this_segment[i]].value == symbols[token_value].value)
             {   char error_b[128];
                 sprintf(error_b,
                     "Property given twice in the same declaration, because \
 the names '%s' and '%s' actually refer to the same property",
-                    symbs[defined_this_segment[i]],
-                    symbs[token_value]);
+                    symbols[defined_this_segment[i]].name,
+                    symbols[token_value].name);
                 error(error_b);
             }
 
         property_name_symbol = token_value;
-        sflags[token_value] |= USED_SFLAG;
+        symbols[token_value].flags |= USED_SFLAG;
 
         length=0;
         do
@@ -1173,12 +1173,12 @@ the names '%s' and '%s' actually refer to the same property",
                 if (current_defn_is_class)
                 {   sprintf(embedded_name,
                         "%s::%s", classname_text,
-                        symbs[property_name_symbol]);
+                        symbols[property_name_symbol].name);
                 }
                 else
                 {   sprintf(embedded_name,
                         "%s.%s", objectname_text,
-                        symbs[property_name_symbol]);
+                        symbols[property_name_symbol].name);
                 }
                 AO.value = parse_routine(NULL, TRUE, embedded_name, FALSE, -1);
                 AO.type = LONG_CONSTANT_OT;
@@ -1210,7 +1210,7 @@ the names '%s' and '%s' actually refer to the same property",
             {   if (length!=0)
                 {
                     if ((token_type == SYMBOL_TT)
-                        && (stypes[token_value]==PROPERTY_T))
+                        && (symbols[token_value].type==PROPERTY_T))
                     {
                         /*  This is not necessarily an error: it's possible
                             to imagine a property whose value is a list
@@ -1232,7 +1232,7 @@ the names '%s' and '%s' actually refer to the same property",
 
             if (length == 64)
             {   error_named("Limit (of 32 values) exceeded for property",
-                    symbs[property_name_symbol]);
+                    symbols[property_name_symbol].name);
                 break;
             }
 
@@ -1276,7 +1276,7 @@ the names '%s' and '%s' actually refer to the same property",
             {
        warning_named("Version 3 limit of 4 values per property exceeded \
 (use -v5 to get 32), so truncating property",
-                    symbs[property_name_symbol]);
+                    symbols[property_name_symbol].name);
                 length = 8;
             }
         }
@@ -1329,10 +1329,10 @@ static void properties_segment_g(int this_segment)
             return;
         }
 
-        individual_property = (stypes[token_value] != PROPERTY_T);
+        individual_property = (symbols[token_value].type != PROPERTY_T);
 
         if (individual_property)
-        {   if (sflags[token_value] & UNKNOWN_SFLAG)
+        {   if (symbols[token_value].flags & UNKNOWN_SFLAG)
             {   this_identifier_number = no_individual_properties++;
                 assign_symbol(token_value, this_identifier_number,
                     INDIVIDUAL_PROPERTY_T);
@@ -1348,10 +1348,10 @@ static void properties_segment_g(int this_segment)
 
             }
             else
-            {   if (stypes[token_value]==INDIVIDUAL_PROPERTY_T)
-                    this_identifier_number = svals[token_value];
+            {   if (symbols[token_value].type==INDIVIDUAL_PROPERTY_T)
+                    this_identifier_number = symbols[token_value].value;
                 else
-                {   ebf_symbol_error("property name", token_text, typename(stypes[token_value]), slines[token_value]);
+                {   ebf_symbol_error("property name", token_text, typename(symbols[token_value].type), symbols[token_value].line);
                     return;
                 }
             }
@@ -1359,7 +1359,7 @@ static void properties_segment_g(int this_segment)
             if (def_t_s >= defined_this_segment_size)
                 ensure_defined_this_segment(def_t_s*2);
             defined_this_segment[def_t_s++] = token_value;
-            property_number = svals[token_value];
+            property_number = symbols[token_value].value;
 
             next_prop=full_object_g.numprops++;
             full_object_g.props[next_prop].num = property_number;
@@ -1370,7 +1370,7 @@ static void properties_segment_g(int this_segment)
             full_object_g.props[next_prop].datalen = 0;
         }
         else
-        {   if (sflags[token_value] & UNKNOWN_SFLAG)
+        {   if (symbols[token_value].flags & UNKNOWN_SFLAG)
             {   error_named("No such property name as", token_text);
                 return;
             }
@@ -1381,7 +1381,7 @@ not 'private':", token_text);
             if (def_t_s >= defined_this_segment_size)
                 ensure_defined_this_segment(def_t_s*2);
             defined_this_segment[def_t_s++] = token_value;
-            property_number = svals[token_value];
+            property_number = symbols[token_value].value;
 
             next_prop=full_object_g.numprops++;
             full_object_g.props[next_prop].num = property_number;
@@ -1394,16 +1394,16 @@ not 'private':", token_text);
         for (i=0; i<(def_t_s-1); i++)
             if (defined_this_segment[i] == token_value)
             {   error_named("Property given twice in the same declaration:",
-                    symbs[token_value]);
+                    symbols[token_value].name);
             }
             else
-            if (svals[defined_this_segment[i]] == svals[token_value])
+            if (symbols[defined_this_segment[i]].value == symbols[token_value].value)
             {   char error_b[128];
                 sprintf(error_b,
                     "Property given twice in the same declaration, because \
 the names '%s' and '%s' actually refer to the same property",
-                    symbs[defined_this_segment[i]],
-                    symbs[token_value]);
+                    symbols[defined_this_segment[i]].name,
+                    symbols[token_value].name);
                 error(error_b);
             }
 
@@ -1412,7 +1412,7 @@ the names '%s' and '%s' actually refer to the same property",
         }
 
         property_name_symbol = token_value;
-        sflags[token_value] |= USED_SFLAG;
+        symbols[token_value].flags |= USED_SFLAG;
 
         length=0;
         do
@@ -1436,12 +1436,12 @@ the names '%s' and '%s' actually refer to the same property",
                 if (current_defn_is_class)
                 {   sprintf(embedded_name,
                         "%s::%s", classname_text,
-                        symbs[property_name_symbol]);
+                        symbols[property_name_symbol].name);
                 }
                 else
                 {   sprintf(embedded_name,
                         "%s.%s", objectname_text,
-                        symbs[property_name_symbol]);
+                        symbols[property_name_symbol].name);
                 }
                 AO.value = parse_routine(NULL, TRUE, embedded_name, FALSE, -1);
                 AO.type = CONSTANT_OT; 
@@ -1473,7 +1473,7 @@ the names '%s' and '%s' actually refer to the same property",
             {   if (length!=0)
                 {
                     if ((token_type == SYMBOL_TT)
-                        && (stypes[token_value]==PROPERTY_T))
+                        && (symbols[token_value].type==PROPERTY_T))
                     {
                         /*  This is not necessarily an error: it's possible
                             to imagine a property whose value is a list
@@ -1495,7 +1495,7 @@ the names '%s' and '%s' actually refer to the same property",
 
             if (length == 32768) /* VENEER_CONSTRAINT_ON_PROP_TABLE_SIZE? */
             {   error_named("Limit (of 32768 values) exceeded for property",
-                    symbs[property_name_symbol]);
+                    symbols[property_name_symbol].name);
                 break;
             }
 
@@ -1576,13 +1576,13 @@ static void attributes_segment(void)
         }
 
         if ((token_type != SYMBOL_TT)
-            || (stypes[token_value] != ATTRIBUTE_T))
+            || (symbols[token_value].type != ATTRIBUTE_T))
         {   ebf_error("name of an already-declared attribute", token_text);
             return;
         }
 
-        attribute_number = svals[token_value];
-        sflags[token_value] |= USED_SFLAG;
+        attribute_number = symbols[token_value].value;
+        symbols[token_value].flags |= USED_SFLAG;
 
         if (!glulx_mode) {
             bitmask = (1 << (7-attribute_number%8));
@@ -1659,13 +1659,13 @@ static void classes_segment(void)
         if ((token_type == SEP_TT) && (token_value == COMMA_SEP)) return;
 
         if ((token_type != SYMBOL_TT)
-            || (stypes[token_value] != CLASS_T))
+            || (symbols[token_value].type != CLASS_T))
         {   ebf_error("name of an already-declared class", token_text);
             return;
         }
 
-        sflags[token_value] |= USED_SFLAG;
-        add_class_to_inheritance_list(svals[token_value]);
+        symbols[token_value].flags |= USED_SFLAG;
+        add_class_to_inheritance_list(symbols[token_value].value);
     } while (TRUE);
 }
 
@@ -1779,9 +1779,9 @@ inconvenience, please contact the maintainers.");
             panic_mode_error_recovery();
             return;
         }
-        if (!(sflags[token_value] & UNKNOWN_SFLAG))
+        if (!(symbols[token_value].flags & UNKNOWN_SFLAG))
         {   discard_token_location(beginning_debug_location);
-            ebf_symbol_error("new class name", token_text, typename(stypes[token_value]), slines[token_value]);
+            ebf_symbol_error("new class name", token_text, typename(symbols[token_value].type), symbols[token_value].line);
             panic_mode_error_recovery();
             return;
         }
@@ -1792,15 +1792,15 @@ inconvenience, please contact the maintainers.");
     strcpy(shortname_buffer, token_text);
 
     assign_symbol(token_value, class_number, CLASS_T);
-    classname_text = symbs[token_value];
+    classname_text = symbols[token_value].name;
 
     if (!glulx_mode) {
-        if (metaclass_flag) sflags[token_value] |= SYSTEM_SFLAG;
+        if (metaclass_flag) symbols[token_value].flags |= SYSTEM_SFLAG;
     }
     else {
         /*  In Glulx, metaclasses have to be backpatched too! So we can't 
             mark it as "system", but we should mark it "used". */
-        if (metaclass_flag) sflags[token_value] |= USED_SFLAG;
+        if (metaclass_flag) symbols[token_value].flags |= USED_SFLAG;
     }
 
     /*  "Class" (object 1) has no parent, whereas all other classes are
@@ -1978,8 +1978,8 @@ extern void make_object(int nearby_flag,
             ebf_error("name for new object or its textual short name",
                 token_text);
         }
-        else if (!(sflags[token_value] & UNKNOWN_SFLAG)) {
-            ebf_symbol_error("new object", token_text, typename(stypes[token_value]), slines[token_value]);
+        else if (!(symbols[token_value].flags & UNKNOWN_SFLAG)) {
+            ebf_symbol_error("new object", token_text, typename(symbols[token_value].type), symbols[token_value].line);
         }
         else
         {   internal_name_symbol = token_value;
@@ -2001,7 +2001,7 @@ extern void make_object(int nearby_flag,
     }
     else
     {   if ((token_type != SYMBOL_TT)
-            || (sflags[token_value] & UNKNOWN_SFLAG))
+            || (symbols[token_value].flags & UNKNOWN_SFLAG))
         {   if (textual_name == NULL)
                 ebf_error("parent object or the object's textual short name",
                     token_text);
@@ -2020,10 +2020,10 @@ extern void make_object(int nearby_flag,
         ebf_error("body of object definition", token_text);
     else
     {   SpecParent:
-        if ((stypes[token_value] == OBJECT_T)
-            || (stypes[token_value] == CLASS_T))
-        {   specified_parent = svals[token_value];
-            sflags[token_value] |= USED_SFLAG;
+        if ((symbols[token_value].type == OBJECT_T)
+            || (symbols[token_value].type == CLASS_T))
+        {   specified_parent = symbols[token_value].value;
+            symbols[token_value].flags |= USED_SFLAG;
         }
         else ebf_error("name of (the parent) object", token_text);
     }
@@ -2047,7 +2047,7 @@ extern void make_object(int nearby_flag,
     if (textual_name == NULL)
     {   if (internal_name_symbol > 0)
             sprintf(shortname_buffer, "(%s)",
-                symbs[internal_name_symbol]);
+                symbols[internal_name_symbol].name);
         else
             sprintf(shortname_buffer, "(%d)", no_objects+1);
     }

--- a/objects.c
+++ b/objects.c
@@ -353,15 +353,15 @@ static int individual_prop_table_size; /* Size of the table of individual
 /*   Arrays used by this file                                                */
 /* ------------------------------------------------------------------------- */
 
-objecttz     *objectsz;                /* Z-code only                        */
+objecttz     *objectsz;              /* Allocated to no_objects; Z-code only */
 memory_list objectsz_memlist;
-objecttg     *objectsg;                /* Glulx only                         */
+objecttg     *objectsg;              /* Allocated to no_objects; Glulx only  */
 static memory_list objectsg_memlist;
-uchar        *objectatts;              /* Glulx only                         */
+uchar        *objectatts;            /* Allocated to no_objects; Glulx only  */
 static memory_list objectatts_memlist;
-static int   *classes_to_inherit_from;
+static int   *classes_to_inherit_from; /* Allocated to no_classes_to_inherit_from */
 static memory_list classes_to_inherit_from_memlist;
-classinfo    *class_info;
+classinfo    *class_info;            /* Allocated up to no_classes           */
 memory_list   class_info_memlist;
 
 /* ------------------------------------------------------------------------- */

--- a/objects.c
+++ b/objects.c
@@ -1135,7 +1135,7 @@ not 'private':", token_text);
         for (i=0; i<(def_t_s-1); i++)
             if (defined_this_segment[i] == token_value)
             {   error_named("Property given twice in the same declaration:",
-                    (char *) symbs[token_value]);
+                    symbs[token_value]);
             }
             else
             if (svals[defined_this_segment[i]] == svals[token_value])
@@ -1143,8 +1143,8 @@ not 'private':", token_text);
                 sprintf(error_b,
                     "Property given twice in the same declaration, because \
 the names '%s' and '%s' actually refer to the same property",
-                    (char *) symbs[defined_this_segment[i]],
-                    (char *) symbs[token_value]);
+                    symbs[defined_this_segment[i]],
+                    symbs[token_value]);
                 error(error_b);
             }
 
@@ -1173,12 +1173,12 @@ the names '%s' and '%s' actually refer to the same property",
                 if (current_defn_is_class)
                 {   sprintf(embedded_name,
                         "%s::%s", classname_text,
-                        (char *) symbs[property_name_symbol]);
+                        symbs[property_name_symbol]);
                 }
                 else
                 {   sprintf(embedded_name,
                         "%s.%s", objectname_text,
-                        (char *) symbs[property_name_symbol]);
+                        symbs[property_name_symbol]);
                 }
                 AO.value = parse_routine(NULL, TRUE, embedded_name, FALSE, -1);
                 AO.type = LONG_CONSTANT_OT;
@@ -1232,7 +1232,7 @@ the names '%s' and '%s' actually refer to the same property",
 
             if (length == 64)
             {   error_named("Limit (of 32 values) exceeded for property",
-                    (char *) symbs[property_name_symbol]);
+                    symbs[property_name_symbol]);
                 break;
             }
 
@@ -1276,7 +1276,7 @@ the names '%s' and '%s' actually refer to the same property",
             {
        warning_named("Version 3 limit of 4 values per property exceeded \
 (use -v5 to get 32), so truncating property",
-                    (char *) symbs[property_name_symbol]);
+                    symbs[property_name_symbol]);
                 length = 8;
             }
         }
@@ -1394,7 +1394,7 @@ not 'private':", token_text);
         for (i=0; i<(def_t_s-1); i++)
             if (defined_this_segment[i] == token_value)
             {   error_named("Property given twice in the same declaration:",
-                    (char *) symbs[token_value]);
+                    symbs[token_value]);
             }
             else
             if (svals[defined_this_segment[i]] == svals[token_value])
@@ -1402,8 +1402,8 @@ not 'private':", token_text);
                 sprintf(error_b,
                     "Property given twice in the same declaration, because \
 the names '%s' and '%s' actually refer to the same property",
-                    (char *) symbs[defined_this_segment[i]],
-                    (char *) symbs[token_value]);
+                    symbs[defined_this_segment[i]],
+                    symbs[token_value]);
                 error(error_b);
             }
 
@@ -1436,12 +1436,12 @@ the names '%s' and '%s' actually refer to the same property",
                 if (current_defn_is_class)
                 {   sprintf(embedded_name,
                         "%s::%s", classname_text,
-                        (char *) symbs[property_name_symbol]);
+                        symbs[property_name_symbol]);
                 }
                 else
                 {   sprintf(embedded_name,
                         "%s.%s", objectname_text,
-                        (char *) symbs[property_name_symbol]);
+                        symbs[property_name_symbol]);
                 }
                 AO.value = parse_routine(NULL, TRUE, embedded_name, FALSE, -1);
                 AO.type = CONSTANT_OT; 
@@ -1495,7 +1495,7 @@ the names '%s' and '%s' actually refer to the same property",
 
             if (length == 32768) /* VENEER_CONSTRAINT_ON_PROP_TABLE_SIZE? */
             {   error_named("Limit (of 32768 values) exceeded for property",
-                    (char *) symbs[property_name_symbol]);
+                    symbs[property_name_symbol]);
                 break;
             }
 
@@ -1792,7 +1792,7 @@ inconvenience, please contact the maintainers.");
     strcpy(shortname_buffer, token_text);
 
     assign_symbol(token_value, class_number, CLASS_T);
-    classname_text = (char *) symbs[token_value];
+    classname_text = symbs[token_value];
 
     if (!glulx_mode) {
         if (metaclass_flag) sflags[token_value] |= SYSTEM_SFLAG;
@@ -2047,7 +2047,7 @@ extern void make_object(int nearby_flag,
     if (textual_name == NULL)
     {   if (internal_name_symbol > 0)
             sprintf(shortname_buffer, "(%s)",
-                (char *) symbs[internal_name_symbol]);
+                symbs[internal_name_symbol]);
         else
             sprintf(shortname_buffer, "(%d)", no_objects+1);
     }

--- a/states.c
+++ b/states.c
@@ -246,17 +246,17 @@ extern int parse_label(void)
     get_next_token();
 
     if ((token_type == SYMBOL_TT) &&
-        (stypes[token_value] == LABEL_T))
-    {   sflags[token_value] |= USED_SFLAG;
-        return(svals[token_value]);
+        (symbols[token_value].type == LABEL_T))
+    {   symbols[token_value].flags |= USED_SFLAG;
+        return(symbols[token_value].value);
     }
 
-    if ((token_type == SYMBOL_TT) && (sflags[token_value] & UNKNOWN_SFLAG))
+    if ((token_type == SYMBOL_TT) && (symbols[token_value].flags & UNKNOWN_SFLAG))
     {   assign_symbol(token_value, next_label, LABEL_T);
         define_symbol_label(token_value);
         next_label++;
-        sflags[token_value] |= CHANGE_SFLAG + USED_SFLAG;
-        return(svals[token_value]);
+        symbols[token_value].flags |= CHANGE_SFLAG + USED_SFLAG;
+        return(symbols[token_value].value);
     }
 
     ebf_error("label name", token_text);
@@ -416,25 +416,25 @@ static void parse_print_z(int finally_return)
                           break;
 
                         case SYMBOL_TT:
-                          if (sflags[token_value] & UNKNOWN_SFLAG)
+                          if (symbols[token_value].flags & UNKNOWN_SFLAG)
                           {   INITAOT(&AO, LONG_CONSTANT_OT);
                               AO.value = token_value;
                               AO.marker = SYMBOL_MV;
                               AO.symindex = token_value;
-                              AO.symtype = stypes[token_value];
-                              AO.symflags = sflags[token_value];
+                              AO.symtype = symbols[token_value].type;
+                              AO.symflags = symbols[token_value].flags;
                           }
                           else
                           {   INITAOT(&AO, LONG_CONSTANT_OT);
-                              AO.value = svals[token_value];
+                              AO.value = symbols[token_value].value;
                               AO.marker = IROUTINE_MV;
                               AO.symindex = token_value;
-                              AO.symtype = stypes[token_value];
-                              AO.symflags = sflags[token_value];
-                              if (stypes[token_value] != ROUTINE_T)
+                              AO.symtype = symbols[token_value].type;
+                              AO.symflags = symbols[token_value].flags;
+                              if (symbols[token_value].type != ROUTINE_T)
                                 ebf_error("printing routine name", token_text);
                           }
-                          sflags[token_value] |= USED_SFLAG;
+                          symbols[token_value].flags |= USED_SFLAG;
 
                           PrintByRoutine:
 
@@ -657,25 +657,25 @@ static void parse_print_g(int finally_return)
                           break;
 
                         case SYMBOL_TT:
-                          if (sflags[token_value] & UNKNOWN_SFLAG)
+                          if (symbols[token_value].flags & UNKNOWN_SFLAG)
                           {   INITAOT(&AO, CONSTANT_OT);
                               AO.value = token_value;
                               AO.marker = SYMBOL_MV;
                               AO.symindex = token_value;
-                              AO.symtype = stypes[token_value];
-                              AO.symflags = sflags[token_value];
+                              AO.symtype = symbols[token_value].type;
+                              AO.symflags = symbols[token_value].flags;
                           }
                           else
                           {   INITAOT(&AO, CONSTANT_OT);
-                              AO.value = svals[token_value];
+                              AO.value = symbols[token_value].value;
                               AO.marker = IROUTINE_MV;
                               AO.symindex = token_value;
-                              AO.symtype = stypes[token_value];
-                              AO.symflags = sflags[token_value];
-                              if (stypes[token_value] != ROUTINE_T)
+                              AO.symtype = symbols[token_value].type;
+                              AO.symflags = symbols[token_value].flags;
+                              if (symbols[token_value].type != ROUTINE_T)
                                 ebf_error("printing routine name", token_text);
                           }
-                          sflags[token_value] |= USED_SFLAG;
+                          symbols[token_value].flags |= USED_SFLAG;
 
                           PrintByRoutine:
 
@@ -746,18 +746,18 @@ static void parse_statement_z(int break_label, int continue_label)
         get_next_token();
         if (token_type == SYMBOL_TT)
         {
-            if (sflags[token_value] & UNKNOWN_SFLAG)
+            if (symbols[token_value].flags & UNKNOWN_SFLAG)
             {   assign_symbol(token_value, next_label, LABEL_T);
-                sflags[token_value] |= USED_SFLAG;
+                symbols[token_value].flags |= USED_SFLAG;
                 assemble_label_no(next_label);
                 define_symbol_label(token_value);
                 next_label++;
             }
             else
-            {   if (stypes[token_value] != LABEL_T) goto LabelError;
-                if (sflags[token_value] & CHANGE_SFLAG)
-                {   sflags[token_value] &= (~(CHANGE_SFLAG));
-                    assemble_label_no(svals[token_value]);
+            {   if (symbols[token_value].type != LABEL_T) goto LabelError;
+                if (symbols[token_value].flags & CHANGE_SFLAG)
+                {   symbols[token_value].flags &= (~(CHANGE_SFLAG));
+                    assemble_label_no(symbols[token_value].value);
                     define_symbol_label(token_value);
                 }
                 else error_named("Duplicate definition of label:", token_text);
@@ -1130,7 +1130,7 @@ static void parse_statement_z(int break_label, int continue_label)
                          ln = clear_attr_zc;
                      else
                      {   if ((token_type == SYMBOL_TT)
-                             && (stypes[token_value] != ATTRIBUTE_T))
+                             && (symbols[token_value].type != ATTRIBUTE_T))
                            warning_named("This is not a declared Attribute:",
                              token_text);
                          ln = set_attr_zc;
@@ -1302,8 +1302,8 @@ static void parse_statement_z(int break_label, int continue_label)
                      AO.value = token_value;
                  else
                  if ((token_type == SYMBOL_TT) &&
-                     (stypes[token_value] == GLOBAL_VARIABLE_T))
-                     AO.value = svals[token_value];
+                     (symbols[token_value].type == GLOBAL_VARIABLE_T))
+                     AO.value = symbols[token_value].value;
                  else
                  {   ebf_error("'objectloop' variable", token_text);
                      panic_mode_error_recovery(); break;
@@ -1726,18 +1726,18 @@ static void parse_statement_g(int break_label, int continue_label)
         get_next_token();
         if (token_type == SYMBOL_TT)
         {
-            if (sflags[token_value] & UNKNOWN_SFLAG)
+            if (symbols[token_value].flags & UNKNOWN_SFLAG)
             {   assign_symbol(token_value, next_label, LABEL_T);
-                sflags[token_value] |= USED_SFLAG;
+                symbols[token_value].flags |= USED_SFLAG;
                 assemble_label_no(next_label);
                 define_symbol_label(token_value);
                 next_label++;
             }
             else
-            {   if (stypes[token_value] != LABEL_T) goto LabelError;
-                if (sflags[token_value] & CHANGE_SFLAG)
-                {   sflags[token_value] &= (~(CHANGE_SFLAG));
-                    assemble_label_no(svals[token_value]);
+            {   if (symbols[token_value].type != LABEL_T) goto LabelError;
+                if (symbols[token_value].flags & CHANGE_SFLAG)
+                {   symbols[token_value].flags &= (~(CHANGE_SFLAG));
+                    assemble_label_no(symbols[token_value].value);
                     define_symbol_label(token_value);
                 }
                 else error_named("Duplicate definition of label:", token_text);
@@ -2098,7 +2098,7 @@ static void parse_statement_g(int break_label, int continue_label)
                          ln = 0;
                      else
                      {   if ((token_type == SYMBOL_TT)
-                             && (stypes[token_value] != ATTRIBUTE_T))
+                             && (symbols[token_value].type != ATTRIBUTE_T))
                            warning_named("This is not a declared Attribute:",
                              token_text);
                          ln = 1;
@@ -2319,8 +2319,8 @@ static void parse_statement_g(int break_label, int continue_label)
                      INITAOTV(&AO, LOCALVAR_OT, token_value);
                  }
                  else if ((token_type == SYMBOL_TT) &&
-                   (stypes[token_value] == GLOBAL_VARIABLE_T)) {
-                     INITAOTV(&AO, GLOBALVAR_OT, svals[token_value]);
+                   (symbols[token_value].type == GLOBAL_VARIABLE_T)) {
+                     INITAOTV(&AO, GLOBALVAR_OT, symbols[token_value].value);
                  }
                  else {
                      ebf_error("'objectloop' variable", token_text);
@@ -2422,7 +2422,7 @@ static void parse_statement_g(int break_label, int continue_label)
                  sequence_point_follows = TRUE;
                  ln = symbol_index("Class", -1);
                  INITAOT(&AO2, CONSTANT_OT);
-                 AO2.value = svals[ln];
+                 AO2.value = symbols[ln].value;
                  AO2.marker = OBJECT_MV;
                  assembleg_store(AO, AO2);
 

--- a/symbols.c
+++ b/symbols.c
@@ -17,24 +17,32 @@ int no_symbols;                        /* Total number of symbols defined    */
 int no_named_constants;                         /* Copied into story file    */
 
 /* ------------------------------------------------------------------------- */
-/*   Plus six arrays.  Each symbol has its own index n (an int32) and        */
+/*   Plus an array of symbolinfo.  Each symbol has its own index n (an       */
+/*   int32) in the array. The struct there contains:                         */
 /*                                                                           */
-/*       symbols[n].value   is its value (must be 32 bits wide, i.e. an int32, tho'  */
-/*                  it is used to hold an unsigned 16 bit Z-machine value)   */
-/*       symbols[n].flags  holds flags (see "header.h" for a list)                  */
-/*       symbols[n].type  is the "type", distinguishing between the data type of   */
+/*       value   is its value. In Z-code, this holds both the 16-bit value   */
+/*                  and the 16-bit backpatch marker, so it is an int32.      */
+/*       marker   is the backpatch marker in Glulx.                          */
+/*       flags  holds flags (see "header.h" for a list of ?_SFLAGS)          */
+/*       type  is the "type", distinguishing between the data type of        */
 /*                  different kinds of constants/variables.                  */
-/*                  (See the "typename()" below.)                            */
-/*       symbols[n].name   is the name of the symbol, in the same case form as      */
+/*                  (A ?_T constant; see the "typename()" below.)            */
+/*       name   is the name of the symbol, in the same case form as          */
 /*                  when created.                                            */
-/*       symbols[n].line  is the source line on which the symbol value was first   */
+/*       line  is the source line on which the symbol value was first        */
 /*                  assigned                                                 */
-/*       symbol_debug_backpatch_positions[n]                                 */
+/*       next_entry  is the forward link in the symbol hash table. (See      */
+/*                  start_of_list, below.)                                   */
+/*                                                                           */
+/*   When generating a debug file (-k switch), we also allocate an array     */
+/*   of symboldebuginfo, which contains:                                     */
+/*                                                                           */
+/*       backpatch_pos                                                       */
 /*                  is a file position in the debug information file where   */
 /*                  the symbol's value should be written after backpatching, */
 /*                  or else the null position if the value was known and     */
 /*                  written beforehand                                       */
-/*       replacement_debug_backpatch_positions[n]                            */
+/*       replacement_backpatch_pos                                           */
 /*                  is a file position in the debug information file where   */
 /*                  the symbol's name can be erased if it is replaced, or    */
 /*                  else null if the name will never need to be replaced     */

--- a/symbols.c
+++ b/symbols.c
@@ -253,11 +253,8 @@ extern int symbol_index(char *p, int hashcode)
             = symbols_free_space;
         if (symbols_free_space+len+1 >= symbols_ceiling)
         {
-            error_numbered("Symbol exceeds the maximum possible length, which is", SYMBOLS_CHUNK_SIZE);
-            /* Avoid an overrun in error recovery. This messes up the
-               hashcode, which will lead to further errors; too bad. */
-            p = "too_long";
-            len = strlen(p);
+            /* This should be impossible, since SYMBOLS_CHUNK_SIZE > MAX_IDENTIFIER_LENGTH. */
+            fatalerror("Symbol exceeds the maximum possible length");
         }
     }
 

--- a/symbols.c
+++ b/symbols.c
@@ -54,8 +54,7 @@ int no_named_constants;                         /* Copied into story file    */
   brief_location  *slines;
   int    *sflags;
   uchar  *stypes;
-  maybe_file_position  *symbol_debug_backpatch_positions;
-  maybe_file_position  *replacement_debug_backpatch_positions;
+  symboldebuginfo *symbol_debug_info;
 
 /* ------------------------------------------------------------------------- */
 /*   Memory to hold the text of symbol names: note that this memory is       */
@@ -266,9 +265,9 @@ extern int symbol_index(char *p, int hashcode)
     slines[no_symbols]  =  get_brief_location(&ErrorReport);
     if (debugfile_switch)
     {   nullify_debug_file_position
-            (&symbol_debug_backpatch_positions[no_symbols]);
+            (&symbol_debug_info[no_symbols].backpatch_pos);
         nullify_debug_file_position
-            (&replacement_debug_backpatch_positions[no_symbols]);
+            (&symbol_debug_info[no_symbols].replacement_backpatch_pos);
     }
 
     if (track_unused_routines)
@@ -1382,6 +1381,7 @@ extern void init_symbols_vars(void)
     sflags = NULL;
     next_entry = NULL;
     start_of_list = NULL;
+    symbol_debug_info = NULL;
 
     symbol_name_space_chunks = NULL;
     no_symbol_name_space_chunks = 0;
@@ -1425,12 +1425,10 @@ extern void symbols_allocate_arrays(void)
     stypes     = my_calloc(sizeof(char),    MAX_SYMBOLS, "symbol types");
     sflags     = my_calloc(sizeof(int),     MAX_SYMBOLS, "symbol flags");
     if (debugfile_switch)
-    {   symbol_debug_backpatch_positions =
-            my_calloc(sizeof(maybe_file_position), MAX_SYMBOLS,
-                      "symbol debug information backpatch positions");
-        replacement_debug_backpatch_positions =
-            my_calloc(sizeof(maybe_file_position), MAX_SYMBOLS,
-                      "replacement debug information backpatch positions");
+    {
+        symbol_debug_info =
+            my_calloc(sizeof(symboldebuginfo), MAX_SYMBOLS,
+                      "symbol debug backpatch info");
     }
     next_entry = my_calloc(sizeof(int),     MAX_SYMBOLS,
                      "symbol linked-list forward links");
@@ -1488,12 +1486,10 @@ extern void symbols_free_arrays(void)
     my_free(&stypes, "symbol types");
     my_free(&sflags, "symbol flags");
     if (debugfile_switch)
-    {   my_free
-            (&symbol_debug_backpatch_positions,
-             "symbol debug information backpatch positions");
+    {
         my_free
-            (&replacement_debug_backpatch_positions,
-             "replacement debug information backpatch positions");
+            (&symbol_debug_info,
+             "symbol debug backpatch info");
     }
     my_free(&next_entry, "symbol linked-list forward links");
     my_free(&start_of_list, "hash code list beginnings");

--- a/symbols.c
+++ b/symbols.c
@@ -25,8 +25,8 @@ int no_named_constants;                         /* Copied into story file    */
 /*       stypes[n]  is the "type", distinguishing between the data type of   */
 /*                  different kinds of constants/variables.                  */
 /*                  (See the "typename()" below.)                            */
-/*       symbs[n]   (needs to be cast to (char *) to be used) is the name    */
-/*                  of the symbol, in the same case form as when created.    */
+/*       symbs[n]   is the name of the symbol, in the same case form as      */
+/*                  when created.                                            */
 /*       slines[n]  is the source line on which the symbol value was first   */
 /*                  assigned                                                 */
 /*       symbol_debug_backpatch_positions[n]                                 */
@@ -42,10 +42,6 @@ int no_named_constants;                         /* Copied into story file    */
 /*   Comparison is case insensitive.                                         */
 /*   Note that local variable names are not entered into the symbols table,  */
 /*   as their numbers and scope are too limited for this to be efficient.    */
-/* ------------------------------------------------------------------------- */
-/*   Caveat editor: some array types are set up to work even on machines     */
-/*   where sizeof(int32 *) differs from, e.g., sizeof(char *): so do not     */
-/*   alter the types unless you understand what is going on!                 */
 /* ------------------------------------------------------------------------- */
 
   char  **symbs;
@@ -212,7 +208,7 @@ extern int symbol_index(char *p, int hashcode)
     do
     {   if (this == -1) break;
 
-        r = (char *)symbs[this];
+        r = symbs[this];
         new_entry = strcmpcis(r, p);
         if (new_entry == 0) 
         {
@@ -249,14 +245,14 @@ extern int symbol_index(char *p, int hashcode)
         if (no_symbol_name_space_chunks >= MAX_SYMBOL_CHUNKS)
             memoryerror("SYMBOLS_CHUNK_SIZE", SYMBOLS_CHUNK_SIZE);
         symbol_name_space_chunks[no_symbol_name_space_chunks++]
-            = (char *) symbols_free_space;
+            = symbols_free_space;
         if (symbols_free_space+strlen(p)+1 >= symbols_ceiling)
             memoryerror("SYMBOLS_CHUNK_SIZE", SYMBOLS_CHUNK_SIZE);
     }
 
-    strcpy((char *) symbols_free_space, p);
+    strcpy(symbols_free_space, p);
     symbs[no_symbols]   = symbols_free_space;
-    symbols_free_space += strlen((char *)symbols_free_space) + 1;
+    symbols_free_space += strlen(symbols_free_space) + 1;
 
     svals[no_symbols]   =  0x100; /* ###-wrong? Would this fix the
                                      unbound-symbol-causes-asm-error? */
@@ -283,7 +279,7 @@ extern void end_symbol_scope(int k)
     */
 
     int j;
-    j = hash_code_from_string((char *) symbs[k]);
+    j = hash_code_from_string(symbs[k]);
     if (start_of_list[j] == k)
     {   start_of_list[j] = next_entry[k];
         return;
@@ -347,7 +343,7 @@ static void describe_flags(int flags)
 
 extern void describe_symbol(int k)
 {   printf("%4d  %-16s  %2d:%04d  %04x  %s  ",
-        k, (char *) (symbs[k]), 
+        k, (symbs[k]), 
         (int)(slines[k].file_index),
         (int)(slines[k].line_number),
         svals[k], typename(stypes[k]));
@@ -383,7 +379,7 @@ extern void issue_unused_warnings(void)
              & (SYSTEM_SFLAG + UNKNOWN_SFLAG + EXPORT_SFLAG
                 + INSF_SFLAG + USED_SFLAG + REPLACE_SFLAG)) == 0)
              && (stypes[i] != OBJECT_T))
-            dbnu_warning(typename(stypes[i]), (char *) symbs[i], slines[i]);
+            dbnu_warning(typename(stypes[i]), symbs[i], slines[i]);
     }
 }
 
@@ -418,13 +414,13 @@ extern void write_the_identifier_names(void)
         if ((t == INDIVIDUAL_PROPERTY_T) || (t == PROPERTY_T))
         {   if (sflags[i] & ALIASED_SFLAG)
             {   if (individual_name_strings[svals[i]] == 0)
-                {   sprintf(idname_string, "%s", (char *) symbs[i]);
+                {   sprintf(idname_string, "%s", symbs[i]);
 
                     for (j=i+1, k=0; (j<no_symbols && k<3); j++)
                     {   if ((stypes[j] == stypes[i])
                             && (svals[j] == svals[i]))
                         {   sprintf(idname_string+strlen(idname_string),
-                                "/%s", (char *) symbs[j]);
+                                "/%s", symbs[j]);
                             k++;
                         }
                     }
@@ -434,7 +430,7 @@ extern void write_the_identifier_names(void)
                 }
             }
             else
-            {   sprintf(idname_string, "%s", (char *) symbs[i]);
+            {   sprintf(idname_string, "%s", symbs[i]);
 
                 individual_name_strings[svals[i]]
                     = compile_string(idname_string, STRCTX_SYMBOL);
@@ -443,13 +439,13 @@ extern void write_the_identifier_names(void)
         if (t == ATTRIBUTE_T)
         {   if (sflags[i] & ALIASED_SFLAG)
             {   if (attribute_name_strings[svals[i]] == null_value)
-                {   sprintf(idname_string, "%s", (char *) symbs[i]);
+                {   sprintf(idname_string, "%s", symbs[i]);
 
                     for (j=i+1, k=0; (j<no_symbols && k<3); j++)
                     {   if ((stypes[j] == stypes[i])
                             && (svals[j] == svals[i]))
                         {   sprintf(idname_string+strlen(idname_string),
-                                "/%s", (char *) symbs[j]);
+                                "/%s", symbs[j]);
                             k++;
                         }
                     }
@@ -459,14 +455,14 @@ extern void write_the_identifier_names(void)
                 }
             }
             else
-            {   sprintf(idname_string, "%s", (char *) symbs[i]);
+            {   sprintf(idname_string, "%s", symbs[i]);
 
                 attribute_name_strings[svals[i]]
                     = compile_string(idname_string, STRCTX_SYMBOL);
             }
         }
         if (sflags[i] & ACTION_SFLAG)
-        {   sprintf(idname_string, "%s", (char *) symbs[i]);
+        {   sprintf(idname_string, "%s", symbs[i]);
             idname_string[strlen(idname_string)-3] = 0;
 
             if (debugfile_switch)
@@ -484,7 +480,7 @@ extern void write_the_identifier_names(void)
 
     for (i=0; i<no_symbols; i++)
     {   if (stypes[i] == FAKE_ACTION_T)
-        {   sprintf(idname_string, "%s", (char *) symbs[i]);
+        {   sprintf(idname_string, "%s", symbs[i]);
             idname_string[strlen(idname_string)-3] = 0;
 
             action_name_strings[svals[i]
@@ -495,7 +491,7 @@ extern void write_the_identifier_names(void)
 
     for (j=0; j<no_arrays; j++)
     {   i = array_symbols[j];
-        sprintf(idname_string, "%s", (char *) symbs[i]);
+        sprintf(idname_string, "%s", symbs[i]);
 
         array_name_strings[j]
             = compile_string(idname_string, STRCTX_SYMBOL);
@@ -503,14 +499,14 @@ extern void write_the_identifier_names(void)
   if (define_INFIX_switch)
   { for (i=0; i<no_symbols; i++)
     {   if (stypes[i] == GLOBAL_VARIABLE_T)
-        {   sprintf(idname_string, "%s", (char *) symbs[i]);
+        {   sprintf(idname_string, "%s", symbs[i]);
             array_name_strings[no_arrays + svals[i] -16]
                 = compile_string(idname_string, STRCTX_SYMBOL);
         }
     }
 
     for (i=0; i<no_named_routines; i++)
-    {   sprintf(idname_string, "%s", (char *) symbs[named_routine_symbols[i]]);
+    {   sprintf(idname_string, "%s", symbs[named_routine_symbols[i]]);
             array_name_strings[no_arrays + no_globals + i]
                 = compile_string(idname_string, STRCTX_SYMBOL);
     }
@@ -519,7 +515,7 @@ extern void write_the_identifier_names(void)
     {   if (((stypes[i] == OBJECT_T) || (stypes[i] == CLASS_T)
             || (stypes[i] == CONSTANT_T))
             && ((sflags[i] & (UNKNOWN_SFLAG+ACTION_SFLAG))==0))
-        {   sprintf(idname_string, "%s", (char *) symbs[i]);
+        {   sprintf(idname_string, "%s", symbs[i]);
             array_name_strings[no_arrays + no_globals + no_named_routines
                 + no_named_constants++]
                 = compile_string(idname_string, STRCTX_SYMBOL);
@@ -800,7 +796,7 @@ extern void add_symbol_replacement_mapping(int original, int renamed)
     int ix;
 
     if (original == renamed) {
-        error_named("A routine cannot be 'Replace'd to itself:", (char *)symbs[original]);
+        error_named("A routine cannot be 'Replace'd to itself:", symbs[original]);
         return;        
     }
 
@@ -821,10 +817,10 @@ extern void add_symbol_replacement_mapping(int original, int renamed)
 
     for (ix=0; ix<symbol_replacements_count; ix++) {
         if (original == symbol_replacements[ix].original_symbol) {
-            error_named("A routine cannot be 'Replace'd to more than one new name:", (char *)symbs[original]);
+            error_named("A routine cannot be 'Replace'd to more than one new name:", symbs[original]);
         }
         if (renamed == symbol_replacements[ix].original_symbol) {
-            error_named("A routine cannot be 'Replace'd to a 'Replace'd name:", (char *)symbs[original]);
+            error_named("A routine cannot be 'Replace'd to a 'Replace'd name:", symbs[original]);
         }
     }
 
@@ -1105,7 +1101,7 @@ extern void locate_dead_functions(void)
         addr = svals[symbol] * (glulx_mode ? 1 : scale_factor);
         tofunc = df_function_for_address(addr);
         if (!tofunc) {
-            error_named("Internal error in stripping: global ROUTINE_T symbol is not found in df_function map:", (char *)symbs[symbol]);
+            error_named("Internal error in stripping: global ROUTINE_T symbol is not found in df_function map:", symbs[symbol]);
             continue;
         }
         /* A function may be marked here more than once. That's fine. */
@@ -1162,7 +1158,7 @@ extern void locate_dead_functions(void)
                 addr = svals[symbol] * (glulx_mode ? 1 : scale_factor);
                 tofunc = df_function_for_address(addr);
                 if (!tofunc) {
-                    error_named("Internal error in stripping: function ROUTINE_T symbol is not found in df_function map:", (char *)symbs[symbol]);
+                    error_named("Internal error in stripping: function ROUTINE_T symbol is not found in df_function map:", symbs[symbol]);
                     continue;
                 }
                 if (tofunc->usage)

--- a/symbols.c
+++ b/symbols.c
@@ -545,18 +545,15 @@ static void assign_symbol_base(int index, int32 value, int type)
 
 extern void assign_symbol(int index, int32 value, int type)
 {
-    if (!glulx_mode) {
-        assign_symbol_base(index, value, type);
-    }
-    else {
-        smarks[index] = 0;
-        assign_symbol_base(index, value, type);
-    }
+    smarks[index] = 0;
+    assign_symbol_base(index, value, type);
 }
 
 extern void assign_marked_symbol(int index, int marker, int32 value, int type)
 {
     if (!glulx_mode) {
+        /* In Z-code, marker is encoded into value */
+        smarks[index] = 0;
         assign_symbol_base(index, (int32)marker*0x10000 + (value % 0x10000),
             type);
     }
@@ -1419,8 +1416,7 @@ extern void symbols_allocate_arrays(void)
 {
     symbs      = my_calloc(sizeof(char *),  MAX_SYMBOLS, "symbols");
     svals      = my_calloc(sizeof(int32),   MAX_SYMBOLS, "symbol values");
-    if (glulx_mode)
-        smarks = my_calloc(sizeof(int),     MAX_SYMBOLS, "symbol markers");
+    smarks     = my_calloc(sizeof(int),     MAX_SYMBOLS, "symbol markers");
     slines     = my_calloc(sizeof(brief_location), MAX_SYMBOLS, "symbol lines");
     stypes     = my_calloc(sizeof(char),    MAX_SYMBOLS, "symbol types");
     sflags     = my_calloc(sizeof(int),     MAX_SYMBOLS, "symbol flags");

--- a/symbols.c
+++ b/symbols.c
@@ -48,7 +48,7 @@ int no_named_constants;                         /* Copied into story file    */
   int32  *svals;
   int    *smarks;            /* Glulx-only */
   brief_location  *slines;
-  int    *sflags;
+  unsigned int    *sflags;
   uchar  *stypes;
   symboldebuginfo *symbol_debug_info;
 
@@ -1415,7 +1415,7 @@ extern void symbols_allocate_arrays(void)
     smarks     = my_calloc(sizeof(int),     MAX_SYMBOLS, "symbol markers");
     slines     = my_calloc(sizeof(brief_location), MAX_SYMBOLS, "symbol lines");
     stypes     = my_calloc(sizeof(char),    MAX_SYMBOLS, "symbol types");
-    sflags     = my_calloc(sizeof(int),     MAX_SYMBOLS, "symbol flags");
+    sflags     = my_calloc(sizeof(unsigned int),     MAX_SYMBOLS, "symbol flags");
     if (debugfile_switch)
     {
         symbol_debug_info =

--- a/symbols.c
+++ b/symbols.c
@@ -62,7 +62,7 @@ static memory_list symbol_debug_info_memlist;
 /*   allocated as needed in chunks of size SYMBOLS_CHUNK_SIZE.               */
 /* ------------------------------------------------------------------------- */
 
-#define MAX_SYMBOL_CHUNKS (100)
+#define MAX_SYMBOL_CHUNKS (100) /*### to do next*/
 
 static char *symbols_free_space,        /* Next byte free to hold new names  */
            *symbols_ceiling;            /* Pointer to the end of the current

--- a/symbols.c
+++ b/symbols.c
@@ -48,7 +48,7 @@ int no_named_constants;                         /* Copied into story file    */
 /*   alter the types unless you understand what is going on!                 */
 /* ------------------------------------------------------------------------- */
 
-  int32  **symbs;
+  char  **symbs;
   int32  *svals;
   int    *smarks;            /* Glulx-only */
   brief_location  *slines;
@@ -63,7 +63,7 @@ int no_named_constants;                         /* Copied into story file    */
 
 #define MAX_SYMBOL_CHUNKS (100)
 
-static uchar *symbols_free_space,       /* Next byte free to hold new names  */
+static char *symbols_free_space,        /* Next byte free to hold new names  */
            *symbols_ceiling;            /* Pointer to the end of the current
                                            allocation of memory for names    */
 
@@ -255,7 +255,7 @@ extern int symbol_index(char *p, int hashcode)
     }
 
     strcpy((char *) symbols_free_space, p);
-    symbs[no_symbols] = (int32 *) symbols_free_space;
+    symbs[no_symbols]   = symbols_free_space;
     symbols_free_space += strlen((char *)symbols_free_space) + 1;
 
     svals[no_symbols]   =  0x100; /* ###-wrong? Would this fix the

--- a/symbols.c
+++ b/symbols.c
@@ -52,9 +52,9 @@ int no_named_constants;                         /* Copied into story file    */
 /*   as their numbers and scope are too limited for this to be efficient.    */
 /* ------------------------------------------------------------------------- */
 
-symbolinfo *symbols;
+symbolinfo *symbols;                           /* Allocated up to no_symbols */
 static memory_list symbols_memlist;
-symboldebuginfo *symbol_debug_info;
+symboldebuginfo *symbol_debug_info;            /* Allocated up to no_symbols */
 static memory_list symbol_debug_info_memlist;
 
 /* ------------------------------------------------------------------------- */

--- a/symbols.c
+++ b/symbols.c
@@ -53,11 +53,7 @@ int no_named_constants;                         /* Copied into story file    */
   int    *smarks;            /* Glulx-only */
   brief_location  *slines;
   int    *sflags;
-#ifdef VAX
-  char   *stypes;            /* In VAX C, insanely, "signed char" is illegal */
-#else
-  signed char *stypes;
-#endif
+  uchar  *stypes;
   maybe_file_position  *symbol_debug_backpatch_positions;
   maybe_file_position  *replacement_debug_backpatch_positions;
 

--- a/syntax.c
+++ b/syntax.c
@@ -171,9 +171,9 @@ extern int parse_directive(int internal_flag)
         {   ebf_error("routine name", token_text);
             return(FALSE);
         }
-        if ((!(sflags[token_value] & UNKNOWN_SFLAG))
-            && (!(sflags[token_value] & REPLACE_SFLAG)))
-        {   ebf_symbol_error("routine name", token_text, typename(stypes[token_value]), slines[token_value]);
+        if ((!(symbols[token_value].flags & UNKNOWN_SFLAG))
+            && (!(symbols[token_value].flags & REPLACE_SFLAG)))
+        {   ebf_symbol_error("routine name", token_text, typename(symbols[token_value].type), symbols[token_value].line);
             return(FALSE);
         }
 
@@ -182,7 +182,7 @@ extern int parse_directive(int internal_flag)
         rep_symbol = routine_symbol;
         is_renamed = find_symbol_replacement(&rep_symbol);
 
-        if ((sflags[routine_symbol] & REPLACE_SFLAG) 
+        if ((symbols[routine_symbol].flags & REPLACE_SFLAG) 
             && !is_renamed && (is_systemfile()))
         {   /* The function is definitely being replaced (system_file
                always loses priority in a replacement) but is not
@@ -201,9 +201,9 @@ extern int parse_directive(int internal_flag)
         {   /* Parse the function definition and assign its symbol. */
             assign_symbol(routine_symbol,
                 parse_routine(lexical_source, FALSE,
-                    symbs[routine_symbol], FALSE, routine_symbol),
+                    symbols[routine_symbol].name, FALSE, routine_symbol),
                 ROUTINE_T);
-            slines[routine_symbol] = routine_starts_line;
+            symbols[routine_symbol].line = routine_starts_line;
         }
 
         if (is_renamed) {
@@ -211,8 +211,8 @@ extern int parse_directive(int internal_flag)
                The first time we see a definition for symbol X, we
                copy it to Y -- that's the "original" form of the
                function. */
-            if (svals[rep_symbol] == 0) {
-                assign_symbol(rep_symbol, svals[routine_symbol], ROUTINE_T);
+            if (symbols[rep_symbol].value == 0) {
+                assign_symbol(rep_symbol, symbols[routine_symbol].value, ROUTINE_T);
             }
         }
 
@@ -224,13 +224,13 @@ extern int parse_directive(int internal_flag)
         return TRUE;
     }
 
-    if ((token_type == SYMBOL_TT) && (stypes[token_value] == CLASS_T))
+    if ((token_type == SYMBOL_TT) && (symbols[token_value].type == CLASS_T))
     {   if (internal_flag)
         {   error("It is illegal to nest an object in a routine using '#classname'");
             return(TRUE);
         }
-        sflags[token_value] |= USED_SFLAG;
-        make_object(FALSE, NULL, -1, -1, svals[token_value]);
+        symbols[token_value].flags |= USED_SFLAG;
+        make_object(FALSE, NULL, -1, -1, symbols[token_value].value);
         return TRUE;
     }
 
@@ -477,7 +477,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         || ((trace_fns_setting==1) && (is_systemfile()==FALSE)))
         debug_flag = TRUE;
     if ((embedded_flag == FALSE) && (veneer_mode == FALSE) && debug_flag)
-        sflags[r_symbol] |= STAR_SFLAG;
+        symbols[r_symbol].flags |= STAR_SFLAG;
 
     packed_address = assemble_routine_header(no_locals, debug_flag,
         name, embedded_flag, r_symbol);

--- a/syntax.c
+++ b/syntax.c
@@ -201,7 +201,7 @@ extern int parse_directive(int internal_flag)
         {   /* Parse the function definition and assign its symbol. */
             assign_symbol(routine_symbol,
                 parse_routine(lexical_source, FALSE,
-                    (char *) symbs[routine_symbol], FALSE, routine_symbol),
+                    symbs[routine_symbol], FALSE, routine_symbol),
                 ROUTINE_T);
             slines[routine_symbol] = routine_starts_line;
         }

--- a/tables.c
+++ b/tables.c
@@ -970,9 +970,9 @@ or less.");
             }
 
             printf("Allocated:\n\
-%6d symbols (maximum %4d)    %8ld bytes of memory\n\
+%6d symbols                    %8ld bytes of memory\n\
 Out:   Version %d \"%s\" %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
-                 no_symbols, MAX_SYMBOLS,
+                 no_symbols,
                  (long int) malloced_bytes,
                  version_number,
                  version_name(version_number),
@@ -1658,9 +1658,9 @@ table format requested (producing number 2 format instead)");
             {char serialnum[8];
             write_serial_number(serialnum);
             printf("Allocated:\n\
-%6d symbols (maximum %4d)    %8ld bytes of memory\n\
+%6d symbols                    %8ld bytes of memory\n\
 Out:   %s %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
-                 no_symbols, MAX_SYMBOLS,
+                 no_symbols,
                  (long int) malloced_bytes,
                  version_name(version_number),
                  output_called,

--- a/tables.c
+++ b/tables.c
@@ -467,7 +467,7 @@ static void construct_storyfile_z(void)
 
     if (define_INFIX_switch)
     {   for (i=0, k=1, l=0; i<no_named_routines; i++)
-        {   if (sflags[named_routine_symbols[i]] & STAR_SFLAG) l=l+k;
+        {   if (symbols[named_routine_symbols[i]].flags & STAR_SFLAG) l=l+k;
             k=k*2;
             if (k==256) { p[mark++] = l; k=1; l=0; }
         }

--- a/text.c
+++ b/text.c
@@ -83,10 +83,13 @@ static int unicode_entity_index(int32 unicode);
 /*   Abbreviation arrays                                                     */
 /* ------------------------------------------------------------------------- */
 
-abbreviation *abbreviations;
+abbreviation *abbreviations;             /* Allocated up to no_abbreviations */
 static memory_list abbreviations_memlist;
-uchar *abbreviations_at;                 /* Memory to hold the text of any
-                                          abbreviation strings declared      */
+
+/* Memory to hold the text of any abbreviation strings declared. This is
+   counted in units of MAX_ABBREV_LENGTH bytes. (An abbreviation must fit
+   in that many bytes, null included.)                                       */
+uchar *abbreviations_at;                 /* Allocated up to no_abbreviations */
 static memory_list abbreviations_at_memlist;
 
 /* ------------------------------------------------------------------------- */

--- a/veneer.c
+++ b/veneer.c
@@ -33,8 +33,8 @@ extern void compile_initial_routine(void)
     assign_symbol(j,
         assemble_routine_header(0, FALSE, "Main__", FALSE, j),
         ROUTINE_T);
-    sflags[j] |= SYSTEM_SFLAG + USED_SFLAG;
-    if (trace_fns_setting==3) sflags[j] |= STAR_SFLAG;
+    symbols[j].flags |= SYSTEM_SFLAG + USED_SFLAG;
+    if (trace_fns_setting==3) symbols[j].flags |= STAR_SFLAG;
 
     if (!glulx_mode) {
 
@@ -2195,8 +2195,8 @@ static void compile_symbol_table_routine(void)
     assign_symbol(j,
         assemble_routine_header(2, FALSE, "Symb__Tab", FALSE, j),
         ROUTINE_T);
-    sflags[j] |= SYSTEM_SFLAG + USED_SFLAG;
-    if (trace_fns_setting==3) sflags[j] |= STAR_SFLAG;
+    symbols[j].flags |= SYSTEM_SFLAG + USED_SFLAG;
+    if (trace_fns_setting==3) symbols[j].flags |= STAR_SFLAG;
 
   if (!glulx_mode) {
 
@@ -2242,11 +2242,11 @@ static void compile_symbol_table_routine(void)
             AO3.marker = 0;
             assemblez_store(temp_var2, AO3);
             AO3.value = array_types[j];
-            if (sflags[array_symbols[j]] & (INSF_SFLAG+SYSTEM_SFLAG))
+            if (symbols[array_symbols[j]].flags & (INSF_SFLAG+SYSTEM_SFLAG))
                 AO3.value = AO3.value + 16;
             AO3.marker = 0;
             assemblez_store(temp_var3, AO3);
-            AO3.value = svals[array_symbols[j]];
+            AO3.value = symbols[array_symbols[j]].value;
             AO3.marker = (!array_locs[j] ? ARRAY_MV : STATIC_ARRAY_MV);
             assemblez_1(ret_zc, AO3);
             assemble_label_no(nl);
@@ -2263,11 +2263,11 @@ static void compile_symbol_table_routine(void)
         sequence_point_follows = FALSE;
         assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
         AO3.value = 0;
-        if (sflags[named_routine_symbols[j]]
+        if (symbols[named_routine_symbols[j]].flags
             & (INSF_SFLAG+SYSTEM_SFLAG)) AO3.value = 16;
         AO3.marker = 0;
         assemblez_store(temp_var3, AO3);
-        AO3.value = svals[named_routine_symbols[j]];
+        AO3.value = symbols[named_routine_symbols[j]].value;
         AO3.marker = IROUTINE_MV;
         assemblez_1(ret_zc, AO3);
         assemble_label_no(nl);
@@ -2277,9 +2277,9 @@ static void compile_symbol_table_routine(void)
 
     assemble_label_no(constants_l);
     for (j=0, no_named_constants=0; j<no_symbols; j++)
-    {   if (((stypes[j] == OBJECT_T) || (stypes[j] == CLASS_T)
-            || (stypes[j] == CONSTANT_T))
-            && ((sflags[j] & (UNKNOWN_SFLAG+ACTION_SFLAG))==0))
+    {   if (((symbols[j].type == OBJECT_T) || (symbols[j].type == CLASS_T)
+            || (symbols[j].type == CONSTANT_T))
+            && ((symbols[j].flags & (UNKNOWN_SFLAG+ACTION_SFLAG))==0))
         {   AO2.value = no_named_constants++;
             if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
             else AO2.type = LONG_CONSTANT_OT;
@@ -2287,9 +2287,9 @@ static void compile_symbol_table_routine(void)
             sequence_point_follows = FALSE;
             assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
             AO3.value = 0;
-            if (stypes[j] == OBJECT_T) AO3.value = 2;
-            if (stypes[j] == CLASS_T) AO3.value = 1;
-            if (sflags[j] & (INSF_SFLAG+SYSTEM_SFLAG))
+            if (symbols[j].type == OBJECT_T) AO3.value = 2;
+            if (symbols[j].type == CLASS_T) AO3.value = 1;
+            if (symbols[j].flags & (INSF_SFLAG+SYSTEM_SFLAG))
                 AO3.value = AO3.value + 16;
             AO3.marker = 0;
             assemblez_store(temp_var3, AO3);
@@ -2348,7 +2348,7 @@ extern void compile_veneer(void)
         for (i=0; i<VENEER_ROUTINES; i++)
         {   if (veneer_routine_needs_compilation[i] == VR_CALLED)
             {   j = symbol_index(VRs[i].name, -1);
-                if (sflags[j] & UNKNOWN_SFLAG)
+                if (symbols[j].flags & UNKNOWN_SFLAG)
                 {   veneer_mode = TRUE;
                     strcpy(veneer_source_area, VRs[i].source1);
                     strcat(veneer_source_area, VRs[i].source2);
@@ -2361,18 +2361,18 @@ extern void compile_veneer(void)
                             VRs[i].name, TRUE, j),
                         ROUTINE_T);
                     veneer_mode = FALSE;
-                    if (trace_fns_setting==3) sflags[j] |= STAR_SFLAG;
+                    if (trace_fns_setting==3) symbols[j].flags |= STAR_SFLAG;
                 }
                 else
-                {   if (stypes[j] != ROUTINE_T)
+                {   if (symbols[j].type != ROUTINE_T)
                 error_named("The following name is reserved by Inform for its \
 own use as a routine name; you can use it as a routine name yourself (to \
 override the standard definition) but cannot use it for anything else:",
                         VRs[i].name);
                     else
-                        sflags[j] |= USED_SFLAG;
+                        symbols[j].flags |= USED_SFLAG;
                 }
-                veneer_routine_address[i] = svals[j];
+                veneer_routine_address[i] = symbols[j].value;
                 veneer_routine_needs_compilation[i] = VR_COMPILED;
                 try_veneer_again = TRUE;
             }

--- a/verbs.c
+++ b/verbs.c
@@ -174,7 +174,7 @@ static void list_grammar_line_v1(int mark)
 
     printf(" -> ");
     actsym = action_symbol[action];
-    str = (char *)(symbs[actsym]);
+    str = (symbs[actsym]);
     len = strlen(str) - 3;   /* remove "__A" */
     for (ix=0; ix<len; ix++) putchar(str[ix]);
     printf("\n");
@@ -259,7 +259,7 @@ static void list_grammar_line_v2(int mark)
     }
     printf(" -> ");
     actsym = action_symbol[action];
-    str = (char *)(symbs[actsym]);
+    str = (symbs[actsym]);
     len = strlen(str) - 3;   /* remove "__A" */
     for (ix=0; ix<len; ix++) putchar(str[ix]);
     if (flags) printf(" (reversed)");
@@ -401,7 +401,7 @@ extern void find_the_actions(void)
         for (i=0; i<no_actions; i++) action_byte_offset[i] = 0;
     else
     for (i=0; i<no_actions; i++)
-    {   strcpy(action_name, (char *) symbs[action_symbol[i]]);
+    {   strcpy(action_name, symbs[action_symbol[i]]);
         action_name[strlen(action_name) - 3] = '\0'; /* remove "__A" */
         strcpy(action_sub, action_name);
         strcat(action_sub, "Sub");

--- a/verbs.c
+++ b/verbs.c
@@ -174,7 +174,7 @@ static void list_grammar_line_v1(int mark)
 
     printf(" -> ");
     actsym = action_symbol[action];
-    str = (symbs[actsym]);
+    str = (symbols[actsym].name);
     len = strlen(str) - 3;   /* remove "__A" */
     for (ix=0; ix<len; ix++) putchar(str[ix]);
     printf("\n");
@@ -259,7 +259,7 @@ static void list_grammar_line_v2(int mark)
     }
     printf(" -> ");
     actsym = action_symbol[action];
-    str = (symbs[actsym]);
+    str = (symbols[actsym].name);
     len = strlen(str) - 3;   /* remove "__A" */
     for (ix=0; ix<len; ix++) putchar(str[ix]);
     if (flags) printf(" (reversed)");
@@ -320,10 +320,10 @@ extern void make_fake_action(void)
     snprintf(action_sub, MAX_IDENTIFIER_LENGTH+4, "%s__A", token_text);
     i = symbol_index(action_sub, -1);
 
-    if (!(sflags[i] & UNKNOWN_SFLAG))
+    if (!(symbols[i].flags & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
         /* The user didn't know they were defining FOO__A, but they were and it's a problem. */
-        ebf_symbol_error("new fake action name", action_sub, typename(stypes[i]), slines[i]);
+        ebf_symbol_error("new fake action name", action_sub, typename(symbols[i].type), symbols[i].line);
         panic_mode_error_recovery(); return;
     }
 
@@ -335,7 +335,7 @@ extern void make_fake_action(void)
     if (debugfile_switch)
     {   debug_file_printf("<fake-action>");
         debug_file_printf("<identifier>##%s</identifier>", token_text);
-        debug_file_printf("<value>%d</value>", svals[i]);
+        debug_file_printf("<value>%d</value>", symbols[i].value);
         get_next_token();
         write_debug_locations
             (get_token_location_end(beginning_debug_location));
@@ -358,33 +358,33 @@ extern assembly_operand action_of_name(char *name)
     snprintf(action_sub, MAX_IDENTIFIER_LENGTH+4, "%s__A", name);
     j = symbol_index(action_sub, -1);
 
-    if (stypes[j] == FAKE_ACTION_T)
+    if (symbols[j].type == FAKE_ACTION_T)
     {   INITAO(&AO);
-        AO.value = svals[j];
+        AO.value = symbols[j].value;
         if (!glulx_mode)
           AO.type = LONG_CONSTANT_OT;
         else
           set_constant_ot(&AO);
-        sflags[j] |= USED_SFLAG;
+        symbols[j].flags |= USED_SFLAG;
         return AO;
     }
 
-    if (sflags[j] & UNKNOWN_SFLAG)
+    if (symbols[j].flags & UNKNOWN_SFLAG)
     {
         if (no_actions>=MAX_ACTIONS) memoryerror("MAX_ACTIONS",MAX_ACTIONS);
         new_action(name, no_actions);
         action_symbol[no_actions] = j;
         assign_symbol(j, no_actions++, CONSTANT_T);
-        sflags[j] |= ACTION_SFLAG;
+        symbols[j].flags |= ACTION_SFLAG;
     }
-    sflags[j] |= USED_SFLAG;
+    symbols[j].flags |= USED_SFLAG;
 
     INITAO(&AO);
-    AO.value = svals[j];
+    AO.value = symbols[j].value;
     AO.marker = ACTION_MV;
     if (!glulx_mode) {
       AO.type = (module_switch)?LONG_CONSTANT_OT:SHORT_CONSTANT_OT;
-      if (svals[j] >= 256) AO.type = LONG_CONSTANT_OT;
+      if (symbols[j].value >= 256) AO.type = LONG_CONSTANT_OT;
     }
     else {
       AO.type = CONSTANT_OT;
@@ -401,24 +401,24 @@ extern void find_the_actions(void)
         for (i=0; i<no_actions; i++) action_byte_offset[i] = 0;
     else
     for (i=0; i<no_actions; i++)
-    {   strcpy(action_name, symbs[action_symbol[i]]);
+    {   strcpy(action_name, symbols[action_symbol[i]].name);
         action_name[strlen(action_name) - 3] = '\0'; /* remove "__A" */
         strcpy(action_sub, action_name);
         strcat(action_sub, "Sub");
         j = symbol_index(action_sub, -1);
-        if (sflags[j] & UNKNOWN_SFLAG)
+        if (symbols[j].flags & UNKNOWN_SFLAG)
         {
-            error_named_at("No ...Sub action routine found for action:", action_name, slines[action_symbol[i]]);
+            error_named_at("No ...Sub action routine found for action:", action_name, symbols[action_symbol[i]].line);
         }
         else
-        if (stypes[j] != ROUTINE_T)
+        if (symbols[j].type != ROUTINE_T)
         {
-            error_named_at("No ...Sub action routine found for action:", action_name, slines[action_symbol[i]]);
-            error_named_at("-- ...Sub symbol found, but not a routine:", action_sub, slines[j]);
+            error_named_at("No ...Sub action routine found for action:", action_name, symbols[action_symbol[i]].line);
+            error_named_at("-- ...Sub symbol found, but not a routine:", action_sub, symbols[j].line);
         }
         else
-        {   action_byte_offset[i] = svals[j];
-            sflags[j] |= USED_SFLAG;
+        {   action_byte_offset[i] = symbols[j].value;
+            symbols[j].flags |= USED_SFLAG;
         }
     }
 }
@@ -703,7 +703,7 @@ into Inform, so suggest rewriting grammar using general parsing routines");
 
                      get_next_token();
                      if ((token_type != SYMBOL_TT)
-                         || (stypes[token_value] != ROUTINE_T))
+                         || (symbols[token_value].type != ROUTINE_T))
                      {   discard_token_location(beginning_debug_location);
                          ebf_error("routine name after 'noun='", token_text);
                          panic_mode_error_recovery();
@@ -711,12 +711,12 @@ into Inform, so suggest rewriting grammar using general parsing routines");
                      }
                      if (grammar_version_number == 1)
                          bytecode
-                             = 16 + make_parsing_routine(svals[token_value]);
+                             = 16 + make_parsing_routine(symbols[token_value].value);
                      else
                      {   bytecode = 0x83;
-                         wordcode = svals[token_value];
+                         wordcode = symbols[token_value].value;
                      }
-                     sflags[token_value] |= USED_SFLAG;
+                     symbols[token_value].flags |= USED_SFLAG;
                  }
                  else
                  {   put_token_back();
@@ -767,7 +767,7 @@ are using Library 6/3 or later");
 
                  get_next_token();
                  if ((token_type != SYMBOL_TT)
-                     || (stypes[token_value] != ROUTINE_T))
+                     || (symbols[token_value].type != ROUTINE_T))
                  {   discard_token_location(beginning_debug_location);
                      ebf_error("routine name after 'scope='", token_text);
                      panic_mode_error_recovery();
@@ -776,9 +776,9 @@ are using Library 6/3 or later");
 
                  if (grammar_version_number == 1)
                      bytecode = 80 +
-                         make_parsing_routine(svals[token_value]);
-                 else { bytecode = 0x85; wordcode = svals[token_value]; }
-                 sflags[token_value] |= USED_SFLAG;
+                         make_parsing_routine(symbols[token_value].value);
+                 else { bytecode = 0x85; wordcode = symbols[token_value].value; }
+                 symbols[token_value].flags |= USED_SFLAG;
              }
         else if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
              {   discard_token_location(beginning_debug_location);
@@ -789,25 +789,25 @@ are using Library 6/3 or later");
         else {   /*  <attribute>  or  <general-parsing-routine>  tokens      */
 
                  if ((token_type != SYMBOL_TT)
-                     || ((stypes[token_value] != ATTRIBUTE_T)
-                         && (stypes[token_value] != ROUTINE_T)))
+                     || ((symbols[token_value].type != ATTRIBUTE_T)
+                         && (symbols[token_value].type != ROUTINE_T)))
                  {   discard_token_location(beginning_debug_location);
                      error_named("No such grammar token as", token_text);
                      panic_mode_error_recovery();
                      return FALSE;
                  }
-                 if (stypes[token_value]==ATTRIBUTE_T)
+                 if (symbols[token_value].type==ATTRIBUTE_T)
                  {   if (grammar_version_number == 1)
-                         bytecode = 128 + svals[token_value];
-                     else { bytecode = 4; wordcode = svals[token_value]; }
+                         bytecode = 128 + symbols[token_value].value;
+                     else { bytecode = 4; wordcode = symbols[token_value].value; }
                  }
                  else
                  {   if (grammar_version_number == 1)
                          bytecode = 48 +
-                             make_parsing_routine(svals[token_value]);
-                     else { bytecode = 0x86; wordcode = svals[token_value]; }
+                             make_parsing_routine(symbols[token_value].value);
+                     else { bytecode = 0x86; wordcode = symbols[token_value].value; }
                  }
-                 sflags[token_value] |= USED_SFLAG;
+                 symbols[token_value].flags |= USED_SFLAG;
              }
 
         grammar_token++; no_grammar_tokens++;


### PR DESCRIPTION
Chapter 2! MAX_SYMBOLS, SYMBOLS_CHUNK_SIZE are gone. That storage now uses dynamic reallocation.

(SYMBOLS_CHUNK_SIZE is now a #defined constant, but any number of chunks can be allocated for symbol name storage.)

This is a messy change because I combined the symbs, svals, stypes, sflags, slines, smarks, and next_entry arrays into a single array of struct symbolinfo. This means lots and lots of lines changing `svals[i]` to `symbols[i].value`, etc.

In doing this, I changed the type of `symbs[]` (now `symbols[].name`) from `int32*` to `char*`. I think it was `int32*` for some archaic reason of VAX C compatibility, but the symbolinfo struct makes that irrelevant. This lets us remove many, many `(char*)` casts.

I also changed `stypes[]` (now `symbols[].type`) from `signed char` to `unsigned char`. (It only ever contains the FOO_T constants, which are all positive.)

---

Other changes:

I went through all the memory functions (`my_malloc()`, etc) and changed their size/count arguments to be `size_t`. I don't really expect anyone to allocate more than `int32` worth of memory, but if they do, it shouldn't fail for *stupid* reasons.

(The code base already used `size_t` in a few places, so this is not going to cause compilation problems.)

The "memory setting XXX is no longer needed" messages are now suppressed by the `-w` switch. This is a bit janky, because they're not exactly warnings. (They aren't counted in the "suppressed warning" count, for example.) And we're left with a situation where

    inform '$MAX_SYMBOLS=1000' -w

generates a message, but

    inform -w '$MAX_SYMBOLS=1000'

does not.

However, I still think this is worth doing. It covers the common-ish case of using the new I7 IDE to compile old (6G60/6M62) I7 code. Those old I7 compilers add `!% $MAX_SYMBOLS` lines to the generated source, and we might as well let the `-w` switch suppress the complaints about them.
