### PR TITLE
Declare individual properties

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -756,7 +756,10 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         break;
 
     /* --------------------------------------------------------------------- */
-    /*   Property [long] [additive] name [alias oldname] [defaultvalue]      */
+    /*   Property [long] [additive] name                                     */
+    /*   Property [long] [additive] name [alias oldname]                     */
+    /*   Property [long] [additive] name [defaultvalue]                      */
+    /*   Property [long] individual name                                     */
     /* --------------------------------------------------------------------- */
 
     case PROPERTY_CODE: make_property(); break;           /* See "objects.c" */

--- a/directs.c
+++ b/directs.c
@@ -757,8 +757,8 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
 
     /* --------------------------------------------------------------------- */
     /*   Property [long] [additive] name                                     */
-    /*   Property [long] [additive] name [alias oldname]                     */
-    /*   Property [long] [additive] name [defaultvalue]                      */
+    /*   Property [long] [additive] name alias oldname                       */
+    /*   Property [long] [additive] name defaultvalue                        */
     /*   Property [long] individual name                                     */
     /* --------------------------------------------------------------------- */
 

--- a/directs.c
+++ b/directs.c
@@ -756,7 +756,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         break;
 
     /* --------------------------------------------------------------------- */
-    /*   Property [long] [additive] name [alias oldname]                     */
+    /*   Property [long] [additive] name [alias oldname] [defaultvalue]      */
     /* --------------------------------------------------------------------- */
 
     case PROPERTY_CODE: make_property(); break;           /* See "objects.c" */

--- a/header.h
+++ b/header.h
@@ -2711,9 +2711,6 @@ extern classinfo *class_info;
 extern memory_list class_info_memlist;
 
 extern commonpropinfo *commonprops;
-extern int32 *prop_default_value;
-extern int *prop_is_long;
-extern int *prop_is_additive;
 extern uchar *properties_table;
 extern memory_list properties_table_memlist;
 extern int properties_table_size;

--- a/header.h
+++ b/header.h
@@ -773,6 +773,16 @@ typedef struct classinfo_s {
     int32 begins_at;
 } classinfo;
 
+/* Common property information. */
+typedef struct commonpropinfo_s {
+    int32 default_value;   /* Common property default value */
+    int is_long;           /* "Long" means "never write a 1-byte value to
+                              this property", and is an obsolete feature:
+                              since Inform 5 all properties have been "long" */
+    int is_additive;       /* "Additive" means that values accumulate rather
+                              than erase each other during class inheritance */
+} commonpropinfo;
+
 /* Property entry record (Z). */
 typedef struct prop {
     uchar l, num;
@@ -2699,6 +2709,7 @@ extern uchar *objectatts;
 extern classinfo *class_info;
 extern memory_list class_info_memlist;
 
+extern commonpropinfo *commonprops;
 extern int32 *prop_default_value;
 extern int *prop_is_long;
 extern int *prop_is_additive;

--- a/header.h
+++ b/header.h
@@ -1581,6 +1581,7 @@ typedef struct operator_s
 #define WARNING_DK      34
 #define TERMINATING_DK  35
 #define STATIC_DK       36
+#define INDIVIDUAL_DK   37
 
 /*  Index numbers into the keyword group "trace_keywords" (see "lexer.c")  */
 

--- a/lexer.c
+++ b/lexer.c
@@ -501,7 +501,7 @@ keyword_group directive_keywords =
     "string", "table", "buffer", "data", "initial", "initstr",
     "with", "private", "has", "class",
     "error", "fatalerror", "warning",
-    "terminating", "static",
+    "terminating", "static", "individual",
     "" },
     DIR_KEYWORD_TT, FALSE, TRUE
 };

