### PR TITLE
Extended dynamic-string syntax

### DIFF
--- a/errors.c
+++ b/errors.c
@@ -370,7 +370,7 @@ extern void error_max_dynamic_strings(int index)
     if (index >= 96 && !glulx_mode)
         snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @95 may be used in Z-code");
     else if (MAX_DYNAMIC_STRINGS == 0)
-        snprintf(error_message_buff, ERROR_BUFLEN, "Dynamic strings may not be used, because $MAX_DYNAMIC_STRINGS has been set to %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS);
+        snprintf(error_message_buff, ERROR_BUFLEN, "Dynamic strings may not be used, because $MAX_DYNAMIC_STRINGS has been set to 0. Increase MAX_DYNAMIC_STRINGS.");
     else if (MAX_DYNAMIC_STRINGS == 32 && !glulx_mode)
         snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @%02d may be used, because $MAX_DYNAMIC_STRINGS has its default value of %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS-1, MAX_DYNAMIC_STRINGS);
     else

--- a/errors.c
+++ b/errors.c
@@ -369,6 +369,8 @@ extern void error_max_dynamic_strings(int index)
 {
     if (index >= 96 && !glulx_mode)
         snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @95 may be used in Z-code");
+    else if (MAX_DYNAMIC_STRINGS == 0)
+        snprintf(error_message_buff, ERROR_BUFLEN, "Dynamic strings may not be used, because $MAX_DYNAMIC_STRINGS has been set to %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS);
     else if (MAX_DYNAMIC_STRINGS == 32 && !glulx_mode)
         snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @%02d may be used, because $MAX_DYNAMIC_STRINGS has its default value of %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS-1, MAX_DYNAMIC_STRINGS);
     else

--- a/errors.c
+++ b/errors.c
@@ -367,9 +367,7 @@ extern void unicode_char_error(char *s, int32 uni)
 
 extern void error_max_dynamic_strings(int index)
 {
-    if (index >= 100)
-        snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @99 may be used in Inform");
-    else if (index >= 96 && !glulx_mode)
+    if (index >= 96 && !glulx_mode)
         snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @95 may be used in Z-code");
     else if (MAX_DYNAMIC_STRINGS == 32 && !glulx_mode)
         snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @%02d may be used, because $MAX_DYNAMIC_STRINGS has its default value of %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS-1, MAX_DYNAMIC_STRINGS);

--- a/inform.c
+++ b/inform.c
@@ -212,14 +212,6 @@ static void select_target(int targ)
       MAX_ABBREVS = 64;
     }
   }
-  else {
-    if (MAX_DYNAMIC_STRINGS > 100) {
-      MAX_DYNAMIC_STRINGS = 100;
-      warning("MAX_DYNAMIC_STRINGS cannot exceed 100; resetting to 100");
-      /* This is because they are specified in text literals like "@00",
-         with two digits. */
-    }
-  }
 }
 
 /* ------------------------------------------------------------------------- */

--- a/memory.c
+++ b/memory.c
@@ -437,7 +437,7 @@ static void explain_parameter(char *command)
     if (strcmp(command,"MAX_DYNAMIC_STRINGS")==0)
     {   printf(
 "  MAX_DYNAMIC_STRINGS is the maximum number of string substitution variables\n\
-  (\"@00\").  It is not allowed to exceed 96 in Z-code or 100 in Glulx.\n");
+  (\"@00\" or \"@(0)\").  It is not allowed to exceed 96 in Z-code.\n");
         return;
     }
     if (strcmp(command,"INDIV_PROP_START")==0)

