### PR TITLE
Automatic builds on releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,59 @@
+name: build-release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_TYPE: Release
+    strategy:
+      fail-fast: false
+      matrix:
+        # specify a specific compiler to build with each OS separately
+        include:
+          - platform_name: linux
+            os: ubuntu-20.04
+            cxx: g++-10
+          - platform_name: macos
+            os: macos-10.15
+            cxx: clang++
+          # NOTE: CXX seems to be ignored on Windows, but specify it anyway for consistency
+          - platform_name: windows
+            os: windows-2019
+            cxx: msvc
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure CMake
+        env:
+          CXX: ${{ matrix.cxx }}
+        # Use a bash shell so we can use the same syntax for environment variable
+        # access regardless of the host operating system
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        # Note the current convention is to use the -S and -B options here to specify source 
+        # and build directories, but this is only available with CMake 3.13 and higher.  
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/artifacts
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        # Execute the build.  You can specify a specific target with "--target <NAME>"
+        run: cmake --build . --config $BUILD_TYPE
+
+      - name: Install
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        # Use CMake to "install" build artifacts (only interested in CMake registered targets) to our custom artifacts directory
+        run: cmake --install . --config $BUILD_TYPE
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: project_build_${{ github.run_number }}_${{ matrix.platform_name }}
+          path: ${{github.workspace}}/artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -58,4 +58,5 @@ jobs:
         with:
           # TODO: get current version of Inform6 and insert this into the filename
           name: Inform6_build_${{ github.run_number }}_${{ matrix.platform_name }}
-          path: ${{github.workspace}}/artifacts
+          # ONLY include the /bin subdirectory, as we only want the Inform6 executable
+          path: ${{github.workspace}}/artifacts/bin

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -63,6 +63,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           # TODO: get current version of Inform6 and insert this into the filename
-          name: Inform${{env.INFORM_RELEASE}}_${{ matrix.platform_name }}
+          name: Inform_${{env.INFORM_RELEASE}}_${{ matrix.platform_name }}
           # ONLY include the /bin subdirectory, as we only want the Inform6 executable
           path: ${{github.workspace}}/artifacts/bin

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Configure CMake
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,10 +1,6 @@
 name: build-release
 
 on:
-  # XXX: temp trigger for testing
-  push:
-    branches:
-      - master
   release:
     types: [published]
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,6 +1,10 @@
 name: build-release
 
 on:
+  # XXX: temp trigger for testing
+  push:
+    branches:
+      - master
   release:
     types: [published]
 
@@ -16,38 +20,35 @@ jobs:
         include:
           - platform_name: linux
             os: ubuntu-20.04
-            cxx: g++-10
+            cc: gcc-10
           - platform_name: macos
             os: macos-10.15
-            cxx: clang++
-          # NOTE: CXX seems to be ignored on Windows, but specify it anyway for consistency
+            cc: clang
+          # NOTE: CC seems to be ignored on Windows, but specify it anyway for consistency
           - platform_name: windows
             os: windows-2019
-            cxx: msvc
+            cc: msvc
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Configure CMake
         env:
-          CXX: ${{ matrix.cxx }}
+          CC: ${{ matrix.cc }}
         # Use a bash shell so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: bash
-        working-directory: ${{github.workspace}}/build
         # Note the current convention is to use the -S and -B options here to specify source 
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/artifacts
 
       - name: Build
-        working-directory: ${{github.workspace}}/build
         shell: bash
         # Execute the build.  You can specify a specific target with "--target <NAME>"
         run: cmake --build . --config $BUILD_TYPE
 
       - name: Install
-        working-directory: ${{github.workspace}}/build
         shell: bash
         # Use CMake to "install" build artifacts (only interested in CMake registered targets) to our custom artifacts directory
         run: cmake --install . --config $BUILD_TYPE
@@ -55,5 +56,6 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: project_build_${{ github.run_number }}_${{ matrix.platform_name }}
+          # TODO: get current version of Inform6 and insert this into the filename
+          name: Inform6_build_${{ github.run_number }}_${{ matrix.platform_name }}
           path: ${{github.workspace}}/artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,10 +53,13 @@ jobs:
         # Use CMake to "install" build artifacts (only interested in CMake registered targets) to our custom artifacts directory
         run: cmake --install . --config $BUILD_TYPE
 
+      - id: get_version
+        uses: battila7/get-version-action@v2
+
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
           # TODO: get current version of Inform6 and insert this into the filename
-          name: Inform6_build_${{ github.run_number }}_${{ matrix.platform_name }}
+          name: Inform${{steps.get_version.outputs.version-without-v}}_${{ matrix.platform_name }}
           # ONLY include the /bin subdirectory, as we only want the Inform6 executable
           path: ${{github.workspace}}/artifacts/bin

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,13 +53,14 @@ jobs:
         # Use CMake to "install" build artifacts (only interested in CMake registered targets) to our custom artifacts directory
         run: cmake --install . --config $BUILD_TYPE
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
+      - name: Get Version
+        shell: bash
+        run: echo "INFORM_RELEASE=$(git describe)" >> $GITHUB_ENV
 
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
           # TODO: get current version of Inform6 and insert this into the filename