--- a/objects.c
+++ b/objects.c
@@ -178,8 +178,10 @@ more than",
 }
 
 /* Format:
+   Property [long] [additive] name
    Property [long] [additive] name [alias oldname]
    Property [long] [additive] name [defaultvalue]
+   Property [long] individual name
  */
 extern void make_property(void)
 {   int32 default_value, i;

--- a/objects.c
+++ b/objects.c
@@ -188,11 +188,14 @@ extern void make_property(void)
     if (!glulx_mode) {
         if (no_properties==((version_number==3)?32:64))
         {   discard_token_location(beginning_debug_location);
+            /* The maximum listed here includes "name" but not the 
+               unused zero value or the two hidden properties (class
+               inheritance and indiv table). */
             if (version_number==3)
-                error("All 30 properties already declared (compile as \
-Advanced game to get an extra 62)");
+                error("All 29 properties already declared (compile as \
+Advanced game to get 32 more)");
             else
-                error("All 62 properties already declared");
+                error("All 61 properties already declared");
             panic_mode_error_recovery();
             put_token_back();
             return;

--- a/objects.c
+++ b/objects.c
@@ -179,8 +179,8 @@ more than",
 
 /* Format:
    Property [long] [additive] name
-   Property [long] [additive] name [alias oldname]
-   Property [long] [additive] name [defaultvalue]
+   Property [long] [additive] name alias oldname
+   Property [long] [additive] name defaultvalue
    Property [long] individual name
  */
 extern void make_property(void)

--- a/objects.c
+++ b/objects.c
@@ -178,13 +178,15 @@ more than",
 }
 
 /* Format:
-   Property [long] [additive] name [alias oldname] [defaultvalue]
+   Property [long] [additive] name [alias oldname]
+   Property [long] [additive] name [defaultvalue]
  */
 extern void make_property(void)
 {   int32 default_value, i;
+    char *name;
     int namelen;
     int additive_flag=FALSE;
-    char *name;
+    int indiv_flag=FALSE;
     debug_location_beginning beginning_debug_location =
         get_token_location_beginning();
 
@@ -223,6 +225,9 @@ Advanced game to get 32 more)");
         else
         if ((token_type == DIR_KEYWORD_TT) && (token_value == ADDITIVE_DK))
             additive_flag = TRUE;
+        else
+        if ((token_type == DIR_KEYWORD_TT) && (token_value == INDIVIDUAL_DK))
+            indiv_flag = TRUE;
         else break;
     } while (TRUE);
 
@@ -245,6 +250,29 @@ Advanced game to get 32 more)");
         panic_mode_error_recovery();
         put_token_back();
         return;
+    }
+
+    if (indiv_flag) {
+        int this_identifier_number;
+        
+        if (additive_flag)
+        {   error("'individual' incompatible with 'additive'");
+            panic_mode_error_recovery();
+            put_token_back();
+            return;
+        }
+
+        this_identifier_number = no_individual_properties++;
+        assign_symbol(i, this_identifier_number, INDIVIDUAL_PROPERTY_T);
+        if (debugfile_switch) {
+            debug_file_printf("<property>");
+            debug_file_printf
+                ("<identifier>%s</identifier>", name);
+            debug_file_printf
+                ("<value>%d</value>", this_identifier_number);
+            debug_file_printf("</property>");
+        }
+        return;        
     }
 
     directive_keywords.enabled = TRUE;

--- a/objects.c
+++ b/objects.c
@@ -177,11 +177,14 @@ more than",
     return;
 }
 
+/* Format:
+   Property [long] [additive] name [alias oldname] [defaultvalue]
+ */
 extern void make_property(void)
 {   int32 default_value, i;
     int namelen;
-    int additive_flag=FALSE; char *name;
-    assembly_operand AO;
+    int additive_flag=FALSE;
+    char *name;
     debug_location_beginning beginning_debug_location =
         get_token_location_beginning();
 
@@ -284,7 +287,8 @@ Advanced game to get 32 more)");
     put_token_back();
 
     if (!((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)))
