### PR TITLE
Check for overflow of the Link "..." directive

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -591,6 +591,10 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         get_next_token();
         if (token_type != DQ_TT)
             return ebf_error_recover("filename in double-quotes", token_text);
+        if (strlen(token_text) >= PATHLEN-1) {
+            error_numbered("'Link' filename is too long; max length is", PATHLEN-1);
+            break;
+        }
         link_module(token_text);                           /* See "linker.c" */
         break;
 

--- a/linker.c
+++ b/linker.c
@@ -505,12 +505,12 @@ static void backpatch_module_image(uchar *p,
 /*   The main routine: linking in a module with the given filename.          */
 /* ------------------------------------------------------------------------- */
 
-char current_module_filename[128];
+char current_module_filename[PATHLEN];
 
 void link_module(char *given_filename)
 {   FILE *fin;
     int record_type;
-    char filename[128];
+    char filename[PATHLEN];
     uchar *p, p0[64];
     int32 last, i, j, k, l, m, vn, len, size, link_offset, module_size, map,
           max_property_identifier, symbols_base = no_symbols;
@@ -631,7 +631,7 @@ of the Inform 6 compiler knows about: it may not link in correctly", filename);
     no_rr = 0;
 
     if ((linker_trace_level>=1) || transcript_switch)
-    {   char link_banner[128];
+    {   char link_banner[PATHLEN+128];
         sprintf(link_banner,
             "[Linking release %d.%c%c%c%c%c%c of module '%s' (size %dK)]",
             p[2]*256 + p[3], p[18], p[19], p[20], p[21], p[22], p[23],


### PR DESCRIPTION
...and its buffers.

(I looked at `link_errorm[128]`, but that's used only for short messages plus a few symbols and type names. Symbols are limited to 32 chars.)