-          name: Inform${{steps.get_version.outputs.version-without-v}}_${{ matrix.platform_name }}
+          name: Inform${{env.INFORM_RELEASE}}_${{ matrix.platform_name }}
           # ONLY include the /bin subdirectory, as we only want the Inform6 executable
           path: ${{github.workspace}}/artifacts/bin

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,47 +1,47 @@
-# name: continuous-integration
+name: continuous-integration
 
-# on:
-#   push:
-#     branches:
-#       - master
-#   pull_request:
-#     types: [opened, synchronize]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize]
 
-# jobs:
-#   build:
-#     runs-on: ${{ matrix.os }}
-#     env:
-#       BUILD_TYPE: Debug
-#     strategy:
-#       fail-fast: true
-#       matrix:
-#         os: [macos-10.15, ubuntu-20.04]
-#         cc: [gcc-10, clang]
-#         include:
-#           - os: windows-2019
-#             cc: msvc
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_TYPE: Debug
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macos-10.15, ubuntu-20.04]
+        cc: [gcc-10, clang]
+        include:
+          - os: windows-2019
+            cc: msvc
 
-#     steps:
-#       - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-#       # when building on master branch and not a pull request, build and test in release mode (optimised build)
-#       - name: Set Build Mode to Release
-#         shell: bash
-#         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
-#         run: echo "BUILD_TYPE=Release" >> $GITHUB_ENV
+      # when building on master branch and not a pull request, build and test in release mode (optimised build)
+      - name: Set Build Mode to Release
+        shell: bash
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
+        run: echo "BUILD_TYPE=Release" >> $GITHUB_ENV
 
-#       - name: Configure CMake
-#         env:
-#           CC: ${{ matrix.cc }}
-#         # Use a bash shell so we can use the same syntax for environment variable
-#         # access regardless of the host operating system
-#         shell: bash
-#         # Note the current convention is to use the -S and -B options here to specify source 
-#         # and build directories, but this is only available with CMake 3.13 and higher.  
-#         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-#         run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      - name: Configure CMake
+        env:
+          CC: ${{ matrix.cc }}
+        # Use a bash shell so we can use the same syntax for environment variable
+        # access regardless of the host operating system
+        shell: bash
+        # Note the current convention is to use the -S and -B options here to specify source 
+        # and build directories, but this is only available with CMake 3.13 and higher.  
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-#       - name: Build
-#         shell: bash
-#         # Execute the build.  You can specify a specific target with "--target <NAME>"
-#         run: cmake --build . --config $BUILD_TYPE
+      - name: Build
+        shell: bash
+        # Execute the build.  You can specify a specific target with "--target <NAME>"
+        run: cmake --build . --config $BUILD_TYPE

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,49 @@
+name: continuous-integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_TYPE: Debug
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macos-10.15, ubuntu-20.04]
+        cc: [gcc-10, clang]
+        include:
+          - os: windows-2019
+            cc: msvc
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # when building on master branch and not a pull request, build and test in release mode (optimised build)
+      - name: Set Build Mode to Release
+        shell: bash
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
+        run: echo "BUILD_TYPE=Release" >> $GITHUB_ENV
+
+      - name: Configure CMake
+        env:
+          CC: ${{ matrix.cc }}
+        # Use a bash shell so we can use the same syntax for environment variable
+        # access regardless of the host operating system
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        # Note the current convention is to use the -S and -B options here to specify source 
+        # and build directories, but this is only available with CMake 3.13 and higher.  
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/test_install -DENABLE_TESTS=ON
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        # Execute the build.  You can specify a specific target with "--target <NAME>"
+        run: cmake --build . --config $BUILD_TYPE

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,14 +36,12 @@ jobs:
         # Use a bash shell so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: bash
-        working-directory: ${{github.workspace}}/build
         # Note the current convention is to use the -S and -B options here to specify source 
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/test_install -DENABLE_TESTS=ON
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build
-        working-directory: ${{github.workspace}}/build
         shell: bash
         # Execute the build.  You can specify a specific target with "--target <NAME>"
         run: cmake --build . --config $BUILD_TYPE

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # when building on master branch and not a pull request, build and test in release mode (optimised build)
+      # when building on master branch and not a pull request, build in release mode (optimised build)
       - name: Set Build Mode to Release
         shell: bash
         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,47 +1,47 @@
-name: continuous-integration
+# name: continuous-integration
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, synchronize]
+# on:
+#   push:
+#     branches:
+#       - master
+#   pull_request:
+#     types: [opened, synchronize]
 
-jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    env:
-      BUILD_TYPE: Debug
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [macos-10.15, ubuntu-20.04]
-        cc: [gcc-10, clang]
-        include:
-          - os: windows-2019
-            cc: msvc
+# jobs:
+#   build:
+#     runs-on: ${{ matrix.os }}
+#     env:
+#       BUILD_TYPE: Debug
+#     strategy:
+#       fail-fast: true
+#       matrix:
+#         os: [macos-10.15, ubuntu-20.04]
+#         cc: [gcc-10, clang]
+#         include:
+#           - os: windows-2019
+#             cc: msvc
 
