### PR TITLE
Fixed property count in -s report

### DIFF
--- a/objects.c
+++ b/objects.c
@@ -210,9 +210,12 @@ Advanced game to get 32 more)");
     }
     else {
         if (no_properties==INDIV_PROP_START) {
+            char error_b[128];
             discard_token_location(beginning_debug_location);
-            error_numbered("All properties already declared -- max is",
-                INDIV_PROP_START);
+            sprintf(error_b,
+                "All %d properties already declared (increase INDIV_PROP_START to get more)",
+                INDIV_PROP_START-3);
+            error(error_b);
             panic_mode_error_recovery(); 
             put_token_back();
             return;

--- a/tables.c
+++ b/tables.c
@@ -1689,7 +1689,7 @@ Out:   %s %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
                  no_grammar_tokens,
                  no_actions,
                  no_attributes, NUM_ATTR_BYTES*8,
-                 no_properties, INDIV_PROP_START,
+                 no_properties-3, INDIV_PROP_START-3,
                  no_individual_properties - INDIV_PROP_START);
 
             if (track_unused_routines)


### PR DESCRIPTION
For both Z-code and Glulx, a trivial I6 game now reports "1 common prop used" -- that being `name`, which the compiler always defines.

The maximum is shown as 29 (v3), 61 (v4+), or INDIV_PROP_START-3 (Glulx). This is consistent with the count shown. Both the count and maximum include `name`. So if you define MAX-1 properties (not counting `name`), it compiles. If you add one more than that, you get an error.

The error message for exceeding the maximum in Glulx is now

> Error:  All 253 properties already declared (increase INDIV_PROP_START to get more)

Again, this is consistent with the Z-code behavior.

