### PR TITLE
Dynalloc: MAX_QTEXT_SIZE

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -575,7 +575,12 @@ extern void make_global(int array_flag, int name_only)
 
             i=0;
             do
-            {   get_next_token();
+            {
+                /* This isn't the start of a statement, but it's safe to
+                   release token texts anyway. Expressions in an array
+                   list are independent of each other. */
+                release_token_texts();
+                get_next_token();
                 if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
                     break;
 
@@ -662,7 +667,12 @@ advance as part of 'Zcharacter table':", unicode);
 
             i = 0;
             while (TRUE)
-            {   get_next_token();
+            {
+                /* This isn't the start of a statement, but it's safe to
+                   release token texts anyway. Expressions in an array
+                   list are independent of each other. */
+                release_token_texts();
+                get_next_token();
                 if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
                     continue;
                 if ((token_type == SEP_TT) && (token_value == CLOSE_SQUARE_SEP))

--- a/directs.c
+++ b/directs.c
@@ -418,14 +418,17 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         {   dont_enter_into_symbol_table = -2; n = 1;
             directives.enabled = TRUE;
             do
-            {   get_next_token();
+            {
+                release_token_texts();
+                get_next_token();
                 if (token_type == EOF_TT)
                 {   error("End of file reached in code 'If...'d out");
                     directives.enabled = FALSE;
                     return TRUE;
                 }
                 if (token_type == DIRECTIVE_TT)
-                {   switch(token_value)
+                {
+                    switch(token_value)
                     {   case ENDIF_CODE:
                             n--; break;
                         case IFV3_CODE:
@@ -498,7 +501,9 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         {   dont_enter_into_symbol_table = -2; n = 1;
             directives.enabled = TRUE;
             do
-            {   get_next_token();
+            {
+                release_token_texts();
+                get_next_token();
                 if (token_type == EOF_TT)
                 {   error("End of file reached in code 'If...'d out");
                     directives.enabled = FALSE;

--- a/header.h
+++ b/header.h
@@ -2640,7 +2640,7 @@ extern void  link_module(char *filename);
 
 extern size_t malloced_bytes;
 
-extern int MAX_QTEXT_SIZE,       HASH_TAB_SIZE,
+extern int HASH_TAB_SIZE,
            MAX_ABBREVS,
            MAX_DYNAMIC_STRINGS;
 

--- a/header.h
+++ b/header.h
@@ -884,8 +884,8 @@ typedef struct keyword_group_s
 
 typedef struct lexeme_data_s {
     char *text;  /* points at lextexts array */
-    int32 value; /* ###-long */
-    int type;
+    int32 value;
+    int type;    /* a *_TT value */
     debug_location location;
     int lextext; /* index of text string in lextexts */
     int context; /* lexical context used to interpret this token */
@@ -893,8 +893,8 @@ typedef struct lexeme_data_s {
 
 typedef struct token_data_s {
     char *text;
-    int32 value; /* ###-long */
-    int type;
+    int32 value;
+    int type;      /* a *_TT value */
     int symindex;
     int symtype;
     int symflags;

--- a/header.h
+++ b/header.h
@@ -2595,6 +2595,7 @@ extern brief_location blank_brief_location;
 
 extern void put_token_back(void);
 extern void get_next_token(void);
+extern void release_token_texts(void);
 extern void restart_lexer(char *lexical_source, char *name);
 
 extern keyword_group directives, statements, segment_markers,

--- a/header.h
+++ b/header.h
@@ -883,11 +883,12 @@ typedef struct keyword_group_s
 } keyword_group;
 
 typedef struct lexeme_data_s {
-    char *text;
+    char *text;  /* points at lextexts array */
     int32 value; /* ###-long */
     int type;
     debug_location location;
     int lextext; /* index of text string in lextexts */
+    int context; /* lexical context used to interpret this token */
 } lexeme_data;
 
 typedef struct token_data_s {

--- a/header.h
+++ b/header.h
@@ -886,6 +886,7 @@ typedef struct token_data_s
     int symflags;
     int marker;
     debug_location location;
+    int lextext; //###
 } token_data;
 
 typedef struct symbolinfo_s {

--- a/header.h
+++ b/header.h
@@ -882,16 +882,22 @@ typedef struct keyword_group_s
     int case_sensitive;
 } keyword_group;
 
-typedef struct token_data_s
-{   char *text;
+typedef struct lexeme_data_s {
+    char *text;
+    int32 value; /* ###-long */
+    int type;
+    debug_location location;
+    int lextext; /* index of text string in lextexts */
+} lexeme_data;
+
+typedef struct token_data_s {
+    char *text;
     int32 value; /* ###-long */
     int type;
     int symindex;
     int symtype;
     int symflags;
     int marker;
-    debug_location location;
-    int lextext; //###
 } token_data;
 
 typedef struct symbolinfo_s {
@@ -2585,7 +2591,9 @@ extern debug_location_beginning get_token_location_beginning(void);
 extern void discard_token_location(debug_location_beginning beginning);
 extern debug_locations get_token_location_end(debug_location_beginning beginning);
 
-extern void describe_token(const token_data *t);
+extern void describe_token_triple(const char *text, int32 value, int type);
+/* The describe_token() macro works on both token_data and lexeme_data structs. */
+#define describe_token(t) describe_token_triple((t)->text, (t)->value, (t)->type)
 
 extern void construct_local_variable_tables(void);
 extern void declare_systemfile(void);

--- a/lexer.c
+++ b/lexer.c
@@ -1463,7 +1463,7 @@ static int get_next_char_from_string(void)
 extern void release_token_texts(void)
 {
     int ix;
-    printf("### start of directive; %d lextexts allocated (putback %d)\n", no_lextexts, tokens_put_back);
+    //printf("### start of directive; %d lextexts allocated (putback %d)\n", no_lextexts, tokens_put_back);
     if (tokens_put_back == 0) {
         cur_lextexts = 0;
         return;

--- a/lexer.c
+++ b/lexer.c
@@ -1450,13 +1450,16 @@ extern void release_token_texts(void)
     }
 
     for (ix=0; ix<tokens_put_back; ix++) {
+        int oldpos;
         lextext temp;
         int pos = circle_position - tokens_put_back + 1 + ix;
         if (pos < 0) pos += CIRCLE_SIZE;
 
+        oldpos = circle[pos].lextext;
+        circle[pos].lextext = ix;
         temp = lextexts[ix];
-        lextexts[ix] = lextexts[circle[pos].lextext];
-        lextexts[circle[pos].lextext] = temp;
+        lextexts[ix] = lextexts[oldpos];
+        lextexts[oldpos] = temp;
     }
     cur_lextexts = tokens_put_back;
 
@@ -1874,6 +1877,7 @@ extern void restart_lexer(char *lexical_source, char *name)
     {   circle[i].type = 0;
         circle[i].value = 0;
         circle[i].text = "(if this is ever visible, there is a bug)";
+        circle[i].lextext = -1;
         token_contexts[i] = 0;
     }
 

--- a/lexer.c
+++ b/lexer.c
@@ -246,11 +246,12 @@ static lexeme_data circle[CIRCLE_SIZE];
 /*   held in Inform's memory for much longer periods: for example, a         */
 /*   dictionary word lexeme (like "'south'") must have its text preserved    */
 /*   until the code generation time for the expression it occurs in, when    */
-/*   the dictionary reference is actually made.  Code generation in general  */
-/*   occurs as early as possible in Inform: pending some better method of    */
-/*   garbage collection, we simply use a buffer so large that unless         */
-/*   expressions spread across 10K of source code are found, there can be    */
-/*   no problem.                                                             */
+/*   the dictionary reference is actually made. We handle this by keeping    */
+/*   all lexeme text until the end of the statement (or, for top-level       */
+/*   directives, until the end of the directive). Then we call               */
+/*   release_token_texts() to start over. The lextexts array will therefore  */
+/*   grow to the largest number of lexemes in a single statement or          */
+/*   directive.                                                              */
 /* ------------------------------------------------------------------------- */
 
 typedef struct lextext_s {

--- a/lexer.c
+++ b/lexer.c
@@ -1542,7 +1542,7 @@ static void lexaddc(char ch)
     lextexts[lex_index].text[lex_pos++] = ch;
 }
 
-/* Remove the last character */
+/* Remove the last character and ensure it's null-terminated */
 static void lexdelc(void)
 {
     if (lex_pos > 0) {

--- a/lexer.c
+++ b/lexer.c
@@ -1442,11 +1442,23 @@ static int get_next_char_from_string(void)
 
 extern void release_token_texts(void)
 {
+    int ix;
     printf("### start of directive; %d lextexts allocated (putback %d)\n", no_lextexts, tokens_put_back);
-    if (tokens_put_back > 0) {
-        fatalerror("###");
+    if (tokens_put_back == 0) {
+        cur_lextexts = 0;
+        return;
     }
-    cur_lextexts = 0;
+
+    for (ix=0; ix<tokens_put_back; ix++) {
+        lextext temp;
+        int pos = circle_position - tokens_put_back + 1 + ix;
+        if (pos < 0) pos += CIRCLE_SIZE;
+
+        temp = lextexts[ix];
+        lextexts[ix] = lextexts[circle[pos].lextext];
+        lextexts[circle[pos].lextext] = temp;
+    }
+    cur_lextexts = tokens_put_back;
 
     //###for (int ix=0; ix<no_lextexts; ix++) lextexts[ix].text[0] = 0; //###
 }
@@ -1538,6 +1550,7 @@ extern void get_next_token(void)
     lex_pos = 0;
     lextexts[lex_index].text[0] = 0; /* start with an empty string */
     
+    circle[circle_position].lextext = lex_index;
     circle[circle_position].text = NULL; /* will fill in later */
     circle[circle_position].value = 0;
     circle[circle_position].type = 0;

--- a/lexer.c
+++ b/lexer.c
@@ -1440,6 +1440,17 @@ static int get_next_char_from_string(void)
 /*                                   otherwise, to read from this string.    */
 /* ------------------------------------------------------------------------- */
 
+extern void release_token_texts(void)
+{
+    printf("### start of directive; %d lextexts allocated (putback %d)\n", no_lextexts, tokens_put_back);
+    if (tokens_put_back > 0) {
+        fatalerror("###");
+    }
+    cur_lextexts = 0;
+
+    //###for (int ix=0; ix<no_lextexts; ix++) lextexts[ix].text[0] = 0; //###
+}
+
 extern void put_token_back(void)
 {   tokens_put_back++;
 
@@ -1462,6 +1473,7 @@ static void lexaddc(char ch)
 {
     if (lex_pos >= lextexts[lex_index].size) {
         size_t newsize = lextexts[lex_index].size * 2;
+        //printf("### realloc lextext %d ('%c' at pos %d) from %ld to %ld: ", lex_index, ch, lex_pos, lextexts[lex_index].size, newsize); fwrite(lextexts[lex_index].text, 1, lextexts[lex_index].size, stdout); printf("\n");
         my_realloc(&lextexts[lex_index].text, lextexts[lex_index].size, newsize, "one lexeme text");
         lextexts[lex_index].size = newsize;
     }
@@ -1985,6 +1997,7 @@ extern void lexer_free_arrays(void)
     }
     deallocate_memory_list(&FileStack_memlist);
 
+    printf("### %d lextexts allocated (cur %d)\n", no_lextexts, cur_lextexts);
     for (ix=0; ix<no_lextexts; ix++) {
         my_free(&lextexts[ix].text, "one lexeme text");
     }

--- a/lexer.c
+++ b/lexer.c
@@ -43,8 +43,6 @@ int32 last_mapped_line;  /* Last syntax line reported to debugging file      */
 /*   For example, the lexeme "$1e3" is understood by Inform as a hexadecimal */
 /*   number, and translated to the token:                                    */
 /*     type NUMBER_TT, value 483, text "$1e3"                                */
-/*   (The token_data struct has several more optional fields which are used  */
-/*   for type-checking and error reporting.)                                 */
 /* ------------------------------------------------------------------------- */
 /*   These three variables are set to the current token on a call to         */
 /*   get_next_token() (but are not changed by a call to put_token_back()).   */
@@ -216,6 +214,11 @@ extern debug_locations get_token_location_end
 /*   0 and CIRCLE_SIZE-1.  We only need a circle size as large as the        */
 /*   maximum number of tokens ever put back at once, plus 1 (in effect, the  */
 /*   maximum token lookahead ever needed in syntax analysis, plus 1).        */
+/*                                                                           */
+/*   Note that the circle struct type is lexeme_data, whereas the expression */
+/*   code all works in token_data. They have slightly different needs. The   */
+/*   data is exported through the token_text, token_value, token_type        */
+/*   globals, so there's no need to use the same struct at both levels.      */
 /*                                                                           */
 /*   Unlike some compilers, Inform does not have a context-free lexer: in    */
 /*   fact it has 12288 different possible states.  However, the context only */
@@ -788,9 +791,6 @@ static void interpret_identifier(char *p, int pos, int dirs_only_flag)
 
     circle[pos].value = symbol_index(p, hashcode);
     circle[pos].type = SYMBOL_TT;
-    /* The symindex, etc fields get set in expressp.c. Although there's
-       no particular reason they couldn't be set here, if get_next_token()
-       returned them, which currently it doesn't. */
 }
 
 

--- a/lexer.c
+++ b/lexer.c
@@ -1717,6 +1717,10 @@ extern void get_next_token(void)
                     "Name exceeds the maximum length of %d characters:",
                          MAX_IDENTIFIER_LENGTH);
                 error_named(bad_length, lextexts[lex_index].text);
+                /* Eat any further extra characters in the identifier */
+                while (((tokeniser_grid[lookahead] == IDENTIFIER_CODE)
+                        || (tokeniser_grid[lookahead] == DIGIT_CODE)))
+                    (*get_next_char)();
                 /* Trim token so that it doesn't violate
                    MAX_IDENTIFIER_LENGTH during error recovery */
                 lextexts[lex_index].text[MAX_IDENTIFIER_LENGTH] = 0;

--- a/lexer.c
+++ b/lexer.c
@@ -236,7 +236,7 @@ extern debug_locations get_token_location_end
      old-style "objectloop (a in b)" and a new "objectloop (a in b ...)".)   */
 
 static int circle_position;
-static token_data circle[CIRCLE_SIZE];
+static lexeme_data circle[CIRCLE_SIZE];
 
 static int token_contexts[CIRCLE_SIZE];
 
@@ -298,7 +298,7 @@ static int tokens_put_back;             /* Count of the number of backward
                                            moves made from the last-read
                                            token                             */
 
-extern void describe_token(const token_data *t)
+extern void describe_token_triple(const char *text, int32 value, int type)
 {
     /*  Many of the token types are not set in this file, but later on in
         Inform's higher stages (for example, in the expression evaluator);
@@ -306,51 +306,51 @@ extern void describe_token(const token_data *t)
 
     printf("{ ");
 
-    switch(t->type)
+    switch(type)
     {
         /*  The following token types occur in lexer output:                 */
 
         case SYMBOL_TT:          printf("symbol ");
-                                 describe_symbol(t->value);
+                                 describe_symbol(value);
                                  break;
-        case NUMBER_TT:          printf("literal number %d", t->value);
+        case NUMBER_TT:          printf("literal number %d", value);
                                  break;
-        case DQ_TT:              printf("string \"%s\"", t->text);
+        case DQ_TT:              printf("string \"%s\"", text);
                                  break;
-        case SQ_TT:              printf("string '%s'", t->text);
+        case SQ_TT:              printf("string '%s'", text);
                                  break;
-        case SEP_TT:             printf("separator '%s'", t->text);
+        case SEP_TT:             printf("separator '%s'", text);
                                  break;
         case EOF_TT:             printf("end of file");
                                  break;
 
-        case STATEMENT_TT:       printf("statement name '%s'", t->text);
+        case STATEMENT_TT:       printf("statement name '%s'", text);
                                  break;
-        case SEGMENT_MARKER_TT:  printf("object segment marker '%s'", t->text);
+        case SEGMENT_MARKER_TT:  printf("object segment marker '%s'", text);
                                  break;
-        case DIRECTIVE_TT:       printf("directive name '%s'", t->text);
+        case DIRECTIVE_TT:       printf("directive name '%s'", text);
                                  break;
-        case CND_TT:             printf("textual conditional '%s'", t->text);
+        case CND_TT:             printf("textual conditional '%s'", text);
                                  break;
-        case OPCODE_NAME_TT:     printf("opcode name '%s'", t->text);
+        case OPCODE_NAME_TT:     printf("opcode name '%s'", text);
                                  break;
-        case SYSFUN_TT:          printf("built-in function name '%s'", t->text);
+        case SYSFUN_TT:          printf("built-in function name '%s'", text);
                                  break;
-        case LOCAL_VARIABLE_TT:  printf("local variable name '%s'", t->text);
+        case LOCAL_VARIABLE_TT:  printf("local variable name '%s'", text);
                                  break;
-        case MISC_KEYWORD_TT:    printf("statement keyword '%s'", t->text);
+        case MISC_KEYWORD_TT:    printf("statement keyword '%s'", text);
                                  break;
-        case DIR_KEYWORD_TT:     printf("directive keyword '%s'", t->text);
+        case DIR_KEYWORD_TT:     printf("directive keyword '%s'", text);
                                  break;
-        case TRACE_KEYWORD_TT:   printf("'trace' keyword '%s'", t->text);
+        case TRACE_KEYWORD_TT:   printf("'trace' keyword '%s'", text);
                                  break;
-        case SYSTEM_CONSTANT_TT: printf("system constant name '%s'", t->text);
+        case SYSTEM_CONSTANT_TT: printf("system constant name '%s'", text);
                                  break;
 
         /*  The remaining are etoken types, not set by the lexer             */
 
         case OP_TT:              printf("operator '%s'",
-                                     operators[t->value].description);
+                                     operators[value].description);
                                  break;
         case ENDEXP_TT:          printf("end of expression");
                                  break;
@@ -358,20 +358,20 @@ extern void describe_token(const token_data *t)
                                  break;
         case SUBCLOSE_TT:        printf("close bracket");
                                  break;
-        case LARGE_NUMBER_TT:    printf("large number: '%s'=%d",t->text,t->value);
+        case LARGE_NUMBER_TT:    printf("large number: '%s'=%d",text,value);
                                  break;
-        case SMALL_NUMBER_TT:    printf("small number: '%s'=%d",t->text,t->value);
+        case SMALL_NUMBER_TT:    printf("small number: '%s'=%d",text,value);
                                  break;
-        case VARIABLE_TT:        printf("variable '%s'=%d", t->text, t->value);
+        case VARIABLE_TT:        printf("variable '%s'=%d", text, value);
                                  break;
-        case DICTWORD_TT:        printf("dictionary word '%s'", t->text);
+        case DICTWORD_TT:        printf("dictionary word '%s'", text);
                                  break;
-        case ACTION_TT:          printf("action name '%s'", t->text);
+        case ACTION_TT:          printf("action name '%s'", text);
                                  break;
 
         default:
             printf("** unknown token type %d, text='%s', value=%d **",
-            t->type, t->text, t->value);
+            type, text, value);
     }
     printf(" }");
 }

--- a/lexer.c
+++ b/lexer.c
@@ -1716,10 +1716,6 @@ extern void get_next_token(void)
             quoted_size=0;
             do
             {   d = (*get_next_char)(); lexaddc(d);
-                if (quoted_size++==MAX_QTEXT_SIZE)
-                {   memoryerror("MAX_QTEXT_SIZE", MAX_QTEXT_SIZE);
-                    break;
-                }
                 if (d == '\n')
                 {   lex_pos--;
                     while (lexlastc() == ' ') lex_pos--;

--- a/lexer.c
+++ b/lexer.c
@@ -2035,7 +2035,6 @@ extern void lexer_free_arrays(void)
     }
     deallocate_memory_list(&FileStack_memlist);
 
-    printf("### %d lextexts allocated (cur %d)\n", no_lextexts, cur_lextexts);
     for (ix=0; ix<no_lextexts; ix++) {
         my_free(&lextexts[ix].text, "one lexeme text");
     }

--- a/lexer.c
+++ b/lexer.c
@@ -300,6 +300,9 @@ static int tokens_put_back;             /* Count of the number of backward
                                            moves made from the last-read
                                            token                             */
 
+/* This gets called for both token_data and lexeme_data structs. It prints
+   a description of the common part (the text, value, type fields). 
+*/
 extern void describe_token_triple(const char *text, int32 value, int type)
 {
     /*  Many of the token types are not set in this file, but later on in

--- a/lexer.c
+++ b/lexer.c
@@ -1534,7 +1534,7 @@ assumption inside Inform");
 /* Add one character */
 static void lexaddc(char ch)
 {
-    if (lex_pos >= lextexts[lex_index].size) {
+    if ((size_t)lex_pos >= lextexts[lex_index].size) {
         size_t newsize = lextexts[lex_index].size * 2;
         my_realloc(&lextexts[lex_index].text, lextexts[lex_index].size, newsize, "one lexeme text");
         lextexts[lex_index].size = newsize;

--- a/memory.c
+++ b/memory.c
@@ -255,7 +255,6 @@ void ensure_memory_list_available(memory_list *ML, size_t count)
 /*   Where the memory settings are declared as variables                     */
 /* ------------------------------------------------------------------------- */
 
-int MAX_QTEXT_SIZE;
 int HASH_TAB_SIZE;
 int MAX_ABBREVS;
 int MAX_DYNAMIC_STRINGS;
@@ -307,7 +306,6 @@ static void list_memory_sizes(void)
     if (glulx_mode)
       printf("|  %25s = %-7d |\n","GLULX_OBJECT_EXT_BYTES",
         GLULX_OBJECT_EXT_BYTES);
-    printf("|  %25s = %-7d |\n","MAX_QTEXT_SIZE",MAX_QTEXT_SIZE);
     if (glulx_mode)
       printf("|  %25s = %-7ld |\n","MAX_STACK_SIZE",
            (long int) MAX_STACK_SIZE);
@@ -319,7 +317,6 @@ static void list_memory_sizes(void)
 
 extern void set_memory_sizes(void)
 {
-    MAX_QTEXT_SIZE  = 4000;
     HASH_TAB_SIZE      = 512;
     DICT_CHAR_SIZE = 1;
     DICT_WORD_SIZE_z = 6;
@@ -367,12 +364,6 @@ extern void adjust_memory_sizes()
 
 static void explain_parameter(char *command)
 {   printf("\n");
-    if (strcmp(command,"MAX_QTEXT_SIZE")==0)
-    {   printf(
-"  MAX_QTEXT_SIZE is the maximum length of a quoted string.  Increasing\n\
-   by 1 costs 5 bytes (for lexical analysis memory)\n.");
-        return;
-    }
     if (strcmp(command,"HASH_TAB_SIZE")==0)
     {   printf(
 "  HASH_TAB_SIZE is the size of the hash tables used for the heaviest \n\
@@ -616,7 +607,7 @@ extern void memory_command(char *command)
             if (strcmp(command,"BUFFER_LENGTH")==0)
                 flag=2;
             if (strcmp(command,"MAX_QTEXT_SIZE")==0)
-            {   MAX_QTEXT_SIZE=j, flag=1;
+            {   flag=3;
             }
             if (strcmp(command,"MAX_SYMBOLS")==0)
                 flag=3;

--- a/objects.c
+++ b/objects.c
@@ -1174,7 +1174,8 @@ the names '%s' and '%s' actually refer to the same property",
                 }
                 ensure_memory_list_available(&embedded_function_name, strlen(prefix)+strlen(sep)+strlen(sym)+1);
                 sprintf(embedded_function_name.data, "%s%s%s", prefix, sep, sym);
-                
+
+                /* parse_routine() releases lexer text! */
                 AO.value = parse_routine(NULL, TRUE, embedded_function_name.data, FALSE, -1);
                 AO.type = LONG_CONSTANT_OT;
                 AO.marker = IROUTINE_MV;
@@ -1442,6 +1443,7 @@ the names '%s' and '%s' actually refer to the same property",
                 sprintf(embedded_function_name.data, "%s%s%s", prefix, sep, sym);
 
                 INITAOT(&AO, CONSTANT_OT);
+                /* parse_routine() releases lexer text! */
                 AO.value = parse_routine(NULL, TRUE, embedded_function_name.data, FALSE, -1);
                 AO.marker = IROUTINE_MV;
 

--- a/objects.c
+++ b/objects.c
@@ -125,6 +125,7 @@ more than",
 
     get_next_token();
     i = token_value; name = token_text;
+    /* We hold onto token_text through the end of this Property directive, which should be okay. */
     if (token_type != SYMBOL_TT)
     {   discard_token_location(beginning_debug_location);
         ebf_error("new attribute name", token_text);
@@ -223,6 +224,7 @@ Advanced game to get an extra 62)");
     get_next_token();
 
     i = token_value; name = token_text;
+    /* We hold onto token_text through the end of this Property directive, which should be okay. */
     if (token_type != SYMBOL_TT)
     {   discard_token_location(beginning_debug_location);
         ebf_error("new property name", token_text);

--- a/objects.c
+++ b/objects.c
@@ -179,6 +179,7 @@ more than",
 
 extern void make_property(void)
 {   int32 default_value, i;
+    int namelen;
     int additive_flag=FALSE; char *name;
     assembly_operand AO;
     debug_location_beginning beginning_debug_location =
@@ -244,7 +245,12 @@ Advanced game to get an extra 62)");
     get_next_token();
     directive_keywords.enabled = FALSE;
 
-    if (strcmp(name+strlen(name)-3, "_to") == 0) symbols[i].flags |= STAR_SFLAG;
+    namelen = strlen(name);
+    if (namelen > 3 && strcmp(name+namelen-3, "_to") == 0) {
+        /* Direction properties "n_to", etc are compared in some
+           libraries. They have STAR_SFLAG to tell us to skip a warning. */
+        symbols[i].flags |= STAR_SFLAG;
+    }
 
     if ((token_type == DIR_KEYWORD_TT) && (token_value == ALIAS_DK))
     {   discard_token_location(beginning_debug_location);

--- a/syntax.c
+++ b/syntax.c
@@ -145,6 +145,9 @@ extern int parse_directive(int internal_flag)
     int is_renamed;
 
     begin_syntax_line(FALSE);
+    if (!internal_flag) {
+        //###release_token_texts();
+    }
     get_next_token();
 
     if (token_type == EOF_TT) return(FALSE);
@@ -487,6 +490,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
     do
     {   begin_syntax_line(TRUE);
 
+        //###release_token_texts();
         get_next_token();
 
         if (token_type == EOF_TT)

--- a/syntax.c
+++ b/syntax.c
@@ -133,9 +133,9 @@ extern void parse_program(char *source)
 
 extern int parse_directive(int internal_flag)
 {
-    /*  Internal_flag is FALSE if the directive is encountered normally,
-        TRUE if encountered with a # prefix inside a routine or object
-        definition.
+    /*  Internal_flag is FALSE if the directive is encountered normally
+        (at the top level of the program); TRUE if encountered with 
+        a # prefix inside a routine or object definition.
 
         (Only directives like #ifdef are permitted inside a definition.)
 
@@ -146,6 +146,8 @@ extern int parse_directive(int internal_flag)
 
     begin_syntax_line(FALSE);
     if (!internal_flag) {
+        /* An internal directive can occur in the middle of an expression or
+           object definition. So we only release for top-level directives.   */
         release_token_texts();
     }
     get_next_token();
@@ -251,6 +253,7 @@ extern int parse_directive(int internal_flag)
     return !(parse_given_directive(internal_flag));
 }
 
+/* Check what's coming up after a switch case value. */
 static int switch_sign(void)
 {
     if ((token_type == SEP_TT)&&(token_value == COLON_SEP))   return 1;
@@ -493,7 +496,6 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
 
     do
     {   begin_syntax_line(TRUE);
-
         release_token_texts();
         get_next_token();
 
@@ -603,11 +605,13 @@ extern void parse_code_block(int break_label, int continue_label,
         unary_minus_flag;
 
     begin_syntax_line(TRUE);
+    release_token_texts();
     get_next_token();
 
     if (token_type == SEP_TT && token_value == OPEN_BRACE_SEP)
     {   do
         {   begin_syntax_line(TRUE);
+            release_token_texts();
             get_next_token();
             
             if ((token_type == SEP_TT) && (token_value == HASH_SEP))

--- a/syntax.c
+++ b/syntax.c
@@ -146,7 +146,7 @@ extern int parse_directive(int internal_flag)
 
     begin_syntax_line(FALSE);
     if (!internal_flag) {
-        //###release_token_texts();
+        release_token_texts();
     }
     get_next_token();
 
@@ -490,7 +490,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
     do
     {   begin_syntax_line(TRUE);
 
-        //###release_token_texts();
+        release_token_texts();
         get_next_token();
 
         if (token_type == EOF_TT)


### PR DESCRIPTION
Finally got this nailed down.

We now store lexeme texts in an extendable array of extendable strings. (The array `lextexts` is handled by a memlist. The individual strings are just malloced and realloced as needed.)

All the places in get_next_token() that used to write directly into the circular buffer now call lexaddc(). This reallocs the current string as needed.

We accumulate lextexts until a new statement begins. At that point it's safe to clear out the array and reuse the strings. (The expression code generator needs us to keep lextexts alive until the expression is completely generated. But we don't need to keep them alive between statements.)

Clearing the array is done by the release_token_texts() call. We call this in a few places, actually:

- Before every top-level directive.
- Before every statement in a code block.
- Before every top-level statement in a function. (Redundant with the above, but it's a cheap call.)
- Between entries in an array initializer directive. (An array init line can contain many expressions, but the expressions are all independent.)
- After every token when skipping a section of #ifdefed-out code.

(Nitpick: if a token has been pushed back via put_token_back(), release_token_texts() retains that token at the head of the lextexts array.)

---

Other stuff:

I split the `token_data` struct into `lexeme_data` (used in the lexer) and `token_data` (used in the expression parser). We never assign directly from one context to the other; token data is exported through the `token_type, token_value, token_text` fields. Both structs contain those three fields, but they have different supporting fields, so it made sense to split them up.

(The `token_contexts[]` array got merged into `lexeme_data` as part of this change. It was one of those supporting fields.)

This makes the describe_token() routine a little messy, since it's used on both. I changed it to describe_token_triple() with three arguments. Then there's a describe_token() *macro* that calls that.

In make_property(), I fixed a potential string underrun when checking for property names ending in "_to".

In make_verb(), we were keeping an array of `token_text` pointers in `English_verbs_given[]`. We now copy the strings themselves into `English_verbs_given[]`, which is now a concatenated string array. 
