### PR TITLE
Dynalloc: MAX_EXPRESSION_NODES

### DIFF
--- a/expressp.c
+++ b/expressp.c
@@ -1090,7 +1090,6 @@ static void emit_token(token_data t)
         emitter_stack[emitter_sp].marker = 0;
         emitter_stack[emitter_sp].bracket_count = 0;
 
-        ensure_memory_list_available(&emitter_stack_memlist, emitter_sp+1);
         if (!evaluate_term(t, &(emitter_stack[emitter_sp++].op)))
             compiler_error_named("Emit token error:", t.text);
         return;

--- a/expressp.c
+++ b/expressp.c
@@ -2059,8 +2059,8 @@ extern void init_expressp_vars(void)
     make_lexical_interface_tables();
     for (i=0;i<32;i++) system_function_usage[i] = 0;
 
-    emitter_stack = NULL;
     ET = NULL;
+    emitter_stack = NULL;
     sr_stack = NULL;
 }
 

--- a/expressp.c
+++ b/expressp.c
@@ -1070,10 +1070,11 @@ static void emit_token(token_data t)
     {   if (stack_size < emitter_sp && emitter_stack[emitter_sp-stack_size-1].bracket_count)
         {   if (stack_size == 0)
             {   error("No expression between brackets '(' and ')'");
+                ensure_memory_list_available(&emitter_stack_memlist, emitter_sp+1);
                 emitter_stack[emitter_sp].op = zero_operand;
                 emitter_stack[emitter_sp].marker = 0;
                 emitter_stack[emitter_sp].bracket_count = 0;
-                ++emitter_sp;
+                emitter_sp++;
             }
             else if (stack_size < 1)
                 compiler_error("SR error: emitter stack empty in subexpression");
@@ -1085,7 +1086,9 @@ static void emit_token(token_data t)
     }
 
     if (t.type != OP_TT)
-    {   emitter_stack[emitter_sp].marker = 0;
+    {
+        ensure_memory_list_available(&emitter_stack_memlist, emitter_sp+1);
+        emitter_stack[emitter_sp].marker = 0;
         emitter_stack[emitter_sp].bracket_count = 0;
 
         ensure_memory_list_available(&emitter_stack_memlist, emitter_sp+1);
@@ -1855,9 +1858,6 @@ extern assembly_operand parse_expression(int context)
     etoken_count = 0;
     inserting_token = FALSE;
 
-    /* There's places where we access emitter_stack[emitter_sp] before
-       incrementing emitter_sp, so ensure 1 right away. */
-    ensure_memory_list_available(&emitter_stack_memlist, 1);
     emitter_sp = 0;
     bracket_level = 0;
 

--- a/expressp.c
+++ b/expressp.c
@@ -1855,6 +1855,9 @@ extern assembly_operand parse_expression(int context)
     etoken_count = 0;
     inserting_token = FALSE;
 
+    /* There's places where we access emitter_stack[emitter_sp] before
+       incrementing emitter_sp, so ensure 1 right away. */
+    ensure_memory_list_available(&emitter_stack_memlist, 1);
     emitter_sp = 0;
     bracket_level = 0;
 
@@ -1862,6 +1865,7 @@ extern assembly_operand parse_expression(int context)
     previous_token.type = ENDEXP_TT;
     previous_token.value = 0;
 
+    ensure_memory_list_available(&sr_stack_memlist, 1);
     sr_sp = 1;
     sr_stack[0] = previous_token;
 

--- a/expressp.c
+++ b/expressp.c
@@ -54,8 +54,7 @@ static int comma_allowed, arrow_allowed, superclass_allowed,
 
 extern int *variable_usage;
 
-/* Must be at least as many as keyword_group system_functions (currently 12) */
-int system_function_usage[32];
+int system_function_usage[NUMBER_SYSTEM_FUNCTIONS];
 
 static int get_next_etoken(void)
 {   int v, symbol = 0, mark_symbol_as_used = FALSE,
@@ -2057,7 +2056,8 @@ extern void init_expressp_vars(void)
 {   int i;
     /* make_operands(); */
     make_lexical_interface_tables();
-    for (i=0;i<32;i++) system_function_usage[i] = 0;
+    for (i=0; i<NUMBER_SYSTEM_FUNCTIONS; i++)
+        system_function_usage[i] = 0;
 
     ET = NULL;
     emitter_stack = NULL;

--- a/expressp.c
+++ b/expressp.c
@@ -1012,8 +1012,7 @@ static void mark_top_of_emitter_stack(int marker, token_data t)
             return;
         }
         error_named("Missing operand for", t.text);
-        if (emitter_sp == MAX_EXPRESSION_NODES)
-            memoryerror("MAX_EXPRESSION_NODES", MAX_EXPRESSION_NODES);
+        ensure_memory_list_available(&emitter_stack_memlist, emitter_sp+1);
         emitter_stack[emitter_sp].marker = 0;
         emitter_stack[emitter_sp].bracket_count = 0;
         emitter_stack[emitter_sp].op = zero_operand;
@@ -1089,8 +1088,7 @@ static void emit_token(token_data t)
     {   emitter_stack[emitter_sp].marker = 0;
         emitter_stack[emitter_sp].bracket_count = 0;
 
-        if (emitter_sp == MAX_EXPRESSION_NODES)
-            memoryerror("MAX_EXPRESSION_NODES", MAX_EXPRESSION_NODES);
+        ensure_memory_list_available(&emitter_stack_memlist, emitter_sp+1);
         if (!evaluate_term(t, &(emitter_stack[emitter_sp++].op)))
             compiler_error_named("Emit token error:", t.text);
         return;
@@ -1162,8 +1160,7 @@ static void emit_token(token_data t)
         if (arity > stack_size)
         {   error_named("Missing operand for", t.text);
             while (arity > stack_size)
-            {   if (emitter_sp == MAX_EXPRESSION_NODES)
-                    memoryerror("MAX_EXPRESSION_NODES", MAX_EXPRESSION_NODES);
+            {   ensure_memory_list_available(&emitter_stack_memlist, emitter_sp+1);
                 emitter_stack[emitter_sp].marker = 0;
                 emitter_stack[emitter_sp].bracket_count = 0;
                 emitter_stack[emitter_sp].op = zero_operand;

--- a/header.h
+++ b/header.h
@@ -2640,7 +2640,7 @@ extern size_t malloced_bytes;
 
 extern int MAX_QTEXT_SIZE,       HASH_TAB_SIZE,   MAX_DICT_ENTRIES,
            MAX_ACTIONS,          MAX_ABBREVS,
-           MAX_EXPRESSION_NODES, MAX_LINESPACE,
+           MAX_LINESPACE,
            MAX_LOW_STRINGS,
            MAX_INCLUSION_DEPTH,
            MAX_SOURCE_FILES,     MAX_DYNAMIC_STRINGS;

--- a/memory.c
+++ b/memory.c
@@ -249,7 +249,6 @@ int MAX_ACTIONS;
 int MAX_DICT_ENTRIES;
 int MAX_ABBREVS;
 int MAX_DYNAMIC_STRINGS;
-int MAX_EXPRESSION_NODES;
 int MAX_LINESPACE;
 int32 MAX_STATIC_STRINGS;
 int32 MAX_ZCODE_SIZE;
@@ -302,7 +301,6 @@ static void list_memory_sizes(void)
     if (glulx_mode)
       printf("|  %25s = %-7d |\n","DICT_CHAR_SIZE",DICT_CHAR_SIZE);
     printf("|  %25s = %-7d |\n","MAX_DYNAMIC_STRINGS",MAX_DYNAMIC_STRINGS);
-    printf("|  %25s = %-7d |\n","MAX_EXPRESSION_NODES",MAX_EXPRESSION_NODES);
     printf("|  %25s = %-7d |\n","MAX_GLOBAL_VARIABLES",MAX_GLOBAL_VARIABLES);
     printf("|  %25s = %-7d |\n","HASH_TAB_SIZE",HASH_TAB_SIZE);
     if (!glulx_mode)
@@ -356,7 +354,6 @@ extern void set_memory_sizes(int size_flag)
         MAX_ACTIONS      = 200;
         MAX_DICT_ENTRIES = 2000;
 
-        MAX_EXPRESSION_NODES = 100;
         MAX_LINESPACE = 16000;
 
         MAX_STATIC_STRINGS = 8000;
@@ -381,7 +378,6 @@ extern void set_memory_sizes(int size_flag)
         MAX_ACTIONS      = 200;
         MAX_DICT_ENTRIES = 1300;
 
-        MAX_EXPRESSION_NODES = 100;
         MAX_LINESPACE = 10000;
 
         MAX_STATIC_STRINGS = 8000;
@@ -406,7 +402,6 @@ extern void set_memory_sizes(int size_flag)
         MAX_ACTIONS      = 200;
         MAX_DICT_ENTRIES = 700;
 
-        MAX_EXPRESSION_NODES = 40;
         MAX_LINESPACE = 10000;
 
         MAX_STATIC_STRINGS = 8000;
@@ -562,14 +557,6 @@ static void explain_parameter(char *command)
     {   printf(
 "  MAX_DYNAMIC_STRINGS is the maximum number of string substitution variables\n\
   (\"@00\").  It is not allowed to exceed 96 in Z-code or 100 in Glulx.\n");
-        return;
-    }
-    if (strcmp(command,"MAX_EXPRESSION_NODES")==0)
-    {   printf(
-"  MAX_EXPRESSION_NODES is the maximum number of nodes in the expression \n\
-  evaluator's storage for parse trees.  In effect, it measures how \n\
-  complicated algebraic expressions are allowed to be.  Increasing it by \n\
-  one costs about 80 bytes.\n");
         return;
     }
     if (strcmp(command,"MAX_LINESPACE")==0)
@@ -895,7 +882,7 @@ extern void memory_command(char *command)
             if (strcmp(command,"MAX_ARRAYS")==0)
                 flag=3;
             if (strcmp(command,"MAX_EXPRESSION_NODES")==0)
-                MAX_EXPRESSION_NODES=j, flag=1;
+                flag=3;
             if (strcmp(command,"MAX_VERBS")==0)
                 flag=3;
             if (strcmp(command,"MAX_VERBSPACE")==0)


### PR DESCRIPTION
This covers three allocated arrays: `emitter_stack[]`, `sr_stack[]`, and `ET[]` (expression tree nodes). 

`emitter_stack[]` is an array of structs that was previously `emitter_stack`, `emitter_markers`, and `emitter_bracket_counts`. (Note that `emitter_stack` used to be an array of `assembly_operand`. Now it's an array of `emitterstackinfo`, which includes `assembly_operand op;`.)

I also changed the static `system_function_usage[]` array to be `NUMBER_SYSTEM_FUNCTIONS` (12) entries, instead of a hardcoded 32 entries. (It's indexed by the entries of the `system_functions` keyword group.)

https://github.com/erkyrath/Inform6-Testing/tree/dynalloc has some new tests that stretch these arrays.
