### PR TITLE
Optimal parsing of abbreviations

### DIFF
--- a/text.c
+++ b/text.c
@@ -530,9 +530,9 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
             p = (uchar *)abbreviations_at+j*MAX_ABBREV_LENGTH;
             for (k=0; p[k]!=0; k++) text_in[i+k]=1;
             // actually write the abbreviation in the story file
+            abbreviations[j].freq++;
             j += MAX_DYNAMIC_STRINGS;
             write_z_char_z(j/32+1); write_z_char_z(j%32);
-            abbreviations[j].freq++;
         }
         
 

--- a/text.c
+++ b/text.c
@@ -451,11 +451,23 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
     /*    (ref: R.A. Wagner , “Common phrases and minimum-space text storage”, Commun. ACM, 16 (3) (1973)) */
     /* We compute this optimal way here; it's stored in optimal_parse_schedule */
     uchar *q, c; int l, min_score, from, abbr_length;
-    int text_in_length = strlen( (char*) text_in);
-    int optimal_parse_scores[text_in_length+1];
-    int optimal_parse_schedule[text_in_length];
+    int text_in_length;
+    int *optimal_parse_scores;
+    memory_list optimal_parse_scores_memlist;
+    initialise_memory_list(&optimal_parse_scores_memlist,
+        sizeof(int), 0, (void**)&optimal_parse_scores,
+        "optimal parse scores");
+    int *optimal_parse_schedule;
+    memory_list optimal_parse_schedule_memlist;
+    initialise_memory_list(&optimal_parse_schedule_memlist,
+        sizeof(int), 0, (void**)&optimal_parse_schedule,
+        "optimal parse schedule");
     if (economy_switch)
     {   
+        text_in_length = strlen( (char*) text_in);
+        ensure_memory_list_available(&optimal_parse_schedule_memlist, text_in_length);
+        ensure_memory_list_available(&optimal_parse_scores_memlist, text_in_length+1);
+        
         optimal_parse_scores[text_in_length] = 0;
         for(j=text_in_length-1; j>=0; j--)
         {    // initial values: empty schedule, score = just write the letter without abbreviating
@@ -669,6 +681,9 @@ advance as part of 'Zcharacter table':", unicode);
 
     end_z_chars();
 
+    /*  Deallocate the memory we needed to reserve for the abbreviation computation */
+    deallocate_memory_list(&optimal_parse_schedule_memlist);
+    deallocate_memory_list(&optimal_parse_scores_memlist);
   }
   else {
 

--- a/text.c
+++ b/text.c
@@ -451,7 +451,7 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
     /*    (ref: R.A. Wagner , “Common phrases and minimum-space text storage”, Commun. ACM, 16 (3) (1973)) */
     /* We compute this optimal way here; it's stored in optimal_parse_schedule */
     uchar *q, c; int l, min_score, from, abbr_length;
-    int text_in_length = strlen(text_in);
+    int text_in_length = strlen( (char*) text_in);
     int optimal_parse_scores[text_in_length+1];
     int optimal_parse_schedule[text_in_length];
     if (economy_switch)

--- a/text.c
+++ b/text.c
@@ -450,13 +450,6 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
     /* Computing the optimal way to parse strings to insert abbreviations with dynamic programming */
     /*    (ref: R.A. Wagner , “Common phrases and minimum-space text storage”, Commun. ACM, 16 (3) (1973)) */
     /* We compute this optimal way here; it's stored in optimal_parse_schedule */
-    uchar *q, c; int l, min_score, from, abbr_length;
-    int text_in_length;
-    int *optimal_parse_scores;
-    memory_list optimal_parse_scores_memlist;
-    initialise_memory_list(&optimal_parse_scores_memlist,
-        sizeof(int), 0, (void**)&optimal_parse_scores,
-        "optimal parse scores");
     int *optimal_parse_schedule;
     memory_list optimal_parse_schedule_memlist;
     initialise_memory_list(&optimal_parse_schedule_memlist,
@@ -464,6 +457,13 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
         "optimal parse schedule");
     if (economy_switch)
     {   
+        uchar *q, c; int l, min_score, from, abbr_length;
+        int text_in_length;
+        int *optimal_parse_scores;
+        memory_list optimal_parse_scores_memlist;
+        initialise_memory_list(&optimal_parse_scores_memlist,
+            sizeof(int), 0, (void**)&optimal_parse_scores,
+            "optimal parse scores");
         text_in_length = strlen( (char*) text_in);
         ensure_memory_list_available(&optimal_parse_schedule_memlist, text_in_length);
         ensure_memory_list_available(&optimal_parse_scores_memlist, text_in_length+1);
@@ -500,6 +500,8 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
         // We gave it our best, this is the smallest we got
         optimal_parse_scores[j] = min_score;
         }
+    /* we're done with this array, but not with the schedule */
+    deallocate_memory_list(&optimal_parse_scores_memlist);
     }
 
 
@@ -683,7 +685,6 @@ advance as part of 'Zcharacter table':", unicode);
 
     /*  Deallocate the memory we needed to reserve for the abbreviation computation */
     deallocate_memory_list(&optimal_parse_schedule_memlist);
-    deallocate_memory_list(&optimal_parse_scores_memlist);
   }
   else {
 


### PR DESCRIPTION
Inform's algorithm to apply abbreviations was as follows: go through the text character by character, if an abbreviation starts with that character, try to apply it (alphabetically).

This is not the optimal way: there is a dynamic programming algorithm that does it better. (Sometimes, like when abbreviations overlap, it's better to wait a bit to be able to apply a better abbreviation.) This is an algorithm by Wagner, discussed in this intfiction.org thread: https://intfiction.org/t/highly-optimized-abbreviations-computed-efficiently/48753/45

The code here implements this optimal parsing algorithm. I tested it on my "Tristam Island" game (128k, v3) and found it saved ~1200 bytes; the game file has been tested, and the "-f" setting of the compiler, and everything appears to be normal.

Feel free to change stuff in the code :) There are three chunks:
- a helper function telling you the weight in units of a character (could be of independent interest, maybe it already exists somewhere)
- a preprocessing phase where, given a string, we determine with Wagner's algorithm which way to apply the abbreviations results in the lowest weight; that weight is optimal_parse_scores[0], and the abbreviation choices that correspond to the optimal scores in the dynamic programming algorithm are stored in optimal_parse_schedule
- a replacement of the code that applied the abbreviations: we now look at the schedule, apply the abbreviation, skip however many characters were replaced, then keep going.

Note that the try_abbreviations_from function isn't used anymore (I think?); it was doing essentially the abbreviation finding and the replacing (and putting 1s instead of the chars that were replaced), but now these two tasks are split up (finding in the preprocessing stage, replacing in the for loop "Loop through the characters of the null-terminated input text").