--- a/text.c
+++ b/text.c
@@ -672,11 +672,9 @@ advance as part of 'Zcharacter table':", unicode);
                 }
                 else if (digits == len) {
                     /* all digits; parse as decimal */
-                    printf("### digits '%s'\n", dsymbol);
                     j = atoi(dsymbol);
                 }
                 else {
-                    printf("### symbol '%s'\n", dsymbol);
                     int sym = symbol_index(dsymbol, -1);
                     if ((symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
                         error_named("'@(...)' abbreviation expected a known constant value, but contained", dsymbol);
@@ -687,7 +685,6 @@ advance as part of 'Zcharacter table':", unicode);
                     }
                 }
                 if (j >= 0) {
-                    printf("### ... value %d\n", j);
                     if (!glulx_mode && j >= 96) {
                         error_max_dynamic_strings(j);
                         j = 0;
@@ -866,11 +863,9 @@ string.");
             }
             else if (digits == len) {
                 /* all digits; parse as decimal */
-                printf("### digits '%s'\n", dsymbol);
                 j = atoi(dsymbol);
             }
             else {
-                printf("### symbol '%s'\n", dsymbol);
                 int sym = symbol_index(dsymbol, -1);
                 if ((symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
                     error_named("'@(...)' abbreviation expected a known constant value, but contained", dsymbol);
@@ -881,7 +876,6 @@ string.");
                 }
             }
             if (j >= 0) {
-                printf("### ... value %d\n", j);
                 if (j >= MAX_DYNAMIC_STRINGS) {
                     error_max_dynamic_strings(j);
                     j = 0;

--- a/text.c
+++ b/text.c
@@ -684,15 +684,13 @@ advance as part of 'Zcharacter table':", unicode);
                         j = symbols[sym].value;
                     }
                 }
-                if (j >= 0) {
-                    if (!glulx_mode && j >= 96) {
-                        error_max_dynamic_strings(j);
-                        j = -1;
-                    }
-                    if (j >= MAX_DYNAMIC_STRINGS) {
-                        error_max_dynamic_strings(j);
-                        j = -1;
-                    }
+                if (!glulx_mode && j >= 96) {
+                    error_max_dynamic_strings(j);
+                    j = -1;
+                }
+                if (j >= MAX_DYNAMIC_STRINGS) {
+                    error_max_dynamic_strings(j);
+                    j = -1;
                 }
                 if (j >= 0) {
                     write_z_char_z(j/32+1); write_z_char_z(j%32);
@@ -885,14 +883,12 @@ string.");
                     j = symbols[sym].value;
                 }
             }
-            if (j >= 0) {
-                if (j >= MAX_DYNAMIC_STRINGS) {
-                    error_max_dynamic_strings(j);
-                    j = -1;
-                }
-                if (j+1 >= no_dynamic_strings)
-                    no_dynamic_strings = j+1;
+            if (j >= MAX_DYNAMIC_STRINGS) {
+                error_max_dynamic_strings(j);
+                j = -1;
             }
+            if (j+1 >= no_dynamic_strings)
+                no_dynamic_strings = j+1;
             if (j >= 0) {
                 write_z_char_g('@');
                 write_z_char_g('D');

--- a/text.c
+++ b/text.c
@@ -672,11 +672,8 @@ advance as part of 'Zcharacter table':", unicode);
                 }
                 else if (digits == len) {
                     /* all digits; parse as decimal */
-                    int ii;
                     printf("### digits '%s'\n", dsymbol);
-                    j = 0;
-                    for (ii=0; ii<len; ii++)
-                        j = 10*j + (dsymbol[ii]-'0');
+                    j = atoi(dsymbol);
                 }
                 else {
                     printf("### symbol '%s'\n", dsymbol);

--- a/text.c
+++ b/text.c
@@ -664,7 +664,7 @@ advance as part of 'Zcharacter table':", unicode);
                     dsymbol[len++] = ch;
                 }
                 dsymbol[len] = '\0';
-                j = 0;
+                j = -1;
                 /* We would like to parse dsymbol as *either* a decimal
                    number or a constant symbol. */
                 if (text_in[i] != ')' || len == 0) {
@@ -684,15 +684,22 @@ advance as part of 'Zcharacter table':", unicode);
                         j = symbols[sym].value;
                     }
                 }
-                if (!glulx_mode && j >= 96) {
-                    error_max_dynamic_strings(j);
-                    j = 0;
+                if (j >= 0) {
+                    if (!glulx_mode && j >= 96) {
+                        error_max_dynamic_strings(j);
+                        j = -1;
+                    }
+                    if (j >= MAX_DYNAMIC_STRINGS) {
+                        error_max_dynamic_strings(j);
+                        j = -1;
+                    }
                 }
-                if (j >= MAX_DYNAMIC_STRINGS) {
-                    error_max_dynamic_strings(j);
-                    j = 0;
+                if (j >= 0) {
+                    write_z_char_z(j/32+1); write_z_char_z(j%32);
                 }
-                write_z_char_z(j/32+1); write_z_char_z(j%32);
+                else {
+                    write_z_char_z(' '); /* error fallback */
+                }
             }
             else if (isdigit(text_in[i+1])!=0)
             {   int d1, d2;
@@ -708,15 +715,20 @@ advance as part of 'Zcharacter table':", unicode);
                     j = d1*10 + d2;
                     if (!glulx_mode && j >= 96) {
                         error_max_dynamic_strings(j);
-                        j = 0;
+                        j = -1;
                     }
                     if (j >= MAX_DYNAMIC_STRINGS) {
                         /* Shouldn't get here with two digits */
                         error_max_dynamic_strings(j);
-                        j = 0;
+                        j = -1;
                     }
                     i+=2;
-                    write_z_char_z(j/32+1); write_z_char_z(j%32);
+                    if (j >= 0) {
+                        write_z_char_z(j/32+1); write_z_char_z(j%32);
+                    }
+                    else {
+                        write_z_char_z(' '); /* error fallback */
+                    }
                 }
             }
             else
@@ -853,7 +865,7 @@ string.");
                 dsymbol[len++] = ch;
             }
             dsymbol[len] = '\0';
-            j = 0;
+            j = -1;
             /* We would like to parse dsymbol as *either* a decimal
                number or a constant symbol. */
             if (text_in[i] != ')' || len == 0) {
@@ -873,18 +885,25 @@ string.");
                     j = symbols[sym].value;
                 }
             }
-            if (j >= MAX_DYNAMIC_STRINGS) {
-                error_max_dynamic_strings(j);
-                j = 0;
+            if (j >= 0) {
+                if (j >= MAX_DYNAMIC_STRINGS) {
+                    error_max_dynamic_strings(j);
+                    j = -1;
+                }
+                if (j+1 >= no_dynamic_strings)
+                    no_dynamic_strings = j+1;
             }
-            if (j+1 >= no_dynamic_strings)
-                no_dynamic_strings = j+1;
-            write_z_char_g('@');
-            write_z_char_g('D');
-            write_z_char_g('A' + ((j >>12) & 0x0F));
-            write_z_char_g('A' + ((j >> 8) & 0x0F));
-            write_z_char_g('A' + ((j >> 4) & 0x0F));
-            write_z_char_g('A' + ((j     ) & 0x0F));
+            if (j >= 0) {
+                write_z_char_g('@');
+                write_z_char_g('D');
+                write_z_char_g('A' + ((j >>12) & 0x0F));
+                write_z_char_g('A' + ((j >> 8) & 0x0F));
+                write_z_char_g('A' + ((j >> 4) & 0x0F));
+                write_z_char_g('A' + ((j     ) & 0x0F));
+            }
+            else {
+                write_z_char_g(' '); /* error fallback */
+            }
         }
         else if (isdigit(text_in[i+1])) {
           int d1, d2;
@@ -901,16 +920,21 @@ string; substituting '   '.");
             j = d1*10 + d2;
             if (j >= MAX_DYNAMIC_STRINGS) {
               error_max_dynamic_strings(j);
-              j = 0;
+              j = -1;
             }
             if (j+1 >= no_dynamic_strings)
               no_dynamic_strings = j+1;
-            write_z_char_g('@');
-            write_z_char_g('D');
-            write_z_char_g('A' + ((j >>12) & 0x0F));
-            write_z_char_g('A' + ((j >> 8) & 0x0F));
-            write_z_char_g('A' + ((j >> 4) & 0x0F));
-            write_z_char_g('A' + ((j     ) & 0x0F));
+            if (j >= 0) {
+                write_z_char_g('@');
+                write_z_char_g('D');
+                write_z_char_g('A' + ((j >>12) & 0x0F));
+                write_z_char_g('A' + ((j >> 8) & 0x0F));
+                write_z_char_g('A' + ((j >> 4) & 0x0F));
+                write_z_char_g('A' + ((j     ) & 0x0F));
+            }
+            else {
+                write_z_char_g(' '); /* error fallback */
+            }
           }
         }
         else {

--- a/text.c
+++ b/text.c
@@ -671,6 +671,7 @@ advance as part of 'Zcharacter table':", unicode);
                     error("'@(...)' abbreviation must contain a symbol");
                 }
                 else if (digits == len) {
+                    /* all digits; parse as decimal */
                     int ii;
                     printf("### digits '%s'\n", dsymbol);
                     j = 0;
@@ -690,7 +691,14 @@ advance as part of 'Zcharacter table':", unicode);
                 }
                 if (j >= 0) {
                     printf("### ... value %d\n", j);
-                    //### range check
+                    if (!glulx_mode && j >= 96) {
+                        error_max_dynamic_strings(j);
+                        j = 0;
+                    }
+                    if (j >= MAX_DYNAMIC_STRINGS) {
+                        error_max_dynamic_strings(j);
+                        j = 0;
+                    }
                     write_z_char_z(j/32+1); write_z_char_z(j%32);
                 }
             }