-    {   AO = parse_expression(CONSTANT_CONTEXT);
+    {
+        assembly_operand AO = parse_expression(CONSTANT_CONTEXT);
         default_value = AO.value;
         if (AO.marker != 0)
             backpatch_zmachine(AO.marker, PROP_DEFAULTS_ZA, 

--- a/objects.c
+++ b/objects.c
@@ -253,10 +253,12 @@ Advanced game to get 32 more)");
 
     namelen = strlen(name);
     if (namelen > 3 && strcmp(name+namelen-3, "_to") == 0) {
-        /* Direction properties "n_to", etc are compared in some
+        /* Direction common properties "n_to", etc are compared in some
            libraries. They have STAR_SFLAG to tell us to skip a warning. */
         symbols[i].flags |= STAR_SFLAG;
     }
+
+    /* Now we might have "alias" or a default value (but not both). */
 
     if ((token_type == DIR_KEYWORD_TT) && (token_value == ALIAS_DK))
     {   discard_token_location(beginning_debug_location);
@@ -2191,7 +2193,11 @@ extern void objects_begin_pass(void)
     no_properties = 4;
 
     if (debugfile_switch)
-    {   debug_file_printf("<property>");
+    {
+        /* These two properties are not symbols, so they won't be emitted
+           by emit_debug_information_for_predefined_symbol(). Do it
+           manually. */
+        debug_file_printf("<property>");
         debug_file_printf
             ("<identifier artificial=\"true\">inheritance class</identifier>");
         debug_file_printf("<value>2</value>");

--- a/tables.c
+++ b/tables.c
@@ -358,8 +358,8 @@ static void construct_storyfile_z(void)
     p[mark++]=0; p[mark++]=0;
 
     for (i=2; i< ((version_number==3)?32:64); i++)
-    {   p[mark++]=prop_default_value[i]/256;
-        p[mark++]=prop_default_value[i]%256;
+    {   p[mark++]=commonprops[i].default_value/256;
+        p[mark++]=commonprops[i].default_value%256;
     }
 
     object_tree_at = mark;
@@ -1395,7 +1395,7 @@ static void construct_storyfile_g(void)
 
     prop_defaults_at = mark;
     for (i=0; i<no_properties; i++) {
-      k = prop_default_value[i];
+      k = commonprops[i].default_value;
       WriteInt32(p+mark, k);
       mark += 4;
     }


### PR DESCRIPTION
It is now possible to declare an individual property with the `Property` directive:

	Property individual propname;

(This handles https://github.com/DavidKinder/Inform6/issues/126 .)

This gives us a total of four forms of the directive:

	Property [long] [additive] name;
	Property [long] [additive] name defaultexpr;
	Property [long] [additive] name alias oldname;
	Property [long] individual name;

Note that an individual property cannot be `additive`, have a default value, or `alias` another property.

The `long` keyword has no effect except a deprecation warning. (All properties have been `long`, which is to say word-sized, since Inform 5.)

Also, it is now possible to declare a property called `long`, `additive`, or `individual`. It was previously impossible to declare properties `long` or `additive`, because those were keywords in this context. The compiler will now look at, e.g:

	Property long long additive long;

...and recognize that `long` is the last symbol before the semicolon/default value, so this must declare a property called "long". (Redundant keywords have always been accepted.)

---

Internally, I shoved the `prop_default_value[]`, `prop_is_long[]`, `prop_is_additive[]` arrays together into an array of structs called `commonprops[]`.

I adjusted the Z-code error "All 62 properties already declared" (or 30 for v3) to say "All 61 (29) properties already declared" instead. This is a bit messier than it looks. The Z-machine actually supports 63 (31) properties, numbered from 1 up. Inform automatically declares `name`, and then creates two hidden (nameless) properties (for class inheritance and the indiv prop table). So, from the user's point of view, 60 (28) *more* properties may be declared. Then the library declares a bunch.

Most people will consider `name` to be a library property (even though it's not declared in the library.) So  I thought it clearest to say that the limit is 61 (29) declared properties, including `name`.




