### PR TITLE
Improve dead-code stripping and warnings

### DIFF
--- a/expressc.c
+++ b/expressc.c
@@ -2805,9 +2805,9 @@ static void generate_code_from(int n, int void_flag)
     OperatorGenerated:
 
     if (!glulx_mode) {
-
         if (ET[n].to_expression)
         {
+            int32 donelabel;
             if (void_flag) {
                 warning("Logical expression has no side-effects");
                 if (ET[n].true_label != -1)
@@ -2816,18 +2816,22 @@ static void generate_code_from(int n, int void_flag)
                     assemble_label_no(ET[n].false_label);
             }
             else if (ET[n].true_label != -1)
-            {   assemblez_1(push_zc, zero_operand);
-                assemblez_jump(next_label++);
+            {
+                donelabel = next_label++;
+                assemblez_1(push_zc, zero_operand);
+                assemblez_jump(donelabel);
                 assemble_label_no(ET[n].true_label);
                 assemblez_1(push_zc, one_operand);
-                assemble_label_no(next_label-1);
+                assemble_label_no(donelabel);
             }
             else
-            {   assemblez_1(push_zc, one_operand);
-                assemblez_jump(next_label++);
+            {
+                donelabel = next_label++;
+                assemblez_1(push_zc, one_operand);
+                assemblez_jump(donelabel);
                 assemble_label_no(ET[n].false_label);
                 assemblez_1(push_zc, zero_operand);
-                assemble_label_no(next_label-1);
+                assemble_label_no(donelabel);
             }
             ET[n].value = stack_pointer;
         }
@@ -2840,6 +2844,7 @@ static void generate_code_from(int n, int void_flag)
 
         if (ET[n].to_expression)
         {   
+            int32 donelabel;
             if (void_flag) {
                 warning("Logical expression has no side-effects");
                 if (ET[n].true_label != -1)
@@ -2848,18 +2853,22 @@ static void generate_code_from(int n, int void_flag)
                     assemble_label_no(ET[n].false_label);
             }
             else if (ET[n].true_label != -1)
-            {   assembleg_store(stack_pointer, zero_operand);
-                assembleg_jump(next_label++);
+            {
+                donelabel = next_label++;
+                assembleg_store(stack_pointer, zero_operand);
+                assembleg_jump(donelabel);
                 assemble_label_no(ET[n].true_label);
                 assembleg_store(stack_pointer, one_operand);
-                assemble_label_no(next_label-1);
+                assemble_label_no(donelabel);
             }
             else
-            {   assembleg_store(stack_pointer, one_operand);
-                assembleg_jump(next_label++);
+            {
+                donelabel = next_label++;
+                assembleg_store(stack_pointer, one_operand);
+                assembleg_jump(donelabel);
                 assemble_label_no(ET[n].false_label);
                 assembleg_store(stack_pointer, zero_operand);
-                assemble_label_no(next_label-1);
+                assemble_label_no(donelabel);
             }
             ET[n].value = stack_pointer;
         }

--- a/expressc.c
+++ b/expressc.c
@@ -2811,6 +2811,7 @@ static void generate_code_from(int n, int void_flag)
     OperatorGenerated:
 
     if (!glulx_mode) {
+        
         if (ET[n].to_expression)
         {
             int32 donelabel;

--- a/expressc.c
+++ b/expressc.c
@@ -1296,6 +1296,12 @@ static void generate_code_from(int n, int void_flag)
 
     if ((opnum == LOGAND_OP) || (opnum == LOGOR_OP))
     {   generate_code_from(below, FALSE);
+        if (execution_never_reaches_here) {
+            /* If the condition never falls through to here, then it
+               was an "... && 0 && ..." test. Our convention is to skip
+               the "not reached" warnings for this case. */
+            execution_never_reaches_here |= EXECSTATE_NOWARN;
+        }
         generate_code_from(ET[below].right, FALSE);
         goto OperatorGenerated;
     }

--- a/expressc.c
+++ b/expressc.c
@@ -2818,8 +2818,10 @@ static void generate_code_from(int n, int void_flag)
             else if (ET[n].true_label != -1)
             {
                 donelabel = next_label++;
-                assemblez_1(push_zc, zero_operand);
-                assemblez_jump(donelabel);
+                if (!execution_never_reaches_here) {
+                    assemblez_1(push_zc, zero_operand);
+                    assemblez_jump(donelabel);
+                }
                 assemble_label_no(ET[n].true_label);
                 assemblez_1(push_zc, one_operand);
                 assemble_forward_label_no(donelabel);
@@ -2827,8 +2829,10 @@ static void generate_code_from(int n, int void_flag)
             else
             {
                 donelabel = next_label++;
-                assemblez_1(push_zc, one_operand);
-                assemblez_jump(donelabel);
+                if (!execution_never_reaches_here) {
+                    assemblez_1(push_zc, one_operand);
+                    assemblez_jump(donelabel);
+                }
                 assemble_label_no(ET[n].false_label);
                 assemblez_1(push_zc, zero_operand);
                 assemble_forward_label_no(donelabel);
@@ -2855,8 +2859,10 @@ static void generate_code_from(int n, int void_flag)
             else if (ET[n].true_label != -1)
             {
                 donelabel = next_label++;
-                assembleg_store(stack_pointer, zero_operand);
-                assembleg_jump(donelabel);
+                if (!execution_never_reaches_here) {
+                    assembleg_store(stack_pointer, zero_operand);
+                    assembleg_jump(donelabel);
+                }
                 assemble_label_no(ET[n].true_label);
                 assembleg_store(stack_pointer, one_operand);
                 assemble_forward_label_no(donelabel);
@@ -2864,8 +2870,10 @@ static void generate_code_from(int n, int void_flag)
             else
             {
                 donelabel = next_label++;
-                assembleg_store(stack_pointer, one_operand);
-                assembleg_jump(donelabel);
+                if (!execution_never_reaches_here) {
+                    assembleg_store(stack_pointer, one_operand);
+                    assembleg_jump(donelabel);
+                }
                 assemble_label_no(ET[n].false_label);
                 assembleg_store(stack_pointer, zero_operand);
                 assemble_forward_label_no(donelabel);

--- a/expressc.c
+++ b/expressc.c
@@ -2822,7 +2822,7 @@ static void generate_code_from(int n, int void_flag)
                 assemblez_jump(donelabel);
                 assemble_label_no(ET[n].true_label);
                 assemblez_1(push_zc, one_operand);
-                assemble_label_no(donelabel);
+                assemble_forward_label_no(donelabel);
             }
             else
             {
@@ -2831,7 +2831,7 @@ static void generate_code_from(int n, int void_flag)
                 assemblez_jump(donelabel);
                 assemble_label_no(ET[n].false_label);
                 assemblez_1(push_zc, zero_operand);
-                assemble_label_no(donelabel);
+                assemble_forward_label_no(donelabel);
             }
             ET[n].value = stack_pointer;
         }
@@ -2859,7 +2859,7 @@ static void generate_code_from(int n, int void_flag)
                 assembleg_jump(donelabel);
                 assemble_label_no(ET[n].true_label);
                 assembleg_store(stack_pointer, one_operand);
-                assemble_label_no(donelabel);
+                assemble_forward_label_no(donelabel);
             }
             else
             {
@@ -2868,7 +2868,7 @@ static void generate_code_from(int n, int void_flag)
                 assembleg_jump(donelabel);
                 assemble_label_no(ET[n].false_label);
                 assembleg_store(stack_pointer, zero_operand);
-                assemble_label_no(donelabel);
+                assemble_forward_label_no(donelabel);
             }
             ET[n].value = stack_pointer;
         }

--- a/expressc.c
+++ b/expressc.c
@@ -2811,7 +2811,7 @@ static void generate_code_from(int n, int void_flag)
     OperatorGenerated:
 
     if (!glulx_mode) {
-        
+
         if (ET[n].to_expression)
         {
             int32 donelabel;

--- a/expressp.c
+++ b/expressp.c
@@ -1305,24 +1305,23 @@ static void emit_token(const token_data *t)
             }
 
             /* We can also fold logical operations if they are certain
-               to short-circuit. */
+               to short-circuit. The right-hand argument is skipped even
+               if it's non-constant or has side effects. */
             
             if ((o1.marker == 0)
-                && is_constant_ot(o1.type)
-                && t->value == LOGAND_OP
-                && o1.value == 0)
-            {
-                x = 0;
-                goto FoldConstant;
-            }
+                && is_constant_ot(o1.type)) {
+                
+                if (t->value == LOGAND_OP && o1.value == 0)
+                {
+                    x = 0;
+                    goto FoldConstant;
+                }
 
-            if ((o1.marker == 0)
-                && is_constant_ot(o1.type)
-                && t->value == LOGOR_OP
-                && o1.value != 0)
-            {
-                x = 1;
-                goto FoldConstant;
+                if (t->value == LOGOR_OP && o1.value != 0)
+                {
+                    x = 1;
+                    goto FoldConstant;
+                }
             }
     }
 

--- a/expressp.c
+++ b/expressp.c
@@ -1304,6 +1304,9 @@ static void emit_token(const token_data *t)
 
             }
 
+            /* We can also fold logical operations if they are certain
+               to short-circuit. */
+            
             if ((o1.marker == 0)
                 && is_constant_ot(o1.type)
                 && t->value == LOGAND_OP

--- a/expressp.c
+++ b/expressp.c
@@ -1303,6 +1303,24 @@ static void emit_token(const token_data *t)
                 }
 
             }
+
+            if ((o1.marker == 0)
+                && is_constant_ot(o1.type)
+                && t->value == LOGAND_OP
+                && o1.value == 0)
+            {
+                x = 0;
+                goto FoldConstant;
+            }
+
+            if ((o1.marker == 0)
+                && is_constant_ot(o1.type)
+                && t->value == LOGOR_OP
+                && o1.value != 0)
+            {
+                x = 1;
+                goto FoldConstant;
+            }
     }
 
     ensure_memory_list_available(&ET_memlist, ET_used+1);


### PR DESCRIPTION
The big dead-code change left a few holes. Both the 6/12 library and the latest PunyInform have lines that look like:

    if (SACK_OBJECT && SACK_OBJECT in player) ...

These were generating spurious "not reached" warnings. I failed to catch those, because I had only tested lines like

    if (SACK_OBJECT) {
        if (SACK_OBJECT in player) ...
    }

This change fixes the other cases. It also improves code generation in a couple more places.

- If `execution_never_reaches_here` gets set in the middle of a logical expression (`&&` or `||`), we also set NOWARN. 
- When computing a logical expression as a value, if one case (`0` or `1`) is impossible, we skip the opcodes that store it.
- The constant-folding logic now folds expressions like (`0 && expr`) and (`1 || expr`) even when the right-hand side is not a constant.

Fixes https://github.com/DavidKinder/Inform6/issues/168 .
