### PR TITLE
Change abbreviation-too-short error to a warning

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -109,10 +109,7 @@ extern int parse_given_directive(int internal_flag)
                panic_mode_error_recovery(); return FALSE;
            }
            if (token_type != DQ_TT)
-               return ebf_error_recover("abbreviation string", token_text);
-           if (strlen(token_text)<2)
-           {   error_named("It's not worth abbreviating", token_text);
-               continue;
+           {   return ebf_error_recover("abbreviation string", token_text);
            }
            /* Abbreviation string with null must fit in a MAX_ABBREV_LENGTH
               array. */

--- a/text.c
+++ b/text.c
@@ -506,7 +506,7 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
     if (economy_switch)
     {   
         uchar *q, c;
-        int l, min_score, from, abbr_length;
+        int l, min_score, from;
         int text_in_length;
 
         text_in_length = strlen( (char*) text_in);
@@ -527,19 +527,16 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
                     (k<no_abbreviations)&&(c==q[0]); k++, q+=MAX_ABBREV_LENGTH)
                 {   
                     /* Let's compare; we also keep track of the length of the abbreviation. */
-                    if (text_in[j+1]==q[1])
-                    {   abbr_length = 2;
-                        for (l=2; q[l]!=0; l++)
-                        {    if (text_in[j+l]!=q[l]) {goto NotMatched;} else {abbr_length++;}
-                        }
-                        /* We have a match, but is it smaller in size? */
-                        if (min_score > 2 + abbreviations_optimal_parse_scores[j+abbr_length])
-                        {   /* It is indeed smaller, so let's write it down in our schedule. */
-                            min_score = 2 + abbreviations_optimal_parse_scores[j+abbr_length];
-                            abbreviations_optimal_parse_schedule[j] = k;
-                        }
-                        NotMatched: ;
+                    for (l=1; q[l]!=0; l++)
+                    {    if (text_in[j+l]!=q[l]) {goto NotMatched;}
                     }
+                    /* We have a match (length l), but is it smaller in size? */
+                    if (min_score > 2 + abbreviations_optimal_parse_scores[j+l])
+                    {   /* It is indeed smaller, so let's write it down in our schedule. */
+                        min_score = 2 + abbreviations_optimal_parse_scores[j+l];
+                        abbreviations_optimal_parse_schedule[j] = k;
+                    }
+                    NotMatched: ;
                 }
             }
             /* We gave it our best, this is the smallest we got. */

--- a/text.c
+++ b/text.c
@@ -226,6 +226,10 @@ extern void make_abbreviation(char *text)
 
     abbreviations[no_abbreviations].quality = zchars_trans_in_last_string - 2;
 
+    if (abbreviations[no_abbreviations].quality < 0) {
+        warning_named("Abbreviation uses more characters than it saves:", text);
+    }
+    
     no_abbreviations++;
 }
 

--- a/text.c
+++ b/text.c
@@ -226,8 +226,8 @@ extern void make_abbreviation(char *text)
 
     abbreviations[no_abbreviations].quality = zchars_trans_in_last_string - 2;
 
-    if (abbreviations[no_abbreviations].quality < 0) {
-        warning_named("Abbreviation uses more characters than it saves:", text);
+    if (abbreviations[no_abbreviations].quality <= 0) {
+        warning_named("Abbreviation does not save any characters:", text);
     }
     
     no_abbreviations++;


### PR DESCRIPTION
If the user wants to create an abbreviation which doesn't save any Z-chars, we show a warning, but we let them do it.

The warning is now checked in make_abbreviations(). We check the Z-char length, not the raw text length, so the warning is more appropriate.

(It doesn't make sense in Glulx, but all the abbreviation quality computations are wrong in Glulx.)

We now warn if the abbreviation improvement is less than *or equal to* zero. The old error only checked for strlen==1. So this will now generate a warning:

    Abbreviate "an";

Previously it would be accepted without complaint.

Added a couple of tests to https://github.com/erkyrath/Inform6-Testing/tree/abbrev-len-warning . The existing `src/abbrevtest.inf` now generates some warnings, which it didn't before.
