### PR TITLE
Code cleanup: use symbolinfo.marker field

### DIFF
--- a/bpatch.c
+++ b/bpatch.c
@@ -124,7 +124,7 @@ static int32 backpatch_value_z(int32 value)
             else
             if (symbols[value].flags & CHANGE_SFLAG)
             {   symbols[value].flags &= (~(CHANGE_SFLAG));
-                backpatch_marker = (symbols[value].value/0x10000);
+                backpatch_marker = (symbols[value].marker);
                 if ((backpatch_marker < 0)
                     || (backpatch_marker > LARGEST_BPATCH_MV))
                 {

--- a/header.h
+++ b/header.h
@@ -883,10 +883,8 @@ typedef struct token_data_s
 
 typedef struct symbolinfo_s {
     char *name; /* Points into a symbol_name_space_chunk */
-    /* In Z-code, the value field encodes value and marker (and the marker
-       field is unused). In Glulx they're separate. */
     int32 value;
-    int marker;
+    int marker; /* ?_MV value */
     brief_location line;
     unsigned int flags;  /* ?_SFLAGS bitmask */
     uchar type; /* ?_T value */

--- a/header.h
+++ b/header.h
@@ -741,10 +741,10 @@ static int32 unique_task_id(void)
 /* ------------------------------------------------------------------------- */
 
 typedef struct assembly_operand_t
-{   int   type;
+{   int   type;     /* ?_OT value */
     int32 value;
-    int   symindex;
-    int   marker;
+    int   symindex; /* index in symbols array, if derived from a symbol */
+    int   marker;   /* ?_MV value */
 } assembly_operand;
 
 #define INITAOTV(aop, typ, val) ((aop)->type=(typ), (aop)->value=(val), (aop)->marker=0, (aop)->symindex=-1)

--- a/linker.c
+++ b/linker.c
@@ -298,7 +298,7 @@ static void accept_export(void)
 
                 break;
         }
-        assign_symbol(index, IE.backpatch*0x10000 + IE.symbol_value,
+        assign_marked_symbol(index, IE.backpatch, IE.symbol_value,
             IE.symbol_type);
         if (IE.backpatch != 0) symbols[index].flags |= CHANGE_SFLAG;
         symbols[index].flags |= EXPORT_SFLAG;
@@ -717,12 +717,12 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
 
     for (i=symbols_base; i<no_symbols; i++)
     {   if ((symbols[i].flags & CHANGE_SFLAG) && (symbols[i].flags & EXPORT_SFLAG))
-        {   backpatch_marker = symbols[i].value/0x10000;
+        {   backpatch_marker = symbols[i].marker;
             j = symbols[i].value % 0x10000;
 
             j = backpatch_backpatch(j);
 
-            symbols[i].value = backpatch_marker*0x10000 + j;
+            symbols[i].value = j;
             if (backpatch_marker == 0) symbols[i].flags &= (~(CHANGE_SFLAG));
         }
     }
@@ -1072,7 +1072,7 @@ static void export_symbols(void)
             write_link_word(symbol_number);
             write_link_byte(symbols[symbol_number].type);
             if (symbols[symbol_number].flags & CHANGE_SFLAG)
-                 write_link_byte(symbols[symbol_number].value / 0x10000);
+                 write_link_byte(symbols[symbol_number].marker);
             else write_link_byte(0);
             write_link_word(symbols[symbol_number].value % 0x10000);
             write_link_string((symbols[symbol_number].name));

--- a/symbols.c
+++ b/symbols.c
@@ -294,6 +294,7 @@ extern int symbol_index(char *p, int hashcode)
     symbols[no_symbols].value   =  0x100; /* ###-wrong? Would this fix the
                                      unbound-symbol-causes-asm-error? */
     symbols[no_symbols].flags  =  UNKNOWN_SFLAG;
+    symbols[no_symbols].marker =  0;
     symbols[no_symbols].type  =  CONSTANT_T;
     symbols[no_symbols].line  =  get_brief_location(&ErrorReport);
     if (debugfile_switch)
@@ -633,22 +634,14 @@ static void assign_symbol_base(int index, int32 value, int type)
 
 extern void assign_symbol(int index, int32 value, int type)
 {
-    symbols[index].marker = 0;
     assign_symbol_base(index, value, type);
+    symbols[index].marker = 0;
 }
 
 extern void assign_marked_symbol(int index, int marker, int32 value, int type)
 {
-    if (!glulx_mode) {
-        /* In Z-code, marker is encoded into value */
-        symbols[index].marker = 0;
-        assign_symbol_base(index, (int32)marker*0x10000 + (value % 0x10000),
-            type);
-    }
-    else {
-        symbols[index].marker = marker;
-        assign_symbol_base(index, value, type);
-    }
+    assign_symbol_base(index, value, type);
+    symbols[index].marker = marker;
 }
 
 static void emit_debug_information_for_predefined_symbol


### PR DESCRIPTION
In Z-code, the `symbolinfo.value` field contained both the value and the marker mashed together (value + 0x10000*marker). But the struct also had a separate `symbolinfo.marker` field, which was added when Glulx went in.

I have unmashed the two values in Z-code. Both back ends now use `s.marker` for the marker and `s.value` for the value.

No change in compiler behavior.