-    steps:
-      - uses: actions/checkout@v2
+#     steps:
+#       - uses: actions/checkout@v2
 
-      # when building on master branch and not a pull request, build and test in release mode (optimised build)
-      - name: Set Build Mode to Release
-        shell: bash
-        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
-        run: echo "BUILD_TYPE=Release" >> $GITHUB_ENV
+#       # when building on master branch and not a pull request, build and test in release mode (optimised build)
+#       - name: Set Build Mode to Release
+#         shell: bash
+#         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
+#         run: echo "BUILD_TYPE=Release" >> $GITHUB_ENV
 
-      - name: Configure CMake
-        env:
-          CC: ${{ matrix.cc }}
-        # Use a bash shell so we can use the same syntax for environment variable
-        # access regardless of the host operating system
-        shell: bash
-        # Note the current convention is to use the -S and -B options here to specify source 
-        # and build directories, but this is only available with CMake 3.13 and higher.  
-        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+#       - name: Configure CMake
+#         env:
+#           CC: ${{ matrix.cc }}
+#         # Use a bash shell so we can use the same syntax for environment variable
+#         # access regardless of the host operating system
+#         shell: bash
+#         # Note the current convention is to use the -S and -B options here to specify source 
+#         # and build directories, but this is only available with CMake 3.13 and higher.  
+#         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+#         run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-      - name: Build
-        shell: bash
-        # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: cmake --build . --config $BUILD_TYPE
+#       - name: Build
+#         shell: bash
+#         # Execute the build.  You can specify a specific target with "--target <NAME>"
+#         run: cmake --build . --config $BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.3)
 project(Inform6 VERSION 0.6.37 LANGUAGES C)
 
 find_program(CCACHE_PROGRAM ccache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,3 +63,6 @@ endif()
 if(OS_ID)
     target_compile_definitions(inform6 PRIVATE -D${OS_ID})
 endif()
+
+# install executable if requested
+install(TARGETS inform6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(Inform6 VERSION 0.6.36 LANGUAGES C)
+project(Inform6 VERSION 0.6.37 LANGUAGES C)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
@@ -42,3 +42,24 @@ add_executable(
         veneer.c
         verbs.c
 )
+
+# try and detect OS with CMake
+set(WINDOWS_PLATFORMS Windows MSYS)
+
+if(INFORM_OS_ID) # if specified manually to CMake at configure-time
+    set(OS_ID ${INFORM_OS_ID})
+# otherwise, try and detect common platforms CMake is documented to know
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux") # Linux
+    set(OS_ID LINUX)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin") # macOS
+    set(OS_ID MACOS)
+elseif(CMAKE_SYSTEM_NAME IN_LIST WINDOWS_PLATFORMS) # Windows
+    set(OS_ID PC_WIN32)
+elseif(UNIX) # Other UNIX, includes BSD, etc...
+    set(OS_ID UNIX)
+endif()
+
+# set macro definitions to tell Inform what OS we're building for
+if(OS_ID)
+    target_compile_definitions(inform6 PRIVATE -D${OS_ID})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.0)
+project(Inform6 VERSION 0.6.36 LANGUAGES C)
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
+# Set a default build type if none was specified
+set(DEFAULT_BUILD_TYPE "Debug")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+set(CMAKE_C_STANDARD "90")
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+add_executable(
+    inform6
+        arrays.c
+        asm.c
+        bpatch.c
+        chars.c
+        directs.c
+        errors.c
+        expressc.c
+        expressp.c
+        files.c
+        inform.c
+        lexer.c
+        linker.c
+        memory.c
+        objects.c
+        states.c
+        symbols.c
+        syntax.c
+        tables.c
+        text.c
+        veneer.c
+        verbs.c
+)


### PR DESCRIPTION
Greetings,

- I have used Github-Actions and CMake to automatically build Inform6 on Linux, macOS and Windows when a Github "release" is published (file `.github/workflows/build-release.yml`). The built executables are available  as ZIP files in the "summary" page of the Github-actions run, in the "actions" tab:
![image](https://user-images.githubusercontent.com/8693463/166295409-b5642de9-9810-4132-a22e-19c1976c62cc.png)
(of course, the version numbers shown in this screengrab are just a demo, nonsense tag name)
- I have also used similar techniques to have Inform6 automatically compiled on all three OSes every time a Pull Request is opened, or a commit pushed to `master` branch (file: `.github/workflows/continuous-integration.yml`). These commits are tested with both clang and gcc on Linux/macOS and just MSVC on Windows.

I appreciate that including a build-generator in this project might be unwelcome and also that noöne has asked for this work, however I am sharing it with you in case you might find it useful for your release process and also in view of #86, cross-platform testing across compilers might be useful (I often enable GCC/clang/MSVC warning flags with CMake to test against compiler warnings in other projects).

I hope you find this useful. If you were interested in incorporating this work into the project, I'm happy to revise or remove anything not wanted and to write some documentation for these additions if needed.