### PR TITLE
Switch -u generates $MAX_ABBREVS abbreviations

### DIFF
--- a/text.c
+++ b/text.c
@@ -1487,9 +1487,10 @@ extern void optimise_abbreviations(void)
         test.text[3]=0;
         if ((test.text[0]=='\n')||(test.text[1]=='\n')||(test.text[2]=='\n'))
             goto DontKeep;
-        for (j=0; j<no_occs; j++)
+        for (j=0; j<no_occs; j++) {
             if (strcmp(test.text,tlbtab[j].text)==0)
                 goto DontKeep;
+        }
         test.occurrences=0;
         test.intab=0;
         for (j=i+3; j<opttextlen; j++)

--- a/text.c
+++ b/text.c
@@ -1418,7 +1418,7 @@ static int any_overlap(char *s1, char *s2)
 }
 
 extern void optimise_abbreviations(void)
-{   int32 i, j, t, max=0, MAX_GTABLE;
+{   int32 i, j, tcount, max=0, MAX_GTABLE;
     int32 j2, selected, available, maxat=0, nl;
 
     if (opttext == NULL)
@@ -1478,7 +1478,7 @@ extern void optimise_abbreviations(void)
     MAX_GTABLE=opttextlen+1;
     grandtable=my_calloc(4*sizeof(int32), MAX_GTABLE/4, "grandtable");
 
-    for (i=0, t=0; i<opttextlen; i++)
+    for (i=0, tcount=0; i<opttextlen; i++)
     {
         tlb test;
         test.text[0]=opttext[i];
@@ -1506,9 +1506,9 @@ extern void optimise_abbreviations(void)
             if ((opttext[i]==opttext[j])
                  && (opttext[i+1]==opttext[j+1])
                  && (opttext[i+2]==opttext[j+2]))
-                 {   grandtable[t+test.occurrences]=j;
+                 {   grandtable[tcount+test.occurrences]=j;
                      test.occurrences++;
-                     if (t+test.occurrences==MAX_GTABLE)
+                     if (tcount+test.occurrences==MAX_GTABLE)
                      {   printf("All %ld cross-references used\n",
                              (long int) MAX_GTABLE);
                          goto Built;
@@ -1519,7 +1519,8 @@ extern void optimise_abbreviations(void)
         {
             ensure_memory_list_available(&tlbtab_memlist, no_occs+1);
             tlbtab[no_occs]=test;
-            tlbtab[no_occs].intab=t; t+=tlbtab[no_occs].occurrences;
+            tlbtab[no_occs].intab=tcount;
+            tcount += tlbtab[no_occs].occurrences;
             if (max<tlbtab[no_occs].occurrences)
                 max=tlbtab[no_occs].occurrences;
             no_occs++;

--- a/text.c
+++ b/text.c
@@ -1313,8 +1313,8 @@ typedef struct optab_s
     char text[MAX_ABBREV_LENGTH];
 } optab;
 static int32 MAX_BESTYET;
-static optab *bestyet; /* High-score entries (up to MAX_BESTYET) */
-static optab *bestyet2; /* The selected entries (up to MAX_ABBREVS) */
+static optab *bestyet; /* High-score entries (up to MAX_BESTYET used/allocated) */
+static optab *bestyet2; /* The selected entries (up to selected used; allocated to MAX_ABBREVS) */
 
 static int pass_no;
 
@@ -1441,7 +1441,7 @@ extern void optimise_abbreviations(void)
     
     no_occs=0;
 
-    /* Not sure what the optimal size is here. The original code used MAX_BESTYET=256 and MAX_ABBREVS=64. */
+    /* Not sure what the optimal size is for MAX_BESTYET. The original code always created 64 abbreviations and used MAX_BESTYET=256. I'm guessing that 4*MAX_ABBREVS is reasonable. */
     MAX_BESTYET = 4 * MAX_ABBREVS;
     
     bestyet=my_calloc(sizeof(optab), MAX_BESTYET, "bestyet");
@@ -1454,6 +1454,8 @@ extern void optimise_abbreviations(void)
     bestyet2[1].text[0]=',';
     bestyet2[1].text[1]=' ';
     bestyet2[1].text[2]=0;
+
+    selected=2;
 
     for (i=0; i<opttextlen; i++)
     {
@@ -1536,7 +1538,7 @@ extern void optimise_abbreviations(void)
                 tlbtab[i].occurrences);
     */
 
-    for (i=0; i<MAX_ABBREVS; i++) bestyet2[i].length=0; selected=2;
+    for (i=0; i<MAX_ABBREVS; i++) bestyet2[i].length=0;
     available=MAX_BESTYET;
     while ((available>0)&&(selected<MAX_ABBREVS))
     {   printf("Pass %d\n", ++pass_no);


### PR DESCRIPTION
I think I've figured this out (issue https://github.com/DavidKinder/Inform6/issues/97).

This is very gnarly and ancient code. Most of my changes are comments and tidying up code for clarity.

`tlbtab[]` is now a memlist. This is only used during optimise_abbreviations(), so it's freed in ao_free_arrays(). ("tlb" stands for "three-letter block", it turns out! I had been reading it as "translation lookaside buffer", which makes no sense.)

`bestyet2[]` is allocated with MAX_ABBREVS entries. `bestyet[]` is allocated with MAX_BESTYET entries, where MAX_BESTYET = 4*MAX_ABBREVS. I'm guessing this is sensible because the old code allocated `bestyet[]` with 256 entries for 64 abbreviations. Maybe? It seems to produce sensible results when MAX_ABBREVS is 96 and MAX_BESTYET is 384.

If MAX_ABBREVS is set less than 2, we skip the whole process. It's hardwired to set the first two abbreviations to `". "` and `", "`.

Testing: https://github.com/erkyrath/Inform6-Testing/tree/create-max-abbrevs does some compiles (using `English.h` from the I6 library) with MAX_ABBREVS of 2, 10, 20, and 96.
