### PR TITLE
Dynalloc: MAX_LABELS

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -1436,6 +1436,8 @@ extern void assemble_label_no(int n)
 extern void define_symbol_label(int symbol)
 {
     int label = symbols[symbol].value;
+    /* We may be creating a new label (label = next_label) or filling in
+       the value of an old one. So we call ensure. */
     ensure_memory_list_available(&labels_memlist, label+1);
     labels[label].symbol = symbol;
 }

--- a/asm.c
+++ b/asm.c
@@ -3157,17 +3157,6 @@ extern void parse_assembly(void)
 /*   Data structure management routines                                      */
 /* ------------------------------------------------------------------------- */
 
-extern void asm_begin_pass(void)
-{   no_instructions = 0;
-    zmachine_pc = 0;
-    no_sequence_points = 0;
-    next_label = 0;
-    next_sequence_point = 0;
-    zcode_ha_size = 0;
-
-    sequence_points = NULL;
-}
-
 extern void init_asm_vars(void)
 {   int i;
 
@@ -3178,10 +3167,20 @@ extern void init_asm_vars(void)
     uses_acceleration_features = FALSE;
     uses_float_features = FALSE;
 
+    sequence_points = NULL;
     sequence_point_follows = TRUE;
     label_moved_error_already_given = FALSE;
 
     zcode_area = NULL;
+}
+
+extern void asm_begin_pass(void)
+{   no_instructions = 0;
+    zmachine_pc = 0;
+    no_sequence_points = 0;
+    next_label = 0;
+    next_sequence_point = 0;
+    zcode_ha_size = 0;
 }
 
 extern void asm_allocate_arrays(void)

--- a/asm.c
+++ b/asm.c
@@ -97,13 +97,9 @@ static void transfer_routine_g(void);
 static labelinfo *labels; /* Label offsets  (i.e. zmachine_pc values).
                              These are allocated sequentially, but accessed
                              as a double-linked list from first_label
-                             to last_label. */
+                             to last_label (in PC order). */
 static memory_list labels_memlist;
 static int first_label, last_label;
-static int32 *label_offsets;       /* Double-linked list of label offsets    */
-static int   *label_next,          /* (i.e. zmachine_pc values) in PC order  */
-             *label_prev;
-static int32 *label_symbols;       /* Symbol numbers if defined in source    */
 
 static sequencepointinfo *sequence_points; /* Allocated to next_sequence_point.
                                               Only used when debugfile_switch
@@ -3197,11 +3193,6 @@ extern void asm_allocate_arrays(void)
     variable_usage = my_calloc(sizeof(int),  
         MAX_LOCAL_VARIABLES+MAX_GLOBAL_VARIABLES, "variable usage");
 
-    label_offsets = my_calloc(sizeof(int32), MAX_LABELS, "label offsets");
-    label_symbols = my_calloc(sizeof(int32), MAX_LABELS, "label symbols");
-    label_next = my_calloc(sizeof(int), MAX_LABELS, "label dll 1");
-    label_prev = my_calloc(sizeof(int), MAX_LABELS, "label dll 1");
-    
     initialise_memory_list(&labels_memlist,
         sizeof(labelinfo), 1000, (void**)&labels,
         "labels");
@@ -3230,10 +3221,6 @@ extern void asm_free_arrays(void)
     my_free(&variable_tokens, "variable tokens");
     my_free(&variable_usage, "variable usage");
 
-    my_free(&label_offsets, "label offsets");
-    my_free(&label_symbols, "label symbols");
-    my_free(&label_next, "label dll 1");
-    my_free(&label_prev, "label dll 2");
     deallocate_memory_list(&labels_memlist);
     deallocate_memory_list(&sequence_points_memlist);
 

--- a/asm.c
+++ b/asm.c
@@ -94,6 +94,11 @@ static void transfer_routine_g(void);
 /*   Label data                                                              */
 /* ------------------------------------------------------------------------- */
 
+static labelinfo *labels; /* Label offsets  (i.e. zmachine_pc values).
+                             These are allocated sequentially, but accessed
+                             as a double-linked list from first_label
+                             to last_label. */
+static memory_list labels_memlist;
 static int first_label, last_label;
 static int32 *label_offsets;       /* Double-linked list of label offsets    */
 static int   *label_next,          /* (i.e. zmachine_pc values) in PC order  */
@@ -3167,6 +3172,7 @@ extern void init_asm_vars(void)
     uses_acceleration_features = FALSE;
     uses_float_features = FALSE;
 
+    labels = NULL;
     sequence_points = NULL;
     sequence_point_follows = TRUE;
     label_moved_error_already_given = FALSE;
@@ -3196,6 +3202,9 @@ extern void asm_allocate_arrays(void)
     label_next = my_calloc(sizeof(int), MAX_LABELS, "label dll 1");
     label_prev = my_calloc(sizeof(int), MAX_LABELS, "label dll 1");
     
+    initialise_memory_list(&labels_memlist,
+        sizeof(labelinfo), 1000, (void**)&labels,
+        "labels");
     initialise_memory_list(&sequence_points_memlist,
         sizeof(sequencepointinfo), 1000, (void**)&sequence_points,
         "sequence points");