--- a/text.c
+++ b/text.c
@@ -664,7 +664,7 @@ advance as part of 'Zcharacter table':", unicode);
                     dsymbol[len++] = ch;
                 }
                 dsymbol[len] = '\0';
-                j = -1;
+                j = 0;
                 /* We would like to parse dsymbol as *either* a decimal
                    number or a constant symbol. */
                 if (text_in[i] != ')' || len == 0) {
@@ -684,17 +684,15 @@ advance as part of 'Zcharacter table':", unicode);
                         j = symbols[sym].value;
                     }
                 }
-                if (j >= 0) {
-                    if (!glulx_mode && j >= 96) {
-                        error_max_dynamic_strings(j);
-                        j = 0;
-                    }
-                    if (j >= MAX_DYNAMIC_STRINGS) {
-                        error_max_dynamic_strings(j);
-                        j = 0;
-                    }
-                    write_z_char_z(j/32+1); write_z_char_z(j%32);
+                if (!glulx_mode && j >= 96) {
+                    error_max_dynamic_strings(j);
+                    j = 0;
                 }
+                if (j >= MAX_DYNAMIC_STRINGS) {
+                    error_max_dynamic_strings(j);
+                    j = 0;
+                }
+                write_z_char_z(j/32+1); write_z_char_z(j%32);
             }
             else if (isdigit(text_in[i+1])!=0)
             {   int d1, d2;
@@ -855,7 +853,7 @@ string.");
                 dsymbol[len++] = ch;
             }
             dsymbol[len] = '\0';
