### PR TITLE
Dynalloc: MAX_LOCAL_VARIABLES

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -1463,8 +1463,8 @@ extern int32 assemble_routine_header(int no_locals,
     ensure_memory_list_available(&variables_memlist, MAX_LOCAL_VARIABLES);
     for (i=0; i<MAX_LOCAL_VARIABLES; i++) variables[i].usage = FALSE;
 
-    if (no_locals >= 1 
-      && !strcmp(local_variables.keywords[0], "_vararg_count")) {
+    if (no_locals >= 1
+      && strcmpcis(get_local_variable_name(0), "_vararg_count")==0) {
       stackargs = TRUE;
     }
 

--- a/asm.c
+++ b/asm.c
@@ -179,7 +179,7 @@ extern int is_variable_ot(int otval)
 extern char *variable_name(int32 i)
 {
     if (i==0) return("sp");
-    if (i<MAX_LOCAL_VARIABLES) return local_variable_texts[i-1];
+    if (i<MAX_LOCAL_VARIABLES) return local_variable_names[i-1].text;
 
     if (!glulx_mode) {
       if (i==255) return("TEMP1");
@@ -1464,7 +1464,7 @@ extern int32 assemble_routine_header(int no_locals,
     for (i=0; i<MAX_LOCAL_VARIABLES; i++) variables[i].usage = FALSE;
 
     if (no_locals >= 1
-      && strcmpcis(get_local_variable_name(0), "_vararg_count")==0) {
+      && strcmpcis(local_variable_names[0].text, "_vararg_count")==0) {
       stackargs = TRUE;
     }
 

--- a/directs.c
+++ b/directs.c
@@ -900,10 +900,14 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
                 for the benefit of the debugging information file,
                 and for assembly tracing to look sensible.                   */
 
-            local_variable_texts[0] = local_variables.keywords[0] = "dummy1";
-            local_variable_texts[1] = local_variables.keywords[1] = "dummy2";
-            local_variable_texts[2] = local_variables.keywords[2] = "dummy3";
-            local_variable_texts[3] = local_variables.keywords[3] = "dummy4";
+            local_variable_texts[0] = "dummy1";
+            local_variable_texts[1] = "dummy2";
+            local_variable_texts[2] = "dummy3";
+            local_variable_texts[3] = "dummy4";
+            set_local_variable_name(0, local_variable_texts[0]);
+            set_local_variable_name(1, local_variable_texts[1]);
+            set_local_variable_name(2, local_variable_texts[2]);
+            set_local_variable_name(3, local_variable_texts[3]);
 
             assign_symbol(i,
                 assemble_routine_header(k, FALSE, symbols[i].name, FALSE, i),

--- a/directs.c
+++ b/directs.c
@@ -898,16 +898,14 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         {
             /*  Give these parameter-receiving local variables names
                 for the benefit of the debugging information file,
-                and for assembly tracing to look sensible.                   */
+                and for assembly tracing to look sensible.
+                (We don't set local_variable.keywords because we're not
+                going to be parsing any code.)                               */
 
-            local_variable_texts[0] = "dummy1";
-            local_variable_texts[1] = "dummy2";
-            local_variable_texts[2] = "dummy3";
-            local_variable_texts[3] = "dummy4";
-            set_local_variable_name(0, local_variable_texts[0]);
-            set_local_variable_name(1, local_variable_texts[1]);
-            set_local_variable_name(2, local_variable_texts[2]);
-            set_local_variable_name(3, local_variable_texts[3]);
+            strcpy(local_variable_names[0].text, "dummy1");
+            strcpy(local_variable_names[1].text, "dummy2");
+            strcpy(local_variable_names[2].text, "dummy3");
+            strcpy(local_variable_names[3].text, "dummy4");
 
             assign_symbol(i,
                 assemble_routine_header(k, FALSE, symbols[i].name, FALSE, i),

--- a/header.h
+++ b/header.h
@@ -732,6 +732,11 @@ typedef struct memory_list_s
     size_t count;       /* number of items allocated */
 } memory_list;
 
+typedef struct identstruct_s
+{
+    char text[MAX_IDENTIFIER_LENGTH+1];
+} identstruct;
+
 typedef struct assembly_operand_t
 {   int   type;     /* ?_OT value */
     int32 value;
@@ -2567,7 +2572,7 @@ extern int  total_source_line_count;
 extern int  dont_enter_into_symbol_table;
 extern int  return_sp_as_variable;
 extern int  next_token_begins_syntax_line;
-extern char **local_variable_texts;
+extern identstruct *local_variable_names;
 
 extern int32 token_value;
 extern int   token_type;
@@ -2581,8 +2586,6 @@ extern debug_locations get_token_location_end(debug_location_beginning beginning
 
 extern void describe_token(const token_data *t);
 
-extern void set_local_variable_name(int pos, char *val);
-extern char *get_local_variable_name(int pos);
 extern void construct_local_variable_tables(void);
 extern void declare_systemfile(void);
 extern int  is_systemfile(void);

--- a/header.h
+++ b/header.h
@@ -2581,6 +2581,8 @@ extern debug_locations get_token_location_end(debug_location_beginning beginning
 
 extern void describe_token(const token_data *t);
 
+extern void set_local_variable_name(int pos, char *val);
+extern char *get_local_variable_name(int pos);
 extern void construct_local_variable_tables(void);
 extern void declare_systemfile(void);
 extern int  is_systemfile(void);

--- a/inform.c
+++ b/inform.c
@@ -110,6 +110,8 @@ static void select_target(int targ)
     WORDSIZE = 2;
     MAXINTWORD = 0x7FFF;
 
+    MAX_LOCAL_VARIABLES = 16; /* including "sp" */
+
     if (INDIV_PROP_START != 64) {
         INDIV_PROP_START = 64;
         fatalerror("You cannot change INDIV_PROP_START in Z-code");
@@ -126,16 +128,16 @@ static void select_target(int targ)
       NUM_ATTR_BYTES = 6;
       fatalerror("You cannot change NUM_ATTR_BYTES in Z-code");
     }
-    if (MAX_LOCAL_VARIABLES != 16) {
-      MAX_LOCAL_VARIABLES = 16;
-      fatalerror("You cannot change MAX_LOCAL_VARIABLES in Z-code");
-    }
   }
   else {
     /* Glulx */
     WORDSIZE = 4;
     MAXINTWORD = 0x7FFFFFFF;
     scale_factor = 0; /* It should never even get used in Glulx */
+
+    /* This could really be 120, since the practical limit is the size
+       of local_variables.keywords. But historically it's been 119. */
+    MAX_LOCAL_VARIABLES = 119; /* including "sp" */
 
     if (INDIV_PROP_START < 256) {
         INDIV_PROP_START = 256;
@@ -153,12 +155,6 @@ static void select_target(int targ)
     }
   }
 
-  if (MAX_LOCAL_VARIABLES >= 120) {
-    MAX_LOCAL_VARIABLES = 119;
-    warning("MAX_LOCAL_VARIABLES cannot exceed 119; resetting to 119");
-    /* This is because the keyword table in the lexer only has 120
-       entries. */
-  }
   if (DICT_WORD_SIZE > MAX_DICT_WORD_SIZE) {
     DICT_WORD_SIZE = MAX_DICT_WORD_SIZE;
     warning_numbered(

--- a/lexer.c
+++ b/lexer.c
@@ -1662,6 +1662,10 @@ extern void get_next_token(void)
                     "Name exceeds the maximum length of %d characters:",
                          MAX_IDENTIFIER_LENGTH);
                 error_named(bad_length, circle[circle_position].text);
+                /* Eat any further extra characters in the identifier */
+                while (((tokeniser_grid[lookahead] == IDENTIFIER_CODE)
+                        || (tokeniser_grid[lookahead] == DIGIT_CODE)))
+                    (*get_next_char)();
                 /* Trim token so that it doesn't violate
                    MAX_IDENTIFIER_LENGTH during error recovery */
                 circle[circle_position].text[MAX_IDENTIFIER_LENGTH] = 0;

--- a/lexer.c
+++ b/lexer.c
@@ -32,7 +32,7 @@ int next_token_begins_syntax_line;      /* When TRUE, start a new syntax
 int32 last_mapped_line;  /* Last syntax line reported to debugging file      */
 
 /* ------------------------------------------------------------------------- */
-/*   The lexer's output is a sequence of triples, each called a "token",     */
+/*   The lexer's output is a sequence of structs, each called a "token",     */
 /*   representing one lexical unit (or "lexeme") each.  Instead of providing */
 /*   "lookahead" (that is, always having available the next token after the  */
 /*   current one, so that syntax analysers higher up in Inform can have      */
@@ -43,9 +43,13 @@ int32 last_mapped_line;  /* Last syntax line reported to debugging file      */
 /*   For example, the lexeme "$1e3" is understood by Inform as a hexadecimal */
 /*   number, and translated to the token:                                    */
 /*     type NUMBER_TT, value 483, text "$1e3"                                */
+/*   (The token_data struct has several more optional fields which are used  */
+/*   for type-checking and error reporting.)                                 */
 /* ------------------------------------------------------------------------- */
 /*   These three variables are set to the current token on a call to         */
 /*   get_next_token() (but are not changed by a call to put_token_back()).   */
+/*   (It would be tidier to use a token_data structure, rather than having   */
+/*   get_next_token() unpack three values. But this is the way it is.)       */
 /* ------------------------------------------------------------------------- */
 
 int token_type;
@@ -751,6 +755,9 @@ static void interpret_identifier(int pos, int dirs_only_flag)
 
     circle[pos].value = symbol_index(p, hashcode);
     circle[pos].type = SYMBOL_TT;
+    /* The symindex, etc fields get set in expressp.c. Although there's
+       no particular reason they couldn't be set here, if get_next_token()
+       returned them, which currently it doesn't. */
 }
 
 

--- a/lexer.c
+++ b/lexer.c
@@ -612,10 +612,15 @@ static int *keywords_data_table;
 static int *local_variable_hash_table;
 static int *local_variable_hash_codes;
 
+/* Note that MAX_LOCAL_VARIABLES is the maximum number of local variables
+   for this VM, *including* "sp" (the stack pointer "local").
+   This used to be a memory setting. Now it is a constant: 16 for Z-code,
+   119 for Glulx.
+*/
+
 /* Names of local variables in the current routine.
-   This is allocated to MAX_LOCAL_VARIABLES-1. (We sometimes think of
-   the stack pointer as the first "local", but it's not included in this
-   array.)
+   This is allocated to MAX_LOCAL_VARIABLES-1. (The stack pointer "local"
+   is not included in this array.)
 
    (This could be a memlist, growing as needed up to MAX_LOCAL_VARIABLES-1.
    But right now we just allocate the max.)

--- a/lexer.c
+++ b/lexer.c
@@ -552,8 +552,10 @@ keyword_group *keyword_groups[12]
     &directive_keywords, &misc_keywords, &statements, &conditions,
     &system_functions, &system_constants, &opcode_macros};
 
+/* These keywords are set to point to local_variable_names entries when
+   a routine header is parsed. See construct_local_variable_tables().        */
 keyword_group local_variables =
-{ { "" },                                 /* Filled in when routine declared */
+{ { "" },
     LOCAL_VARIABLE_TT, FALSE, FALSE
 };
 

--- a/lexer.c
+++ b/lexer.c
@@ -609,13 +609,16 @@ static int *keywords_data_table;
 
 static int *local_variable_hash_table;
 static int *local_variable_hash_codes;
-char **local_variable_texts;
 
 /* Local variable N begins at char N*(MAX_IDENTIFIER_LENGTH+1).
    (This could be a memlist, growing as needed up to MAX_LOCAL_VARIABLES.
    But right now we just allocate the max.)
  */
 static char *local_variable_text_table;
+
+/* These pointers just point into local_variable_text_table. A bit
+   redundant, but it simplifies life. */
+char **local_variable_texts;
 
 static char one_letter_locals[128];
 
@@ -696,8 +699,11 @@ extern void construct_local_variable_tables(void)
         local_variable_hash_codes[i] = h;
         local_variable_texts[i] = p;
     }
-    for (;i<MAX_LOCAL_VARIABLES-1;i++) 
-      local_variable_texts[i] = "<no such local variable>";
+    for (;i<MAX_LOCAL_VARIABLES-1;i++) {
+        char *p = local_variable_text_table + i * (MAX_IDENTIFIER_LENGTH+1);
+        *p = 0;
+        local_variable_texts[i] = "<no such local variable>";
+    }
 }
 
 static void interpret_identifier(int pos, int dirs_only_flag)

--- a/memory.c
+++ b/memory.c
@@ -277,7 +277,6 @@ int TRANSCRIPT_FORMAT; /* 0: classic, 1: prefixed */
    which have different defaults under Z-code and Glulx. We have to get
    the defaults right whether the user sets "-G $HUGE" or "$HUGE -G". 
    And an explicit value set by the user should override both defaults. */
-static int MAX_LOCAL_VARIABLES_z, MAX_LOCAL_VARIABLES_g;
 static int DICT_WORD_SIZE_z, DICT_WORD_SIZE_g;
 static int NUM_ATTR_BYTES_z, NUM_ATTR_BYTES_g;
 static int MAX_DYNAMIC_STRINGS_z, MAX_DYNAMIC_STRINGS_g;
@@ -303,8 +302,6 @@ static void list_memory_sizes(void)
       printf("|  %25s = %-7d |\n","ZCODE_HEADER_FLAGS_3",ZCODE_HEADER_FLAGS_3);
     printf("|  %25s = %-7d |\n","INDIV_PROP_START", INDIV_PROP_START);
     if (glulx_mode)
-      printf("|  %25s = %-7d |\n","MAX_LOCAL_VARIABLES",MAX_LOCAL_VARIABLES);
-    if (glulx_mode)
       printf("|  %25s = %-7d |\n","MEMORY_MAP_EXTENSION",
         MEMORY_MAP_EXTENSION);
     if (glulx_mode)
@@ -324,8 +321,6 @@ extern void set_memory_sizes(void)
 {
     MAX_QTEXT_SIZE  = 4000;
     HASH_TAB_SIZE      = 512;
-    MAX_LOCAL_VARIABLES_z = 16;
-    MAX_LOCAL_VARIABLES_g = 119;
     DICT_CHAR_SIZE = 1;
     DICT_WORD_SIZE_z = 6;
     DICT_WORD_SIZE_g = 9;
@@ -357,14 +352,12 @@ extern void set_memory_sizes(void)
 extern void adjust_memory_sizes()
 {
   if (!glulx_mode) {
-    MAX_LOCAL_VARIABLES = MAX_LOCAL_VARIABLES_z;
     DICT_WORD_SIZE = DICT_WORD_SIZE_z;
     NUM_ATTR_BYTES = NUM_ATTR_BYTES_z;
     MAX_DYNAMIC_STRINGS = MAX_DYNAMIC_STRINGS_z;
     INDIV_PROP_START = 64;
   }
   else {
-    MAX_LOCAL_VARIABLES = MAX_LOCAL_VARIABLES_g;
     DICT_WORD_SIZE = DICT_WORD_SIZE_g;
     NUM_ATTR_BYTES = NUM_ATTR_BYTES_g;
     MAX_DYNAMIC_STRINGS = MAX_DYNAMIC_STRINGS_g;
@@ -448,12 +441,6 @@ static void explain_parameter(char *command)
     {   printf(
 "  Properties 1 to INDIV_PROP_START-1 are common properties; individual\n\
   properties are numbered INDIV_PROP_START and up.\n");
-        return;
-    }
-    if (strcmp(command,"MAX_LOCAL_VARIABLES")==0)
-    {   printf(
-"  MAX_LOCAL_VARIABLES is the number of local variables (including \n\
-  arguments) allowed in a procedure. (Glulx only)\n");
         return;
     }
     if (strcmp(command,"MAX_STACK_SIZE")==0)
@@ -729,8 +716,7 @@ extern void memory_command(char *command)
             if (strcmp(command,"MAX_OBJ_PROP_COUNT")==0)
                 flag=3;
             if (strcmp(command,"MAX_LOCAL_VARIABLES")==0)
-            {   MAX_LOCAL_VARIABLES=j, flag=1;
-                MAX_LOCAL_VARIABLES_g=MAX_LOCAL_VARIABLES_z=j;
+            {   flag=3;
             }
             if (strcmp(command,"MAX_GLOBAL_VARIABLES")==0)
             {   flag=3;

--- a/memory.c
+++ b/memory.c
@@ -325,7 +325,7 @@ extern void set_memory_sizes(void)
     MAX_QTEXT_SIZE  = 4000;
     HASH_TAB_SIZE      = 512;
     MAX_LOCAL_VARIABLES_z = 16;
-    MAX_LOCAL_VARIABLES_g = 32;
+    MAX_LOCAL_VARIABLES_g = 119;
     DICT_CHAR_SIZE = 1;
     DICT_WORD_SIZE_z = 6;
     DICT_WORD_SIZE_g = 9;

--- a/syntax.c
+++ b/syntax.c
@@ -433,7 +433,8 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
 
     no_locals = 0;
 
-    for (i=0;i<MAX_LOCAL_VARIABLES-1;i++) local_variables.keywords[i] = "";
+    for (i=0;i<MAX_LOCAL_VARIABLES-1;i++)
+        local_variable_names[i].text[0] = 0;
 
     do
     {   statements.enabled = TRUE;
@@ -467,12 +468,14 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         }
 
         for (i=0;i<no_locals;i++) {
-            if (strcmpcis(token_text, get_local_variable_name(i))==0)
+            if (strcmpcis(token_text, local_variable_names[i].text)==0)
                 error_named("Local variable defined twice:", token_text);
         }
-        set_local_variable_name(no_locals++, token_text);
+        strcpy(local_variable_names[no_locals++].text, token_text);
     } while(TRUE);
 
+    /* Set up the local variable hash and the local_variables.keywords
+       table. */
     construct_local_variable_tables();
 
     if ((trace_fns_setting==3)

--- a/syntax.c
+++ b/syntax.c
@@ -467,9 +467,9 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         }
 
         for (i=0;i<no_locals;i++)
-            if (strcmpcis(token_text, local_variables.keywords[i])==0)
+            if (strcmpcis(token_text, get_local_variable_name(i))==0)
                 error_named("Local variable defined twice:", token_text);
-        local_variables.keywords[no_locals++] = token_text;
+        set_local_variable_name(no_locals++, token_text);
     } while(TRUE);
 
     construct_local_variable_tables();

--- a/syntax.c
+++ b/syntax.c
@@ -466,9 +466,10 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
             break;
         }
 
-        for (i=0;i<no_locals;i++)
+        for (i=0;i<no_locals;i++) {
             if (strcmpcis(token_text, get_local_variable_name(i))==0)
                 error_named("Local variable defined twice:", token_text);
+        }
         set_local_variable_name(no_locals++, token_text);
     } while(TRUE);
 

--- a/veneer.c
+++ b/veneer.c
@@ -2190,11 +2190,13 @@ static void compile_symbol_table_routine(void)
 
     /* Assign local var names for the benefit of the debugging information 
        file. */
-    local_variable_texts[0] = local_variables.keywords[0] = "dummy1";
-    local_variable_texts[1] = local_variables.keywords[1] = "dummy2";
+    local_variable_texts[0] = "dummy1";
+    local_variable_texts[1] = "dummy2";
+    set_local_variable_name(0, local_variable_texts[0]);
+    set_local_variable_name(1, local_variable_texts[1]);
 
     if (glulx_mode && last_veneer_stackargs) {
-        local_variables.keywords[0] = "_vararg_count";
+        set_local_variable_name(0, "_vararg_count");
     }
 
     veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1);

--- a/veneer.c
+++ b/veneer.c
@@ -2189,14 +2189,13 @@ static void compile_symbol_table_routine(void)
     assembly_operand AO, AO2, AO3;
 
     /* Assign local var names for the benefit of the debugging information 
-       file. */
-    local_variable_texts[0] = "dummy1";
-    local_variable_texts[1] = "dummy2";
-    set_local_variable_name(0, local_variable_texts[0]);
-    set_local_variable_name(1, local_variable_texts[1]);
+       file. (We don't set local_variable.keywords because we're not
+       going to be parsing any code.)*/
+    strcpy(local_variable_names[0].text, "dummy1");
+    strcpy(local_variable_names[1].text, "dummy2");
 
     if (glulx_mode && last_veneer_stackargs) {
-        set_local_variable_name(0, "_vararg_count");
+        strcpy(local_variable_names[0].text, "_vararg_count");
     }
 
     veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1);

--- a/veneer.c
+++ b/veneer.c
@@ -2190,7 +2190,7 @@ static void compile_symbol_table_routine(void)
 
     /* Assign local var names for the benefit of the debugging information 
        file. (We don't set local_variable.keywords because we're not
-       going to be parsing any code.)*/
+       going to be parsing any code.) */
     strcpy(local_variable_names[0].text, "dummy1");
     strcpy(local_variable_names[1].text, "dummy2");
 


### PR DESCRIPTION
I left this one off the master list because it doesn't call memoryerror() per se. Nonetheless, we can clean it up.

MAX_LOCAL_VARIABLES still exists, but now it's set to a constant 16 in Z-code, 119 in Glulx. (It could be 120 in Glulx, really. I was off-by-one when I thought up the design twenty years ago. But it's not one of the limits people run into, so I'm leaving it as 119.)

(Confusingly, the maximum number of local variables for a routine is MAX_LOCAL_VARIABLES-1. That is, 15 and 118. This is because the "first" local variable is `sp`, the special-case stack pointer. So some of the locals arrays are zero-based and some are one-based, and this is how the limit wound up working. Sorry. Now that MAX_LOCAL_VARIABLES is no longer a settable value, it doesn't matter that it's confusing.)

Local variable names used to be a bit of a mess. parse_routine() used to stash copies of the `token_data` pointer in the `local_variables.keywords[]` array, and then call construct_local_variable_tables(), which copied the *strings* into `local_variable_text_table[]`, and *then* set `local_variable_texts[]` to point to those strings. So we had three arrays storing the same info. And the `local_variables.keywords[]` array contained references to the circular lexeme buffer, which was supposed to be short-lived. A mess.

We now have a single array `local_variable_names[]` which we copy the strings into. `local_variables.keywords[]` now refers to that. The order of initialization is different, but it makes more sense this way and there's no dependency on the lexeme buffer.

(Since MAX_LOCAL_VARIABLES is now a constant, we allocate `local_variable_names[]` all at once rather than using a memlist. It's an array of structs big enough to hold an identifier.)

---

Other bits:

In the "identifier too long" error case, we chew up the rest of the identifier before printing an error and continuing on. This reduces spurious follow-on errors.

The check for the magic "_vararg_count" local variable is now case-insensitive. This is consistent with how all other variable names are handled.

In make_global(), when we stash the current global/array name, we copy it into a memlist `current_array_name` rather than copying the `token_data` pointer. (C.f. the analogous `current_routine_name` and `current_object_name`.) This has nothing to do with local variables; I just ran across it while reviewing `token_data` use.