@@ -3225,6 +3234,7 @@ extern void asm_free_arrays(void)
     my_free(&label_symbols, "label symbols");
     my_free(&label_next, "label dll 1");
     my_free(&label_prev, "label dll 2");
+    deallocate_memory_list(&labels_memlist);
     deallocate_memory_list(&sequence_points_memlist);
 
     my_free(&zcode_holding_area, "compiled routine code area");

--- a/asm.c
+++ b/asm.c
@@ -108,7 +108,7 @@ static memory_list sequence_points_memlist;
 
 static void set_label_offset(int label, int32 offset)
 {
-    if (label >= MAX_LABELS) memoryerror("MAX_LABELS", MAX_LABELS);
+    ensure_memory_list_available(&labels_memlist, label+1);
 
     labels[label].offset = offset;
     if (last_label == -1)
@@ -1434,7 +1434,10 @@ extern void assemble_label_no(int n)
 }
 
 extern void define_symbol_label(int symbol)
-{   labels[symbols[symbol].value].symbol = symbol;
+{
+    int label = symbols[symbol].value;
+    ensure_memory_list_available(&labels_memlist, label+1);
+    labels[label].symbol = symbol;
 }
 
 extern int32 assemble_routine_header(int no_locals,
@@ -3186,8 +3189,7 @@ extern void asm_begin_pass(void)
 }
 
 extern void asm_allocate_arrays(void)
-{   if ((debugfile_switch) && (MAX_LABELS < 2000)) MAX_LABELS = 2000;
-
+{
     variable_tokens = my_calloc(sizeof(int32),  
         MAX_LOCAL_VARIABLES+MAX_GLOBAL_VARIABLES, "variable tokens");
     variable_usage = my_calloc(sizeof(int),  

--- a/asm.c
+++ b/asm.c
@@ -100,7 +100,9 @@ static int   *label_next,          /* (i.e. zmachine_pc values) in PC order  */
              *label_prev;
 static int32 *label_symbols;       /* Symbol numbers if defined in source    */
 
-static sequencepointinfo *sequence_points; /* Allocated to next_sequence_point */
+static sequencepointinfo *sequence_points; /* Allocated to next_sequence_point.
+                                              Only used when debugfile_switch
+                                              is set.                        */
 static memory_list sequence_points_memlist;
 
 static void set_label_offset(int label, int32 offset)
@@ -834,7 +836,9 @@ extern void assemblez_instruction(assembly_instruction *AI)
     if (sequence_point_follows)
     {   sequence_point_follows = FALSE; at_seq_point = TRUE;
         if (debugfile_switch)
-        {   sequence_points[next_sequence_point].label = next_label;
+        {
+            ensure_memory_list_available(&sequence_points_memlist, next_sequence_point+1);
+            sequence_points[next_sequence_point].label = next_label;
             sequence_points[next_sequence_point].location =
                 statement_debug_location;
             set_label_offset(next_label++, zmachine_pc);
@@ -1140,7 +1144,9 @@ extern void assembleg_instruction(assembly_instruction *AI)
     if (sequence_point_follows)
     {   sequence_point_follows = FALSE; at_seq_point = TRUE;
         if (debugfile_switch)
-        {   sequence_points[next_sequence_point].label = next_label;
+        {
+            ensure_memory_list_available(&sequence_points_memlist, next_sequence_point+1);
+            sequence_points[next_sequence_point].label = next_label;
             sequence_points[next_sequence_point].location =
                 statement_debug_location;
             set_label_offset(next_label++, zmachine_pc);

--- a/header.h
+++ b/header.h
@@ -2640,7 +2640,7 @@ extern size_t malloced_bytes;
 
 extern int MAX_QTEXT_SIZE,       HASH_TAB_SIZE,   MAX_DICT_ENTRIES,
            MAX_ACTIONS,          MAX_ABBREVS,
-           MAX_EXPRESSION_NODES, MAX_LABELS,            MAX_LINESPACE,
+           MAX_EXPRESSION_NODES, MAX_LINESPACE,
            MAX_LOW_STRINGS,
            MAX_INCLUSION_DEPTH,
            MAX_SOURCE_FILES,     MAX_DYNAMIC_STRINGS;

--- a/header.h
+++ b/header.h
@@ -926,6 +926,13 @@ typedef struct arrayinfo_s {
     int loc;      /* true for static, false for dynamic (regular) arrays */
 } arrayinfo;
 
+typedef struct labelinfo_s {
+    int32 offset; /* Offset (zmachine_pc) value */
+    int32 symbol; /* Symbol numbers if defined in source */
+    int next;     /* For linked list */
+    int prev;     /* For linked list */
+} labelinfo;
+
 typedef struct sequencepointinfo_s {
     int label;               /* Label number */
     debug_location location; /* Source code reference (used for making

--- a/header.h
+++ b/header.h
@@ -926,6 +926,12 @@ typedef struct arrayinfo_s {
     int loc;      /* true for static, false for dynamic (regular) arrays */
 } arrayinfo;
 
+typedef struct sequencepointinfo_s {
+    int label;               /* Label number */
+    debug_location location; /* Source code reference (used for making
+                                debugging file)                              */
+} sequencepointinfo;
+
 typedef struct FileId_s                 /*  Source code file identifier:     */
 {   char *filename;                     /*  The filename (after translation) */
     FILE *handle;                       /*  Handle of file (when open), or

--- a/memory.c
+++ b/memory.c
@@ -250,7 +250,6 @@ int MAX_DICT_ENTRIES;
 int MAX_ABBREVS;
 int MAX_DYNAMIC_STRINGS;
 int MAX_EXPRESSION_NODES;
-int MAX_LABELS;
 int MAX_LINESPACE;
 int32 MAX_STATIC_STRINGS;
 int32 MAX_ZCODE_SIZE;
@@ -312,7 +311,6 @@ static void list_memory_sizes(void)
       printf("|  %25s = %-7d |\n","ZCODE_HEADER_FLAGS_3",ZCODE_HEADER_FLAGS_3);
     printf("|  %25s = %-7d |\n","MAX_INCLUSION_DEPTH",MAX_INCLUSION_DEPTH);
     printf("|  %25s = %-7d |\n","INDIV_PROP_START", INDIV_PROP_START);
-    printf("|  %25s = %-7d |\n","MAX_LABELS",MAX_LABELS);
     printf("|  %25s = %-7d |\n","MAX_LINESPACE",MAX_LINESPACE);
     printf("|  %25s = %-7d |\n","MAX_LINK_DATA_SIZE",MAX_LINK_DATA_SIZE);
     if (glulx_mode)
@@ -359,7 +357,6 @@ extern void set_memory_sizes(int size_flag)
         MAX_DICT_ENTRIES = 2000;
 
         MAX_EXPRESSION_NODES = 100;
-        MAX_LABELS = 1000;
         MAX_LINESPACE = 16000;
 
         MAX_STATIC_STRINGS = 8000;
@@ -387,7 +384,6 @@ extern void set_memory_sizes(int size_flag)
         MAX_EXPRESSION_NODES = 100;
         MAX_LINESPACE = 10000;
 
-        MAX_LABELS = 1000;
         MAX_STATIC_STRINGS = 8000;
         MAX_ZCODE_SIZE_z = 20000;
         MAX_ZCODE_SIZE_g = 40000;
@@ -412,7 +408,6 @@ extern void set_memory_sizes(int size_flag)
 
         MAX_EXPRESSION_NODES = 40;
         MAX_LINESPACE = 10000;
-        MAX_LABELS = 1000;
 
         MAX_STATIC_STRINGS = 8000;
         MAX_ZCODE_SIZE_z = 10000;
@@ -575,15 +570,6 @@ static void explain_parameter(char *command)
   evaluator's storage for parse trees.  In effect, it measures how \n\
   complicated algebraic expressions are allowed to be.  Increasing it by \n\
   one costs about 80 bytes.\n");
-        return;
-    }
-    if (strcmp(command,"MAX_LABELS")==0)
-    {   printf(
-"  MAX_LABELS is the maximum number of label points in any one routine.\n\
-  (If the -k debugging information switch is set, MAX_LABELS is raised to\n\
-  a minimum level of 2000, as about twice the normal number of label points\n\
-  are needed to generate tables of how source code corresponds to positions\n\
-  in compiled code.)");
         return;
     }
     if (strcmp(command,"MAX_LINESPACE")==0)
@@ -915,7 +901,7 @@ extern void memory_command(char *command)
             if (strcmp(command,"MAX_VERBSPACE")==0)
                 flag=3;
             if (strcmp(command,"MAX_LABELS")==0)
-                MAX_LABELS=j, flag=1;
+                flag=3;
             if (strcmp(command,"MAX_LINESPACE")==0)
                 MAX_LINESPACE=j, flag=1;
             if (strcmp(command,"MAX_NUM_STATIC_STRINGS")==0)

--- a/text.c
+++ b/text.c
@@ -542,6 +542,7 @@ extern uchar *translate_text(uchar *p, uchar *p_limit, char *s_text, int strctx)
             for (k=0; p[k]!=0; k++) text_in[i+k]=1;
             /* Actually write the abbreviation in the story file. */
             abbreviations[j].freq++;
+            /* Abbreviations run from MAX_DYNAMIC_STRINGS to 96. */
             j += MAX_DYNAMIC_STRINGS;
             write_z_char_z(j/32+1); write_z_char_z(j%32);
         }


### PR DESCRIPTION
There are two separate allocations of this size: `sequence_points[]` and `labels[]`. 

`sequence_points[]` is an array of structs which combines `sequence_point_labels[]` and `sequence_point_locations[]`.
`labels[]` is an array of structs which combines `label_offsets[]`, `label_symbols[]`, `label_next[]`, and `label_prev[]`.

Minor changes: I moved the asm_begin_pass() function after init_asm_vars(), following the order of setup functions in other files.