-            j = -1;
+            j = 0;
             /* We would like to parse dsymbol as *either* a decimal
                number or a constant symbol. */
             if (text_in[i] != ')' || len == 0) {
@@ -875,20 +873,18 @@ string.");
                     j = symbols[sym].value;
                 }
             }
-            if (j >= 0) {
-                if (j >= MAX_DYNAMIC_STRINGS) {
-                    error_max_dynamic_strings(j);
-                    j = 0;
-                }
-                if (j+1 >= no_dynamic_strings)
-                    no_dynamic_strings = j+1;
-                write_z_char_g('@');
-                write_z_char_g('D');
-                write_z_char_g('A' + ((j >>12) & 0x0F));
-                write_z_char_g('A' + ((j >> 8) & 0x0F));
-                write_z_char_g('A' + ((j >> 4) & 0x0F));
-                write_z_char_g('A' + ((j     ) & 0x0F));
+            if (j >= MAX_DYNAMIC_STRINGS) {
+                error_max_dynamic_strings(j);
+                j = 0;
             }
+            if (j+1 >= no_dynamic_strings)
+                no_dynamic_strings = j+1;
+            write_z_char_g('@');
+            write_z_char_g('D');
+            write_z_char_g('A' + ((j >>12) & 0x0F));
+            write_z_char_g('A' + ((j >> 8) & 0x0F));
+            write_z_char_g('A' + ((j >> 4) & 0x0F));
+            write_z_char_g('A' + ((j     ) & 0x0F));
         }
         else if (isdigit(text_in[i+1])) {
           int d1, d2;


### PR DESCRIPTION
This introduces a new syntax for dynamic-string intrpolations: `"@(N)"`. The original syntax was `"@NN"`, which is still supported, but the new form is better.

- You can use any number of digits between the parens. So you can write `"@(1)"` instead of `"@01"`. In Glulx, you can use more than 100 dynamic strings; `"@(123)"` is legal. (As long as you set `$MAX_DYNAMIC_STRINGS` to 124 or more.)

(`$MAX_DYNAMIC_STRINGS` was previously limited to 100 in Glulx, but this limit has been removed.)

- You can define a constant to use between the parens. This is legal:

````
Constant DIRNAME 5;
[ func;
    string DIRNAME "east";
    print "You face @(DIRNAME).^";
];
````

The symbol must be an already-defined numeric constant. (Variable names are not allowed, sorry.)

https://github.com/erkyrath/Inform6-Testing/blob/symbolic-abbrev/src/symbolic_abbrev_test.inf is a test case.

Addresses https://github.com/DavidKinder/Inform6/issues/162 .
