### PR TITLE
Fix for stub functions being compiled stackargs

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -900,10 +900,10 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
                 for the benefit of the debugging information file,
                 and for assembly tracing to look sensible.                   */
 
-            local_variable_texts[0] = "dummy1";
-            local_variable_texts[1] = "dummy2";
-            local_variable_texts[2] = "dummy3";
-            local_variable_texts[3] = "dummy4";
+            local_variable_texts[0] = local_variables.keywords[0] = "dummy1";
+            local_variable_texts[1] = local_variables.keywords[1] = "dummy2";
+            local_variable_texts[2] = local_variables.keywords[2] = "dummy3";
+            local_variable_texts[3] = local_variables.keywords[3] = "dummy4";
 
             assign_symbol(i,
                 assemble_routine_header(k, FALSE, symbols[i].name, FALSE, i),

--- a/veneer.c
+++ b/veneer.c
@@ -13,6 +13,8 @@
 int veneer_mode;                      /*  Is the code currently being
                                           compiled from the veneer?          */
 
+static int last_veneer_stackargs = FALSE; //###
+
 static debug_locations null_debug_locations =
     { { 0, 0, 0, 0, 0, 0, 0 }, NULL, 0 };
 
@@ -2188,8 +2190,12 @@ static void compile_symbol_table_routine(void)
 
     /* Assign local var names for the benefit of the debugging information 
        file. */
-    local_variable_texts[0] = "dummy1";
-    local_variable_texts[1] = "dummy2";
+    local_variable_texts[0] = local_variables.keywords[0] = "dummy1";
+    local_variable_texts[1] = local_variables.keywords[1] = "dummy2";
+
+    if (glulx_mode && last_veneer_stackargs) {
+        local_variables.keywords[0] = "_vararg_count";
+    }
 
     veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1);
     assign_symbol(j,
@@ -2350,6 +2356,7 @@ extern void compile_veneer(void)
             {   j = symbol_index(VRs[i].name, -1);
                 if (symbols[j].flags & UNKNOWN_SFLAG)
                 {   veneer_mode = TRUE;
+                    last_veneer_stackargs = (i == CA__Pr_VR || i == Cl__Ms_VR || i == Glk__Wrap_VR);
                     strcpy(veneer_source_area, VRs[i].source1);
                     strcat(veneer_source_area, VRs[i].source2);
                     strcat(veneer_source_area, VRs[i].source3);

--- a/veneer.c
+++ b/veneer.c
@@ -13,8 +13,6 @@
 int veneer_mode;                      /*  Is the code currently being
                                           compiled from the veneer?          */
 
-static int last_veneer_stackargs = FALSE; //###
-
 static debug_locations null_debug_locations =
     { { 0, 0, 0, 0, 0, 0, 0 }, NULL, 0 };
 
@@ -2193,10 +2191,6 @@ static void compile_symbol_table_routine(void)
     local_variable_texts[0] = local_variables.keywords[0] = "dummy1";
     local_variable_texts[1] = local_variables.keywords[1] = "dummy2";
 
-    if (glulx_mode && last_veneer_stackargs) {
-        local_variables.keywords[0] = "_vararg_count";
-    }
-
     veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1);
     assign_symbol(j,
         assemble_routine_header(2, FALSE, "Symb__Tab", FALSE, j),
@@ -2356,7 +2350,6 @@ extern void compile_veneer(void)
             {   j = symbol_index(VRs[i].name, -1);
                 if (symbols[j].flags & UNKNOWN_SFLAG)
                 {   veneer_mode = TRUE;
-                    last_veneer_stackargs = (i == CA__Pr_VR || i == Cl__Ms_VR || i == Glk__Wrap_VR);
                     strcpy(veneer_source_area, VRs[i].source1);
                     strcat(veneer_source_area, VRs[i].source2);
                     strcat(veneer_source_area, VRs[i].source3);


### PR DESCRIPTION
See https://github.com/DavidKinder/Inform6/issues/122 for the very long explanation.

The fix is simple, but it changes the compiled game file for many (not all) Glulx games. So I had to sit down and run through a lot of old unit tests to see if anything had regressed.

No changes in behavior detected.

(This sets up for removing the MAX_LOCAL_VARIABLES setting. That'll be next.)
