### PR TITLE
Consolidate trace options

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -220,6 +220,8 @@ extern void array_entry(int32 i, int is_static, assembly_operand VAL)
             else {
                 /* We can't use backpatch_zmachine() because that only applies to RAM. Instead we add an entry to staticarray_backpatch_table.
                    A backpatch entry is five bytes: *_MV followed by the array offset (in static array area). */
+                if (bpatch_trace_setting >= 2)
+                    printf("BP added: MV %d staticarray %04x\n", VAL.marker, addr);
                 ensure_memory_list_available(&staticarray_backpatch_table_memlist, staticarray_backpatch_size+5);
                 staticarray_backpatch_table[staticarray_backpatch_size++] = VAL.marker;
                 staticarray_backpatch_table[staticarray_backpatch_size++] = ((addr >> 24) & 0xFF);

--- a/asm.c
+++ b/asm.c
@@ -2183,6 +2183,9 @@ static void transfer_routine_z(void)
                         break;
                     }
 
+                    if (bpatch_trace_setting >= 2)
+                        printf("BP added: MV %d PC %04x\n", zcode_markers[i], new_pc);
+
                     ensure_memory_list_available(&zcode_backpatch_table_memlist, zcode_backpatch_size+3);
                     zcode_backpatch_table[zcode_backpatch_size++] = zcode_markers[i] + 32*(new_pc/65536);
                     zcode_backpatch_table[zcode_backpatch_size++] = (new_pc/256)%256;
@@ -2412,6 +2415,8 @@ static void transfer_routine_g(void)
              Then a byte indicating the data size to be patched (1, 2, 4).
              Then the four-byte address (new_pc).
           */
+          if (bpatch_trace_setting >= 2)
+              printf("BP added: MV %d size %d PC %04x\n", zcode_markers[i], 4, new_pc);
           ensure_memory_list_available(&zcode_backpatch_table_memlist, zcode_backpatch_size+6);
           zcode_backpatch_table[zcode_backpatch_size++] = zcode_markers[i];
           zcode_backpatch_table[zcode_backpatch_size++] = 4;

--- a/bpatch.c
+++ b/bpatch.c
@@ -29,7 +29,7 @@ static int32 backpatch_value_z(int32 value)
 
     ASSERT_ZCODE();
 
-    if (asm_trace_level >= 4)
+    if (bpatch_trace_setting)
         printf("BP %s applied to %04x giving ",
             describe_mv(backpatch_marker), value);
 
@@ -163,7 +163,7 @@ static int32 backpatch_value_z(int32 value)
             break;
     }
 
-    if (asm_trace_level >= 4) printf(" %04x\n", value);
+    if (bpatch_trace_setting) printf(" %04x\n", value);
 
     return(value);
 }
@@ -174,7 +174,7 @@ static int32 backpatch_value_g(int32 value)
 
     ASSERT_GLULX();
 
-    if (asm_trace_level >= 4)
+    if (bpatch_trace_setting)
         printf("BP %s applied to %04x giving ",
             describe_mv(backpatch_marker), value);
 
@@ -331,7 +331,7 @@ symbol");
             break;
     }
 
-    if (asm_trace_level >= 4) printf(" %04x\n", value);
+    if (bpatch_trace_setting) printf(" %04x\n", value);
 
     return(value);
 }

--- a/bpatch.c
+++ b/bpatch.c
@@ -354,7 +354,8 @@ static void backpatch_zmachine_z(int mv, int zmachine_area, int32 offset)
         if (mv == ACTION_MV) return;
     }
 
-    /* printf("MV %d ZA %d Off %04x\n", mv, zmachine_area, offset); */
+    if (bpatch_trace_setting >= 2)
+        printf("BP added: MV %d ZA %d Off %04x\n", mv, zmachine_area, offset);
 
     ensure_memory_list_available(&zmachine_backpatch_table_memlist, zmachine_backpatch_size+4);
     zmachine_backpatch_table[zmachine_backpatch_size++] = mv;
@@ -378,7 +379,8 @@ static void backpatch_zmachine_g(int mv, int zmachine_area, int32 offset)
    Then the four-byte address.
 */
 
-/*    printf("+MV %d ZA %d Off %06x\n", mv, zmachine_area, offset);  */
+    if (bpatch_trace_setting >= 2)
+        printf("BP added: MV %d ZA %d Off %06x\n", mv, zmachine_area, offset);
 
     ensure_memory_list_available(&zmachine_backpatch_table_memlist, zmachine_backpatch_size+6);
     zmachine_backpatch_table[zmachine_backpatch_size++] = mv;
@@ -455,9 +457,7 @@ extern void backpatch_zmachine_image_g(void)
           zmachine_backpatch_table[bm+4];
         offset = (offset << 8) |
           zmachine_backpatch_table[bm+5];
-            bm += 6;
-
-        /* printf("-MV %d ZA %d Off %06x\n", backpatch_marker, zmachine_area, offset);  */
+        bm += 6;
 
             switch(zmachine_area) {   
         case PROP_DEFAULTS_ZA:   addr = prop_defaults_offset+4; break;

--- a/directs.c
+++ b/directs.c
@@ -1015,7 +1015,7 @@ the first constant definition");
            It shows the grammar at this point in the code. Setting
            list_verbs_setting shows the grammar at the end of 
            compilation.
-           Same goes for "Trace dictionary" and list_dict_setting. */
+           Same goes for "Trace dictionary" and list_dict_setting, etc. */
         
         i = token_value; j = 0;
 

--- a/directs.c
+++ b/directs.c
@@ -1017,7 +1017,7 @@ the first constant definition");
            compilation.
            Same goes for "Trace dictionary" and list_dict_setting, etc. */
         
-        i = token_value; j = 0;
+        i = token_value;
 
         switch(i)
         {

--- a/directs.c
+++ b/directs.c
@@ -1025,8 +1025,6 @@ the first constant definition");
             trace_level = &asm_trace_level;  break;
         case EXPRESSIONS_TK:
             trace_level = &expr_trace_level; break;
-        case LINES_TK:
-            trace_level = &line_trace_level; break;
         case TOKENS_TK:
             trace_level = &tokens_trace_level; break;
         case LINKER_TK:
@@ -1035,6 +1033,9 @@ the first constant definition");
         case SYMBOLS_TK:
         case OBJECTS_TK:
         case VERBS_TK:
+            trace_level = NULL; break;
+        case LINES_TK:
+            /* never implememented */
             trace_level = NULL; break;
         default:
             put_token_back();
@@ -1074,8 +1075,12 @@ the first constant definition");
             case OBJECTS_TK:    list_object_tree();  break;
             case SYMBOLS_TK:    list_symbols(j);     break;
             case VERBS_TK:      list_verb_table();   break;
+            case LINES_TK:
+                warning("'Trace lines' is not supported");
+                break;                
             default:
-                *trace_level = j;
+                if (trace_level)
+                    *trace_level = j;
                 break;
         }
         break;

--- a/directs.c
+++ b/directs.c
@@ -1065,6 +1065,11 @@ the first constant definition");
 
         HandleTraceKeyword:
 
+        if (i == LINES_TK) {
+            warning_named("Trace option is not supported:", trace_keywords.keywords[i]);
+            break;
+        }
+        
         if (trace_level == NULL && j == 0) {
             warning_named("Trace directive to display table at 'off' level has no effect: table", trace_keywords.keywords[i]);
             break;
@@ -1075,9 +1080,6 @@ the first constant definition");
             case OBJECTS_TK:    list_object_tree();  break;
             case SYMBOLS_TK:    list_symbols(j);     break;
             case VERBS_TK:      list_verb_table();   break;
-            case LINES_TK:
-                warning("'Trace lines' is not supported");
-                break;                
             default:
                 if (trace_level)
                     *trace_level = j;

--- a/directs.c
+++ b/directs.c
@@ -967,12 +967,14 @@ the first constant definition");
     /* --------------------------------------------------------------------- */
     /*   Trace dictionary                                                    */
     /*         objects                                                       */
-    /*         symbols                                                       */
+    /*         symbols      [on/off/NUM]                                     */
     /*         verbs                                                         */
     /*                      [on/off]                                         */
-    /*         assembly     [on/off]                                         */
-    /*         expressions  [on/off]                                         */
-    /*         lines        [on/off]                                         */
+    /*         assembly     [on/off/NUM]                                     */
+    /*         expressions  [on/off/NUM]                                     */
+    /*         lines        [on/off/NUM]                                     */
+    /*         tokens       [on/off/NUM]                                     */
+    /*         linker       [on/off/NUM]                                     */
     /* --------------------------------------------------------------------- */
 
     case TRACE_CODE:

--- a/directs.c
+++ b/directs.c
@@ -994,48 +994,54 @@ the first constant definition");
         /* Note that "Trace verbs" doesn't affect list_verbs_setting.
            It shows the grammar at this point in the code. Setting
            list_verbs_setting shows the grammar at the end of 
-           compilation. */
+           compilation.
+           Same goes for "Trace dictionary" and list_dict_setting. */
         
         i = token_value; j = 0;
+
         switch(i)
-        {   case DICTIONARY_TK: break;
-            case OBJECTS_TK:    break;
-            case VERBS_TK:      break;
-            default:
-                switch(token_value)
-                {   case ASSEMBLY_TK:
-                        trace_level = &asm_trace_level;  break;
-                    case EXPRESSIONS_TK:
-                        trace_level = &expr_trace_level; break;
-                    case LINES_TK:
-                        trace_level = &line_trace_level; break;
-                    case TOKENS_TK:
-                        trace_level = &tokens_trace_level; break;
-                    case LINKER_TK:
-                        trace_level = &linker_trace_level; break;
-                    case SYMBOLS_TK:
-                        trace_level = NULL; break;
-                    default:
-                        put_token_back();
-                        trace_level = &asm_trace_level; break;
-                }
-                j = 1;
-                get_next_token();
-                if ((token_type == SEP_TT) &&
-                    (token_value == SEMICOLON_SEP))
-                {   put_token_back(); break;
-                }
-                if (token_type == NUMBER_TT)
-                {   j = token_value; break; }
-                if ((token_type == TRACE_KEYWORD_TT) && (token_value == ON_TK))
-                {   j = 1; break; }
-                if ((token_type == TRACE_KEYWORD_TT) && (token_value == OFF_TK))
-                {   j = 0; break; }
-                put_token_back(); break;
+        {
+        case ASSEMBLY_TK:
+            trace_level = &asm_trace_level;  break;
+        case EXPRESSIONS_TK:
+            trace_level = &expr_trace_level; break;
+        case LINES_TK:
+            trace_level = &line_trace_level; break;
+        case TOKENS_TK:
+            trace_level = &tokens_trace_level; break;
+        case LINKER_TK:
+            trace_level = &linker_trace_level; break;
+        case DICTIONARY_TK:
+        case SYMBOLS_TK:
+        case OBJECTS_TK:
+        case VERBS_TK:
+            trace_level = NULL; break;
+        default:
+            put_token_back();
+            trace_level = &asm_trace_level; break;
+        }
+        
+        j = 1;
+        get_next_token();
+        if ((token_type == SEP_TT) &&
+            (token_value == SEMICOLON_SEP))
+        {   put_token_back();
+        }
+        else if (token_type == NUMBER_TT)
+        {   j = token_value;
+        }
+        else if ((token_type == TRACE_KEYWORD_TT) && (token_value == ON_TK))
+        {   j = 1;
+        }
+        else if ((token_type == TRACE_KEYWORD_TT) && (token_value == OFF_TK))
+        {   j = 0;
+        }
+        else
+        {   put_token_back();
         }
 
         switch(i)
-        {   case DICTIONARY_TK: show_dictionary();  break;
+        {   case DICTIONARY_TK: show_dictionary(j);  break;
             case OBJECTS_TK:    list_object_tree(); break;
             case SYMBOLS_TK:    list_symbols(j);     break;
             case VERBS_TK:      list_verb_table();  break;

--- a/directs.c
+++ b/directs.c
@@ -991,6 +991,11 @@ the first constant definition");
 
         trace_keywords.enabled = TRUE;
 
+        /* Note that "Trace verbs" doesn't affect list_verbs_setting.
+           It shows the grammar at this point in the code. Setting
+           list_verbs_setting shows the grammar at the end of 
+           compilation. */
+        
         i = token_value; j = 0;
         switch(i)
         {   case DICTIONARY_TK: break;

--- a/files.c
+++ b/files.c
@@ -136,8 +136,10 @@ extern void load_sourcefile(char *filename_given, int same_directory_flag)
         fatalerror_named("Couldn't open source file", name);
 
     InputFiles[total_files].is_input = TRUE;
+    InputFiles[total_files].initial_buffering = TRUE;
 
-    if (files_trace_setting > 0) printf("Opening file \"%s\"\n",name);
+    if (files_trace_setting > 0)
+        printf("Opening file \"%s\"\n",name);
 
     total_files++;
     total_input_files++;
@@ -159,7 +161,10 @@ static void close_sourcefile(int file_number)
 
     InputFiles[file_number-1].handle = NULL;
 
-    if (files_trace_setting > 0) printf("Closing file \"%s\"\n", InputFiles[file_number-1].filename);
+    if (files_trace_setting > 0) {
+        char *str = (InputFiles[file_number-1].initial_buffering ? " (in initial buffering)" : "");
+        printf("Closing file \"%s\"%s\n", InputFiles[file_number-1].filename, str);
+    }
 }
 
 extern void close_all_source(void)
@@ -215,6 +220,7 @@ extern int register_orig_sourcefile(char *filename)
 
     InputFiles[total_files].handle = NULL;
     InputFiles[total_files].is_input = FALSE;
+    InputFiles[total_files].initial_buffering = FALSE;
 
     total_files++;
     current_origsource_file = total_files;

--- a/files.c
+++ b/files.c
@@ -137,7 +137,7 @@ extern void load_sourcefile(char *filename_given, int same_directory_flag)
 
     InputFiles[total_files].is_input = TRUE;
 
-    if (line_trace_level > 0) printf("\nOpening file \"%s\"\n",name);
+    if (files_trace_setting > 0) printf("Opening file \"%s\"\n",name);
 
     total_files++;
     total_input_files++;
@@ -159,7 +159,7 @@ static void close_sourcefile(int file_number)
 
     InputFiles[file_number-1].handle = NULL;
 
-    if (line_trace_level > 0) printf("\nClosing file \"%s\"\n", InputFiles[file_number-1].filename);
+    if (files_trace_setting > 0) printf("Closing file \"%s\"\n", InputFiles[file_number-1].filename);
 }
 
 extern void close_all_source(void)

--- a/files.c
+++ b/files.c
@@ -159,7 +159,7 @@ static void close_sourcefile(int file_number)
 
     InputFiles[file_number-1].handle = NULL;
 
-    if (line_trace_level > 0) printf("\nClosing file\n");
+    if (line_trace_level > 0) printf("\nClosing file \"%s\"\n", InputFiles[file_number-1].filename);
 }
 
 extern void close_all_source(void)

--- a/header.h
+++ b/header.h
@@ -2541,6 +2541,7 @@ extern int
     economy_switch,         frequencies_setting,
     ignore_switches_switch, debugfile_switch,
     listing_switch,         memout_switch,        printprops_switch,
+    printactions_switch,
     obsolete_switch,        optabbrevs_trace_setting,
     transcript_switch,      statistics_switch,    optimise_switch,
     version_set_switch,     nowarnings_switch,    hash_switch,

--- a/header.h
+++ b/header.h
@@ -2533,14 +2533,14 @@ extern int WORDSIZE, INDIV_PROP_START,
     OBJECT_BYTE_LENGTH, DICT_ENTRY_BYTE_LENGTH, DICT_ENTRY_FLAG_POS;
 extern int32 MAXINTWORD;
 
-extern int asm_trace_level, line_trace_level,     expr_trace_level,
+extern int asm_trace_level, expr_trace_level,
     linker_trace_level,     tokens_trace_level;
 
 extern int
     concise_switch,
     economy_switch,         frequencies_setting,
     ignore_switches_switch, debugfile_switch,
-    line_trace_setting,     memout_switch,        printprops_switch,
+    files_trace_setting,    memout_switch,        printprops_switch,
     printactions_switch,
     obsolete_switch,        optabbrevs_trace_setting,
     transcript_switch,      statistics_switch,    optimise_switch,

--- a/header.h
+++ b/header.h
@@ -2547,7 +2547,8 @@ extern int
     memory_map_setting,     module_switch,        temporary_files_switch,
     define_DEBUG_switch,    define_USE_MODULES_switch, define_INFIX_switch,
     runtime_error_checking_switch,
-    list_verbs_setting,     list_dict_setting;
+    list_verbs_setting,     list_dict_setting,    list_objects_setting,
+    list_symbols_setting;
 
 extern int oddeven_packing_switch;
 

--- a/header.h
+++ b/header.h
@@ -2574,7 +2574,7 @@ extern int32 requested_glulx_version;
 
 extern int error_format,    store_the_text,       asm_trace_setting,
     expr_trace_setting,     linker_trace_setting, tokens_trace_setting,
-    bpatch_trace_setting,
+    bpatch_trace_setting,   symdef_trace_setting,
     double_space_setting,   trace_fns_setting,    character_set_setting,
     character_set_unicode;
 

--- a/header.h
+++ b/header.h
@@ -2538,7 +2538,7 @@ extern int asm_trace_level, line_trace_level,     expr_trace_level,
 
 extern int
     bothpasses_switch,      concise_switch,
-    economy_switch,         frequencies_switch,
+    economy_switch,         frequencies_setting,
     ignore_switches_switch, listobjects_switch,   debugfile_switch,
     listing_switch,         memout_switch,        printprops_switch,
     obsolete_switch,        optabbrevs_trace_setting,

--- a/header.h
+++ b/header.h
@@ -2574,6 +2574,7 @@ extern int32 requested_glulx_version;
 
 extern int error_format,    store_the_text,       asm_trace_setting,
     expr_trace_setting,     linker_trace_setting, tokens_trace_setting,
+    bpatch_trace_setting,
     double_space_setting,   trace_fns_setting,    character_set_setting,
     character_set_unicode;
 

--- a/header.h
+++ b/header.h
@@ -954,6 +954,8 @@ typedef struct FileId_s                 /*  Source code file identifier:     */
                                             parsing? If not, this is an
                                             origsource filename (and handle
                                             is NULL).                        */
+    int initial_buffering;              /* Are we still in the initial
+                                           begin_buffering_file() call?      */
 } FileId;
 
 typedef struct ErrorPosition_s

--- a/header.h
+++ b/header.h
@@ -2541,7 +2541,7 @@ extern int
     economy_switch,         frequencies_switch,
     ignore_switches_switch, listobjects_switch,   debugfile_switch,
     listing_switch,         memout_switch,        printprops_switch,
-    offsets_switch,         percentages_switch,   obsolete_switch,
+    offsets_switch,         obsolete_switch,
     transcript_switch,      statistics_switch,    optimise_switch,
     version_set_switch,     nowarnings_switch,    hash_switch,
     memory_map_switch,      module_switch,        temporary_files_switch,

--- a/header.h
+++ b/header.h
@@ -2540,7 +2540,7 @@ extern int
     concise_switch,
     economy_switch,         frequencies_setting,
     ignore_switches_switch, debugfile_switch,
-    listing_switch,         memout_switch,        printprops_switch,
+    line_trace_setting,     memout_switch,        printprops_switch,
     printactions_switch,
     obsolete_switch,        optabbrevs_trace_setting,
     transcript_switch,      statistics_switch,    optimise_switch,

--- a/header.h
+++ b/header.h
@@ -2541,7 +2541,7 @@ extern int
     economy_switch,         frequencies_switch,
     ignore_switches_switch, listobjects_switch,   debugfile_switch,
     listing_switch,         memout_switch,        printprops_switch,
-    obsolete_switch,
+    obsolete_switch,        optabbrevs_trace_setting,
     transcript_switch,      statistics_switch,    optimise_switch,
     version_set_switch,     nowarnings_switch,    hash_switch,
     memory_map_setting,     module_switch,        temporary_files_switch,

--- a/header.h
+++ b/header.h
@@ -2547,7 +2547,7 @@ extern int
     memory_map_setting,     module_switch,        temporary_files_switch,
     define_DEBUG_switch,    define_USE_MODULES_switch, define_INFIX_switch,
     runtime_error_checking_switch,
-    list_verbs_setting;
+    list_verbs_setting,     list_dict_setting;
 
 extern int oddeven_packing_switch;
 
@@ -2903,7 +2903,7 @@ extern int32 compile_string(char *b, int strctx);
 extern int32 translate_text(int32 p_limit, char *s_text, int strctx);
 extern void  optimise_abbreviations(void);
 extern void  make_abbreviation(char *text);
-extern void  show_dictionary(void);
+extern void  show_dictionary(int level);
 extern void  word_to_ascii(uchar *p, char *result);
 extern void  print_dict_word(int node);
 extern void  write_dictionary_to_transcript(void);

--- a/header.h
+++ b/header.h
@@ -2541,7 +2541,7 @@ extern int
     economy_switch,         frequencies_switch,
     ignore_switches_switch, listobjects_switch,   debugfile_switch,
     listing_switch,         memout_switch,        printprops_switch,
-    offsets_switch,         obsolete_switch,
+    obsolete_switch,
     transcript_switch,      statistics_switch,    optimise_switch,
     version_set_switch,     nowarnings_switch,    hash_switch,
     memory_map_setting,     module_switch,        temporary_files_switch,

--- a/header.h
+++ b/header.h
@@ -2537,7 +2537,7 @@ extern int asm_trace_level, line_trace_level,     expr_trace_level,
     linker_trace_level,     tokens_trace_level;
 
 extern int
-    bothpasses_switch,      concise_switch,
+    concise_switch,
     economy_switch,         frequencies_setting,
     ignore_switches_switch, debugfile_switch,
     listing_switch,         memout_switch,        printprops_switch,

--- a/header.h
+++ b/header.h
@@ -2544,7 +2544,7 @@ extern int
     offsets_switch,         obsolete_switch,
     transcript_switch,      statistics_switch,    optimise_switch,
     version_set_switch,     nowarnings_switch,    hash_switch,
-    memory_map_switch,      module_switch,        temporary_files_switch,
+    memory_map_setting,     module_switch,        temporary_files_switch,
     define_DEBUG_switch,    define_USE_MODULES_switch, define_INFIX_switch,
     runtime_error_checking_switch;
 

--- a/header.h
+++ b/header.h
@@ -2546,7 +2546,8 @@ extern int
     version_set_switch,     nowarnings_switch,    hash_switch,
     memory_map_setting,     module_switch,        temporary_files_switch,
     define_DEBUG_switch,    define_USE_MODULES_switch, define_INFIX_switch,
-    runtime_error_checking_switch;
+    runtime_error_checking_switch,
+    list_verbs_setting;
 
 extern int oddeven_packing_switch;
 

--- a/header.h
+++ b/header.h
@@ -2539,7 +2539,7 @@ extern int asm_trace_level, line_trace_level,     expr_trace_level,
 extern int
     bothpasses_switch,      concise_switch,
     economy_switch,         frequencies_setting,
-    ignore_switches_switch, listobjects_switch,   debugfile_switch,
+    ignore_switches_switch, debugfile_switch,
     listing_switch,         memout_switch,        printprops_switch,
     obsolete_switch,        optabbrevs_trace_setting,
     transcript_switch,      statistics_switch,    optimise_switch,
@@ -2556,6 +2556,7 @@ extern int glulx_mode, compression_switch;
 extern int32 requested_glulx_version;
 
 extern int error_format,    store_the_text,       asm_trace_setting,
+    expr_trace_setting,
     double_space_setting,   trace_fns_setting,    character_set_setting,
     character_set_unicode;
 

--- a/header.h
+++ b/header.h
@@ -2556,7 +2556,7 @@ extern int glulx_mode, compression_switch;
 extern int32 requested_glulx_version;
 
 extern int error_format,    store_the_text,       asm_trace_setting,
-    expr_trace_setting,
+    expr_trace_setting,     tokens_trace_setting,
     double_space_setting,   trace_fns_setting,    character_set_setting,
     character_set_unicode;
 

--- a/header.h
+++ b/header.h
@@ -2557,7 +2557,7 @@ extern int glulx_mode, compression_switch;
 extern int32 requested_glulx_version;
 
 extern int error_format,    store_the_text,       asm_trace_setting,
-    expr_trace_setting,     tokens_trace_setting,
+    expr_trace_setting,     linker_trace_setting, tokens_trace_setting,
     double_space_setting,   trace_fns_setting,    character_set_setting,
     character_set_unicode;
 

--- a/inform.c
+++ b/inform.c
@@ -1312,7 +1312,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   --opt SETTING=number   (change setting)\n\
   --helptrace            (list all trace options)\n\
   --trace TRACEOPT       (set trace option)\n\
-  --trace TRACEOPT=N     (more tracing)\n\
+  --trace TRACEOPT=num   (more tracing)\n\
   --define SYMBOL=number (define constant)\n\
   --config filename      (read setup file)\n\n");
 

--- a/inform.c
+++ b/inform.c
@@ -1295,6 +1295,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 "     $list            list current settings\n\
      $?SETTING        explain briefly what SETTING is for\n\
      $SETTING=number  change SETTING to given number\n\
+     $!TRACE=number   set trace option TRACE to given number (default 1)\n\
      $#SYMBOL=number  define SYMBOL as a constant in the story\n\n");
 
   printf(
@@ -1308,6 +1309,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   --list                 (list current settings)\n\
   --helpopt SETTING      (explain setting)\n\
   --opt SETTING=number   (change setting)\n\
+  --trace TRACE=number   (set trace option)\n\
   --define SYMBOL=number (define constant)\n\
   --config filename      (read setup file)\n\n");
 

--- a/inform.c
+++ b/inform.c
@@ -232,7 +232,7 @@ int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
                             branch info                                      */
     line_trace_level,    /* line tracing: 0 off, 1 on                        */
     expr_trace_level,    /* expression tracing: 0 off, 1 on, 2/3 more        */
-    linker_trace_level,  /* set by -y: 0 to 4 levels of tracing              */
+    linker_trace_level,  /* linker tracing: 0 to 4 levels                    */
     tokens_trace_level;  /* lexer output tracing: 0 off, 1 on, 2/3 more      */
 
 /* ------------------------------------------------------------------------- */
@@ -283,7 +283,8 @@ int character_set_setting,          /* set by -C0 through -C9 */
     optabbrevs_trace_setting,       /* $!FINDABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
-    linker_trace_setting,           /* set by -y: ditto for linker_... */
+    linker_trace_setting,           /* $!LINKER: initial value of
+                                       linker_trace_level */
     list_verbs_setting,             /* $!VERBS */
     list_dict_setting,              /* $!DICT */
     list_objects_setting,           /* $!OBJECTS */
@@ -1389,7 +1390,6 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   v8  compile to version-8 (expanded \"Advanced\") story file\n\
   w   disable warning messages\n\
   x   print # for every 100 lines compiled\n\
-  y   trace linking system\n\
   z   print memory map of the virtual machine\n\n");
 
 printf("\
@@ -1519,7 +1519,6 @@ extern void switches(char *p, int cmode)
                   break;
         case 'w': nowarnings_switch = state; break;
         case 'x': hash_switch = state; break;
-        case 'y': s=2; linker_trace_setting=p[i+1]-'0'; break;
         case 'z': memory_map_setting = (state ? 1 : 0); break;
         case 'B': oddeven_packing_switch = state; break;
         case 'C': s=2;

--- a/inform.c
+++ b/inform.c
@@ -276,7 +276,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
                                        tokens_trace_level */
     optabbrevs_trace_setting,       /* $!FINDABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
-    trace_fns_setting,              /* set by -g: 0, 1 or 2 */
+    trace_fns_setting,              /* $!RUNTIME, -g: 0, 1, 2, or 3 */
     files_trace_setting,            /* $!FILES */
     linker_trace_setting,           /* $!LINKER: initial value of
                                        linker_trace_level */

--- a/inform.c
+++ b/inform.c
@@ -233,7 +233,7 @@ int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
     line_trace_level,    /* line tracing: 0 off, 1 on                        */
     expr_trace_level,    /* expression tracing: 0 off, 1 on, 2/3 more        */
     linker_trace_level,  /* set by -y: 0 to 4 levels of tracing              */
-    tokens_trace_level;  /* lexer output tracing: 0 off, 1 on                */
+    tokens_trace_level;  /* lexer output tracing: 0 off, 1 on, 2/3 more      */
 
 /* ------------------------------------------------------------------------- */
 /*   On/off switch variables (by default all FALSE); other switch settings   */
@@ -278,6 +278,8 @@ int character_set_setting,          /* set by -C0 through -C9 */
                                        asm_trace_level */
     expr_trace_setting,             /* $!EXPR: initial value of
                                        expr_trace_level */
+    tokens_trace_setting,           /* $!TOKENS: initial value of
+                                       tokens_trace_level */
     optabbrevs_trace_setting,       /* $!FINDABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
@@ -293,13 +295,18 @@ static int r_e_c_s_set;             /* has -S been explicitly set? */
 int glulx_mode;                     /* -G */
 
 static void reset_switch_settings(void)
-{   asm_trace_setting=0;
-    linker_trace_level=0;
-    tokens_trace_level=0;
-    list_verbs_setting=0;
-    list_dict_setting=0;
-    list_objects_setting=0;
-    list_symbols_setting=0;
+{   asm_trace_setting = 0;
+    asm_trace_level = 0;
+    linker_trace_setting = 0;
+    linker_trace_level = 0;
+    tokens_trace_setting = 0;
+    tokens_trace_level = 0;
+    expr_trace_setting = 0;
+    expr_trace_level = 0;
+    list_verbs_setting = 0;
+    list_dict_setting = 0;
+    list_objects_setting = 0;
+    list_symbols_setting = 0;
 
     store_the_text = FALSE;
 
@@ -322,7 +329,7 @@ static void reset_switch_settings(void)
     version_set_switch = FALSE;
     nowarnings_switch = FALSE;
     hash_switch = FALSE;
-    memory_map_setting = FALSE;
+    memory_map_setting = 0;
     oddeven_packing_switch = FALSE;
     define_DEBUG_switch = FALSE;
 #ifdef USE_TEMPORARY_FILES
@@ -407,6 +414,7 @@ static void begin_pass(void)
     line_trace_level = 0;
     expr_trace_level = expr_trace_setting;
     asm_trace_level = asm_trace_setting;
+    tokens_trace_level = tokens_trace_setting;
     linker_trace_level = linker_trace_setting;
     if (listing_switch) line_trace_level=1;
 

--- a/inform.c
+++ b/inform.c
@@ -224,6 +224,8 @@ static void select_target(int targ)
 
 /* ------------------------------------------------------------------------- */
 /*   Tracery: output control variables                                       */
+/*   (These are initially set to foo_trace_setting, but the Trace directive  */
+/*   can change them on the fly)                                             */
 /* ------------------------------------------------------------------------- */
 
 int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
@@ -274,6 +276,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
     error_format,                   /* set by -E */
     asm_trace_setting,              /* $!ASM, -a: initial value of
                                        asm_trace_level */
+    bpatch_trace_setting,           /* $!BPATCH */
     expr_trace_setting,             /* $!EXPR: initial value of
                                        expr_trace_level */
     tokens_trace_setting,           /* $!TOKENS: initial value of
@@ -296,13 +299,10 @@ int glulx_mode;                     /* -G */
 
 static void reset_switch_settings(void)
 {   asm_trace_setting = 0;
-    asm_trace_level = 0;
     linker_trace_setting = 0;
-    linker_trace_level = 0;
     tokens_trace_setting = 0;
-    tokens_trace_level = 0;
     expr_trace_setting = 0;
-    expr_trace_level = 0;
+    bpatch_trace_setting = 0;
     list_verbs_setting = 0;
     list_dict_setting = 0;
     list_objects_setting = 0;
@@ -356,6 +356,12 @@ static void reset_switch_settings(void)
     compression_switch = TRUE;
     glulx_mode = FALSE;
     requested_glulx_version = 0;
+
+    /* These aren't switches, but for clarity we reset them too. */
+    asm_trace_level = 0;
+    expr_trace_level = 0;
+    linker_trace_level = 0;
+    tokens_trace_level = 0;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/inform.c
+++ b/inform.c
@@ -248,7 +248,6 @@ int bothpasses_switch,              /* -b */
     memout_switch,                  /* -m */
     printprops_switch,              /* -n */
     offsets_switch,                 /* -o */
-    percentages_switch,             /* -p */
     obsolete_switch,                /* -q */
     transcript_switch,              /* -r */
     statistics_switch,              /* $!STATS, -s */
@@ -256,7 +255,7 @@ int bothpasses_switch,              /* -b */
     version_set_switch,             /* -v */
     nowarnings_switch,              /* -w */
     hash_switch,                    /* -x */
-    memory_map_switch,              /* -z */
+    memory_map_switch,              /* $!MAP, -z */
     oddeven_packing_switch,         /* -B */
     define_DEBUG_switch,            /* -D */
     temporary_files_switch,         /* -F */
@@ -305,7 +304,6 @@ static void reset_switch_settings(void)
     memout_switch = FALSE;
     printprops_switch = FALSE;
     offsets_switch = FALSE;
-    percentages_switch = FALSE;
     obsolete_switch = FALSE;
     transcript_switch = FALSE;
     statistics_switch = FALSE;
@@ -1359,7 +1357,6 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
           Debugging_Name);
    printf("\
   o   print offset addresses\n\
-  p   give percentage breakdown of story file\n\
   q   keep quiet about obsolete usages\n\
   r   record all the text to \"%s\"\n\
   s   give statistics\n\
@@ -1474,7 +1471,6 @@ extern void switches(char *p, int cmode)
         case 'm': memout_switch = state; break;
         case 'n': printprops_switch = state; break;
         case 'o': offsets_switch = state; break;
-        case 'p': percentages_switch = state; break;
         case 'q': obsolete_switch = state; break;
         case 'r': if (cmode == 0)
                       error("The switch '-r' can't be set with 'Switches'");
@@ -1590,12 +1586,6 @@ extern void switches(char *p, int cmode)
         }
     }
 
-    if (percentages_switch)
-    {
-        /* -p is now treated like an extended -z. It will be renamed to
-           something like -TMAP=2 in the future. */
-        memory_map_switch = TRUE;
-    }
     if (optimise_switch)
     {
         /* store_the_text is equivalent to optimise_switch; -u sets both.

--- a/inform.c
+++ b/inform.c
@@ -245,7 +245,6 @@ int concise_switch,                 /* -c */
     frequencies_setting,            /* $!FREQ, -f */
     ignore_switches_switch,         /* -i */
     debugfile_switch,               /* -k */
-    listing_switch,                 /* -l */
     memout_switch,                  /* $!MEM */
     printprops_switch,              /* $!PROPS */
     printactions_switch,            /* $!ACTIONS */
@@ -283,6 +282,8 @@ int character_set_setting,          /* set by -C0 through -C9 */
     optabbrevs_trace_setting,       /* $!FINDABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
+    line_trace_setting,             /* $!LINES: initial value of
+                                       line_trace_level */
     linker_trace_setting,           /* $!LINKER: initial value of
                                        linker_trace_level */
     list_verbs_setting,             /* $!VERBS */
@@ -304,6 +305,8 @@ static void reset_switch_settings(void)
     tokens_trace_level = 0;
     expr_trace_setting = 0;
     expr_trace_level = 0;
+    line_trace_level = 0;
+    line_trace_setting = 0;
     list_verbs_setting = 0;
     list_dict_setting = 0;
     list_objects_setting = 0;
@@ -318,7 +321,6 @@ static void reset_switch_settings(void)
     trace_fns_setting = 0;
     ignore_switches_switch = FALSE;
     debugfile_switch = FALSE;
-    listing_switch = FALSE;
     memout_switch = 0;
     printprops_switch = 0;
     printactions_switch = 0;
@@ -412,12 +414,11 @@ static void begin_pass(void)
     files_begin_pass();
 
     endofpass_flag = FALSE;
-    line_trace_level = 0;
+    line_trace_level = line_trace_setting;
     expr_trace_level = expr_trace_setting;
     asm_trace_level = asm_trace_setting;
     tokens_trace_level = tokens_trace_setting;
     linker_trace_level = linker_trace_setting;
-    if (listing_switch) line_trace_level=1;
 
     lexer_begin_pass();
     linker_begin_pass();
@@ -1371,8 +1372,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 
    printf("\
   i   ignore default switches set within the file\n\
-  k   output debugging information to \"%s\"\n\
-  l   list every statement run through Inform (not implemented)\n",
+  k   output debugging information to \"%s\"\n",
           Debugging_Name);
    printf("\
   q   keep quiet about obsolete usages\n\
@@ -1488,7 +1488,6 @@ extern void switches(char *p, int cmode)
                   else
                       debugfile_switch = state;
                   break;
-        case 'l': listing_switch = state; break;
         case 'q': obsolete_switch = state; break;
         case 'r': if (cmode == 0)
                       error("The switch '-r' can't be set with 'Switches'");

--- a/inform.c
+++ b/inform.c
@@ -248,7 +248,8 @@ int bothpasses_switch,              /* -b */
     debugfile_switch,               /* -k */
     listing_switch,                 /* -l */
     memout_switch,                  /* -m */
-    printprops_switch,              /* -n */
+    printprops_switch,              /* $!PROPS */
+    printactions_switch,            /* $!ACTIONS */
     obsolete_switch,                /* -q */
     transcript_switch,              /* -r */
     statistics_switch,              /* $!STATS, -s */
@@ -320,7 +321,8 @@ static void reset_switch_settings(void)
     debugfile_switch = FALSE;
     listing_switch = FALSE;
     memout_switch = FALSE;
-    printprops_switch = FALSE;
+    printprops_switch = 0;
+    printactions_switch = 0;
     obsolete_switch = FALSE;
     transcript_switch = FALSE;
     statistics_switch = FALSE;
@@ -1372,8 +1374,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   i   ignore default switches set within the file\n\
   k   output debugging information to \"%s\"\n\
   l   list every statement run through Inform (not implemented)\n\
-  m   say how much memory has been allocated\n\
-  n   print numbers of properties, attributes and actions\n",
+  m   say how much memory has been allocated\n",
           Debugging_Name);
    printf("\
   q   keep quiet about obsolete usages\n\
@@ -1493,7 +1494,6 @@ extern void switches(char *p, int cmode)
                   break;
         case 'l': listing_switch = state; break;
         case 'm': memout_switch = state; break;
-        case 'n': printprops_switch = state; break;
         case 'q': obsolete_switch = state; break;
         case 'r': if (cmode == 0)
                       error("The switch '-r' can't be set with 'Switches'");

--- a/inform.c
+++ b/inform.c
@@ -251,7 +251,7 @@ int bothpasses_switch,              /* -b */
     percentages_switch,             /* -p */
     obsolete_switch,                /* -q */
     transcript_switch,              /* -r */
-    statistics_switch,              /* -s */
+    statistics_switch,              /* $!STATS, -s */
     optimise_switch,                /* -u */
     version_set_switch,             /* -v */
     nowarnings_switch,              /* -w */

--- a/inform.c
+++ b/inform.c
@@ -283,6 +283,8 @@ int character_set_setting,          /* set by -C0 through -C9 */
     linker_trace_setting,           /* set by -y: ditto for linker_... */
     list_verbs_setting,             /* $!VERBS */
     list_dict_setting,              /* $!DICT */
+    list_objects_setting,           /* $!OBJECTS */
+    list_symbols_setting,           /* $!SYMBOLS */
     store_the_text;                 /* when set, record game text to a chunk
                                        of memory (used by -u) */
 static int r_e_c_s_set;             /* has -S been explicitly set? */
@@ -295,6 +297,8 @@ static void reset_switch_settings(void)
     tokens_trace_level=0;
     list_verbs_setting=0;
     list_dict_setting=0;
+    list_objects_setting=0;
+    list_symbols_setting=0;
 
     store_the_text = FALSE;
 

--- a/inform.c
+++ b/inform.c
@@ -1295,7 +1295,9 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 "     $list            list current settings\n\
      $?SETTING        explain briefly what SETTING is for\n\
      $SETTING=number  change SETTING to given number\n\
-     $!TRACE=number   set trace option TRACE to given number (default 1)\n\
+     $!TRACEOPT       set trace option TRACEOPT\n\
+                      (or $!TRACEOPT=2, 3, etc for more tracing;\n\
+                      $! by itself to list all trace options)\n\
      $#SYMBOL=number  define SYMBOL as a constant in the story\n\n");
 
   printf(
@@ -1309,7 +1311,9 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   --list                 (list current settings)\n\
   --helpopt SETTING      (explain setting)\n\
   --opt SETTING=number   (change setting)\n\
-  --trace TRACE=number   (set trace option)\n\
+  --helptrace            (list all trace options)\n\
+  --trace TRACEOPT       (set trace option)\n\
+  --trace TRACEOPT=N     (more tracing)\n\
   --define SYMBOL=number (define constant)\n\
   --config filename      (read setup file)\n\n");
 
@@ -1892,9 +1896,14 @@ static int execute_dashdash_command(char *p, char *p2)
     }
     else if (!strcmp(p, "trace")) {
         consumed2 = TRUE;
+        if (!p2) {
+            printf("--trace must be followed by \"traceopt\" or \"traceopt=N\"\n");
+            return consumed2;
+        }
+        snprintf(cli_buff, CMD_BUF_SIZE, "$!%s", p2);
+    }
+    else if (!strcmp(p, "helptrace")) {
         strcpy(cli_buff, "$!");
-        if (p2)
-            strcpyupper(cli_buff+2, p2, CMD_BUF_SIZE-2);
     }
     else {
         printf("Option \"--%s\" unknown (try \"inform -h\")\n", p);

--- a/inform.c
+++ b/inform.c
@@ -277,6 +277,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
     asm_trace_setting,              /* $!ASM, -a: initial value of
                                        asm_trace_level */
     bpatch_trace_setting,           /* $!BPATCH */
+    symdef_trace_setting,           /* $!SYMDEF */
     expr_trace_setting,             /* $!EXPR: initial value of
                                        expr_trace_level */
     tokens_trace_setting,           /* $!TOKENS: initial value of
@@ -303,6 +304,7 @@ static void reset_switch_settings(void)
     tokens_trace_setting = 0;
     expr_trace_setting = 0;
     bpatch_trace_setting = 0;
+    symdef_trace_setting = 0;
     list_verbs_setting = 0;
     list_dict_setting = 0;
     list_objects_setting = 0;

--- a/inform.c
+++ b/inform.c
@@ -282,6 +282,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
     linker_trace_setting,           /* set by -y: ditto for linker_... */
     list_verbs_setting,             /* $!VERBS */
+    list_dict_setting,              /* $!DICT */
     store_the_text;                 /* when set, record game text to a chunk
                                        of memory (used by -u) */
 static int r_e_c_s_set;             /* has -S been explicitly set? */
@@ -293,6 +294,7 @@ static void reset_switch_settings(void)
     linker_trace_level=0;
     tokens_trace_level=0;
     list_verbs_setting=0;
+    list_dict_setting=0;
 
     store_the_text = FALSE;
 

--- a/inform.c
+++ b/inform.c
@@ -1598,6 +1598,7 @@ extern void switches(char *p, int cmode)
     }
 }
 
+/* Check whether the string looks like an ICL command. */
 static int icl_command(char *p)
 {   if ((p[0]=='+')||(p[0]=='-')||(p[0]=='$')
         || ((p[0]=='(')&&(p[strlen(p)-1]==')')) ) return TRUE;
@@ -1886,6 +1887,12 @@ static int execute_dashdash_command(char *p, char *p2)
             return consumed2;
         }
         snprintf(cli_buff, CMD_BUF_SIZE, "(%s)", p2);
+    }
+    else if (!strcmp(p, "trace")) {
+        consumed2 = TRUE;
+        strcpy(cli_buff, "$!");
+        if (p2)
+            strcpyupper(cli_buff+2, p2, CMD_BUF_SIZE-2);
     }
     else {
         printf("Option \"--%s\" unknown (try \"inform -h\")\n", p);

--- a/inform.c
+++ b/inform.c
@@ -231,7 +231,7 @@ int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
                             3 for branch shortening info, 4 for verbose
                             branch info                                      */
     line_trace_level,    /* line tracing: 0 off, 1 on                        */
-    expr_trace_level,    /* expression tracing: 0 off, 1 full, 2 brief       */
+    expr_trace_level,    /* expression tracing: 0 off, 1 on, 2/3 more        */
     linker_trace_level,  /* set by -y: 0 to 4 levels of tracing              */
     tokens_trace_level;  /* lexer output tracing: 0 off, 1 on                */
 
@@ -245,7 +245,6 @@ int bothpasses_switch,              /* -b */
     economy_switch,                 /* -e */
     frequencies_setting,            /* $!FREQ, -f */
     ignore_switches_switch,         /* -i */
-    listobjects_switch,             /* -j */
     debugfile_switch,               /* -k */
     listing_switch,                 /* -l */
     memout_switch,                  /* -m */
@@ -277,6 +276,8 @@ int character_set_setting,          /* set by -C0 through -C9 */
     error_format,                   /* set by -E */
     asm_trace_setting,              /* $!ASM, -a: initial value of
                                        asm_trace_level */
+    expr_trace_setting,             /* $!EXPR: initial value of
+                                       expr_trace_level */
     optabbrevs_trace_setting,       /* $!FINDABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
@@ -309,7 +310,6 @@ static void reset_switch_settings(void)
     frequencies_setting = 0;
     trace_fns_setting = 0;
     ignore_switches_switch = FALSE;
-    listobjects_switch = FALSE;
     debugfile_switch = FALSE;
     listing_switch = FALSE;
     memout_switch = FALSE;
@@ -404,7 +404,8 @@ static void begin_pass(void)
     files_begin_pass();
 
     endofpass_flag = FALSE;
-    line_trace_level = 0; expr_trace_level = 0;
+    line_trace_level = 0;
+    expr_trace_level = expr_trace_setting;
     asm_trace_level = asm_trace_setting;
     linker_trace_level = linker_trace_setting;
     if (listing_switch) line_trace_level=1;
@@ -1361,7 +1362,6 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 
    printf("\
   i   ignore default switches set within the file\n\
-  j   list objects as constructed\n\
   k   output debugging information to \"%s\"\n\
   l   list every statement run through Inform (not implemented)\n\
   m   say how much memory has been allocated\n\
@@ -1478,7 +1478,6 @@ extern void switches(char *p, int cmode)
                   }
                   break;
         case 'i': ignore_switches_switch = state; break;
-        case 'j': listobjects_switch = state; break;
         case 'k': if (cmode == 0)
                       error("The switch '-k' can't be set with 'Switches'");
                   else

--- a/inform.c
+++ b/inform.c
@@ -230,7 +230,6 @@ int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
                             only, 2 for full assembly tracing with hex dumps,
                             3 for branch shortening info, 4 for verbose
                             branch info                                      */
-    line_trace_level,    /* line tracing: 0 off, 1 on                        */
     expr_trace_level,    /* expression tracing: 0 off, 1 on, 2/3 more        */
     linker_trace_level,  /* linker tracing: 0 to 4 levels                    */
     tokens_trace_level;  /* lexer output tracing: 0 off, 1 on, 2/3 more      */
@@ -282,8 +281,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
     optabbrevs_trace_setting,       /* $!FINDABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
-    line_trace_setting,             /* $!LINES: initial value of
-                                       line_trace_level */
+    files_trace_setting,            /* $!FILES */
     linker_trace_setting,           /* $!LINKER: initial value of
                                        linker_trace_level */
     list_verbs_setting,             /* $!VERBS */
@@ -305,8 +303,6 @@ static void reset_switch_settings(void)
     tokens_trace_level = 0;
     expr_trace_setting = 0;
     expr_trace_level = 0;
-    line_trace_level = 0;
-    line_trace_setting = 0;
     list_verbs_setting = 0;
     list_dict_setting = 0;
     list_objects_setting = 0;
@@ -317,6 +313,7 @@ static void reset_switch_settings(void)
     concise_switch = FALSE;
     double_space_setting = 0;
     economy_switch = FALSE;
+    files_trace_setting = 0;
     frequencies_setting = 0;
     trace_fns_setting = 0;
     ignore_switches_switch = FALSE;
@@ -414,7 +411,6 @@ static void begin_pass(void)
     files_begin_pass();
 
     endofpass_flag = FALSE;
-    line_trace_level = line_trace_setting;
     expr_trace_level = expr_trace_setting;
     asm_trace_level = asm_trace_setting;
     tokens_trace_level = tokens_trace_setting;

--- a/inform.c
+++ b/inform.c
@@ -235,6 +235,7 @@ int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
 
 /* ------------------------------------------------------------------------- */
 /*   On/off switch variables (by default all FALSE); other switch settings   */
+/*   (Some of these have become numerical settings now)                      */
 /* ------------------------------------------------------------------------- */
 
 int bothpasses_switch,              /* -b */
@@ -255,7 +256,7 @@ int bothpasses_switch,              /* -b */
     version_set_switch,             /* -v */
     nowarnings_switch,              /* -w */
     hash_switch,                    /* -x */
-    memory_map_switch,              /* $!MAP, -z */
+    memory_map_setting,             /* $!MAP, -z */
     oddeven_packing_switch,         /* -B */
     define_DEBUG_switch,            /* -D */
     temporary_files_switch,         /* -F */
@@ -311,7 +312,7 @@ static void reset_switch_settings(void)
     version_set_switch = FALSE;
     nowarnings_switch = FALSE;
     hash_switch = FALSE;
-    memory_map_switch = FALSE;
+    memory_map_setting = FALSE;
     oddeven_packing_switch = FALSE;
     define_DEBUG_switch = FALSE;
 #ifdef USE_TEMPORARY_FILES
@@ -1503,7 +1504,7 @@ extern void switches(char *p, int cmode)
         case 'w': nowarnings_switch = state; break;
         case 'x': hash_switch = state; break;
         case 'y': s=2; linker_trace_setting=p[i+1]-'0'; break;
-        case 'z': memory_map_switch = (state ? 1 : 0); break;
+        case 'z': memory_map_setting = (state ? 1 : 0); break;
         case 'B': oddeven_packing_switch = state; break;
         case 'C': s=2;
                   if (p[i+1] == 'u') {

--- a/inform.c
+++ b/inform.c
@@ -277,7 +277,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
     error_format,                   /* set by -E */
     asm_trace_setting,              /* $!ASM, -a: initial value of
                                        asm_trace_level */
-    optabbrevs_trace_setting,       /* $!MAKEABBREVS */
+    optabbrevs_trace_setting,       /* $!FINDABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
     linker_trace_setting,           /* set by -y: ditto for linker_... */

--- a/inform.c
+++ b/inform.c
@@ -277,6 +277,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
     error_format,                   /* set by -E */
     asm_trace_setting,              /* $!ASM, -a: initial value of
                                        asm_trace_level */
+    optabbrevs_trace_setting,       /* $!MAKEABBREVS */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
     linker_trace_setting,           /* set by -y: ditto for linker_... */
@@ -309,6 +310,7 @@ static void reset_switch_settings(void)
     transcript_switch = FALSE;
     statistics_switch = FALSE;
     optimise_switch = FALSE;
+    optabbrevs_trace_setting = 0;
     version_set_switch = FALSE;
     nowarnings_switch = FALSE;
     hash_switch = FALSE;

--- a/inform.c
+++ b/inform.c
@@ -240,8 +240,7 @@ int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
 /*   (Some of these have become numerical settings now)                      */
 /* ------------------------------------------------------------------------- */
 
-int bothpasses_switch,              /* -b */
-    concise_switch,                 /* -c */
+int concise_switch,                 /* -c */
     economy_switch,                 /* -e */
     frequencies_setting,            /* $!FREQ, -f */
     ignore_switches_switch,         /* -i */
@@ -311,7 +310,6 @@ static void reset_switch_settings(void)
 
     store_the_text = FALSE;
 
-    bothpasses_switch = FALSE;
     concise_switch = FALSE;
     double_space_setting = 0;
     economy_switch = FALSE;
@@ -1461,7 +1459,6 @@ extern void switches(char *p, int cmode)
                       default: asm_trace_setting=1; break;
                   }
                   break;
-        case 'b': bothpasses_switch = state; break;
         case 'c': concise_switch = state; break;
         case 'd': switch(p[i+1])
                   {   case '1': double_space_setting=1; s=2; break;

--- a/inform.c
+++ b/inform.c
@@ -281,6 +281,7 @@ int character_set_setting,          /* set by -C0 through -C9 */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
     linker_trace_setting,           /* set by -y: ditto for linker_... */
+    list_verbs_setting,             /* $!VERBS */
     store_the_text;                 /* when set, record game text to a chunk
                                        of memory (used by -u) */
 static int r_e_c_s_set;             /* has -S been explicitly set? */
@@ -291,6 +292,7 @@ static void reset_switch_settings(void)
 {   asm_trace_setting=0;
     linker_trace_level=0;
     tokens_trace_level=0;
+    list_verbs_setting=0;
 
     store_the_text = FALSE;
 

--- a/inform.c
+++ b/inform.c
@@ -1503,7 +1503,7 @@ extern void switches(char *p, int cmode)
         case 'w': nowarnings_switch = state; break;
         case 'x': hash_switch = state; break;
         case 'y': s=2; linker_trace_setting=p[i+1]-'0'; break;
-        case 'z': memory_map_switch = state; break;
+        case 'z': memory_map_switch = (state ? 1 : 0); break;
         case 'B': oddeven_packing_switch = state; break;
         case 'C': s=2;
                   if (p[i+1] == 'u') {

--- a/inform.c
+++ b/inform.c
@@ -247,7 +247,7 @@ int bothpasses_switch,              /* -b */
     ignore_switches_switch,         /* -i */
     debugfile_switch,               /* -k */
     listing_switch,                 /* -l */
-    memout_switch,                  /* -m */
+    memout_switch,                  /* $!MEM */
     printprops_switch,              /* $!PROPS */
     printactions_switch,            /* $!ACTIONS */
     obsolete_switch,                /* -q */
@@ -320,7 +320,7 @@ static void reset_switch_settings(void)
     ignore_switches_switch = FALSE;
     debugfile_switch = FALSE;
     listing_switch = FALSE;
-    memout_switch = FALSE;
+    memout_switch = 0;
     printprops_switch = 0;
     printactions_switch = 0;
     obsolete_switch = FALSE;
@@ -1373,8 +1373,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
    printf("\
   i   ignore default switches set within the file\n\
   k   output debugging information to \"%s\"\n\
-  l   list every statement run through Inform (not implemented)\n\
-  m   say how much memory has been allocated\n",
+  l   list every statement run through Inform (not implemented)\n",
           Debugging_Name);
    printf("\
   q   keep quiet about obsolete usages\n\
@@ -1493,7 +1492,6 @@ extern void switches(char *p, int cmode)
                       debugfile_switch = state;
                   break;
         case 'l': listing_switch = state; break;
-        case 'm': memout_switch = state; break;
         case 'q': obsolete_switch = state; break;
         case 'r': if (cmode == 0)
                       error("The switch '-r' can't be set with 'Switches'");

--- a/inform.c
+++ b/inform.c
@@ -243,7 +243,7 @@ int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
 int bothpasses_switch,              /* -b */
     concise_switch,                 /* -c */
     economy_switch,                 /* -e */
-    frequencies_switch,             /* -f */
+    frequencies_setting,            /* $!FREQ, -f */
     ignore_switches_switch,         /* -i */
     listobjects_switch,             /* -j */
     debugfile_switch,               /* -k */
@@ -298,7 +298,7 @@ static void reset_switch_settings(void)
     concise_switch = FALSE;
     double_space_setting = 0;
     economy_switch = FALSE;
-    frequencies_switch = FALSE;
+    frequencies_setting = 0;
     trace_fns_setting = 0;
     ignore_switches_switch = FALSE;
     listobjects_switch = FALSE;
@@ -1454,7 +1454,7 @@ extern void switches(char *p, int cmode)
                   }
                   break;
         case 'e': economy_switch = state; break;
-        case 'f': frequencies_switch = state; break;
+        case 'f': frequencies_setting = (state?1:0); break;
         case 'g': switch(p[i+1])
                   {   case '1': trace_fns_setting=1; s=2; break;
                       case '2': trace_fns_setting=2; s=2; break;

--- a/inform.c
+++ b/inform.c
@@ -250,7 +250,6 @@ int bothpasses_switch,              /* -b */
     listing_switch,                 /* -l */
     memout_switch,                  /* -m */
     printprops_switch,              /* -n */
-    offsets_switch,                 /* -o */
     obsolete_switch,                /* -q */
     transcript_switch,              /* -r */
     statistics_switch,              /* $!STATS, -s */
@@ -306,7 +305,6 @@ static void reset_switch_settings(void)
     listing_switch = FALSE;
     memout_switch = FALSE;
     printprops_switch = FALSE;
-    offsets_switch = FALSE;
     obsolete_switch = FALSE;
     transcript_switch = FALSE;
     statistics_switch = FALSE;
@@ -1360,7 +1358,6 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   n   print numbers of properties, attributes and actions\n",
           Debugging_Name);
    printf("\
-  o   print offset addresses\n\
   q   keep quiet about obsolete usages\n\
   r   record all the text to \"%s\"\n\
   s   give statistics\n",
@@ -1480,7 +1477,6 @@ extern void switches(char *p, int cmode)
         case 'l': listing_switch = state; break;
         case 'm': memout_switch = state; break;
         case 'n': printprops_switch = state; break;
-        case 'o': offsets_switch = state; break;
         case 'q': obsolete_switch = state; break;
         case 'r': if (cmode == 0)
                       error("The switch '-r' can't be set with 'Switches'");

--- a/inform.c
+++ b/inform.c
@@ -227,7 +227,9 @@ static void select_target(int targ)
 /* ------------------------------------------------------------------------- */
 
 int asm_trace_level,     /* trace assembly: 0 for off, 1 for assembly
-                            only, 2 for full assembly tracing with hex dumps */
+                            only, 2 for full assembly tracing with hex dumps,
+                            3 for branch shortening info, 4 for verbose
+                            branch info                                      */
     line_trace_level,    /* line tracing: 0 off, 1 on                        */
     expr_trace_level,    /* expression tracing: 0 off, 1 full, 2 brief       */
     linker_trace_level,  /* set by -y: 0 to 4 levels of tracing              */
@@ -274,8 +276,8 @@ int compression_switch;             /* set by -H */
 int character_set_setting,          /* set by -C0 through -C9 */
     character_set_unicode,          /* set by -Cu */
     error_format,                   /* set by -E */
-    asm_trace_setting,              /* set by -a and -t: value of
-                                       asm_trace_level to use when tracing */
+    asm_trace_setting,              /* $!ASM, -a: initial value of
+                                       asm_trace_level */
     double_space_setting,           /* set by -d: 0, 1 or 2 */
     trace_fns_setting,              /* set by -g: 0, 1 or 2 */
     linker_trace_setting,           /* set by -y: ditto for linker_... */
@@ -1333,7 +1335,8 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
    /* The -h2 (switches) help information: */
 
    printf("Help on the full list of legal switch commands:\n\n\
-  a   trace assembly-language (without hex dumps; see -t)\n\
+  a   trace assembly-language\n\
+  a2  trace assembly with hex dumps\n\
   c   more concise error messages\n\
   d   contract double spaces after full stops in text\n\
   d2  contract double spaces after exclamation and question marks, too\n\
@@ -1360,8 +1363,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   o   print offset addresses\n\
   q   keep quiet about obsolete usages\n\
   r   record all the text to \"%s\"\n\
-  s   give statistics\n\
-  t   trace assembly-language (with full hex dumps; see -a)\n",
+  s   give statistics\n",
       Transcript_Name);
 
    printf("\
@@ -1436,7 +1438,14 @@ extern void switches(char *p, int cmode)
         }
         switch(p[i])
         {
-        case 'a': asm_trace_setting = 1; break;
+        case 'a': switch(p[i+1])
+                  {   case '1': asm_trace_setting=1; s=2; break;
+                      case '2': asm_trace_setting=2; s=2; break;
+                      case '3': asm_trace_setting=3; s=2; break;
+                      case '4': asm_trace_setting=4; s=2; break;
+                      default: asm_trace_setting=1; break;
+                  }
+                  break;
         case 'b': bothpasses_switch = state; break;
         case 'c': concise_switch = state; break;
         case 'd': switch(p[i+1])
@@ -1478,7 +1487,6 @@ extern void switches(char *p, int cmode)
                   else
                       transcript_switch = state; break;
         case 's': statistics_switch = state; break;
-        case 't': asm_trace_setting=2; break;
         case 'u': if (cmode == 0) {
                       error("The switch '-u' can't be set with 'Switches'");
                       break;

--- a/lexer.c
+++ b/lexer.c
@@ -1908,8 +1908,10 @@ extern void get_next_token(void)
     }
 
     if (tokens_trace_level > 0)
-    {   if (tokens_trace_level == 1)
+    {   if (tokens_trace_level == 1) {
             printf("'%s' ", circle[i].text);
+            if (circle[i].type == EOF_TT) printf("\n");
+        }
         else
         {   printf("-> "); describe_token(&circle[i]);
             printf(" ");

--- a/lexer.c
+++ b/lexer.c
@@ -1319,6 +1319,8 @@ static void begin_buffering_file(int i, int file_no)
     FileStack[i].file_no = file_no;
     FileStack[i].size = file_load_chars(file_no,
         (char *) p, SOURCE_BUFFER_SIZE);
+    /* If the file is shorter than SOURCE_BUFFER_SIZE, it's now closed already. We still need to set up the file entry though. */
+    
     lookahead  = source_to_iso_grid[p[0]];
     lookahead2 = source_to_iso_grid[p[1]];
     lookahead3 = source_to_iso_grid[p[2]];
@@ -1338,6 +1340,8 @@ static void begin_buffering_file(int i, int file_no)
     FileStack[i].LB.orig_source = NULL; FileStack[i].LB.orig_file = 0; 
     FileStack[i].LB.orig_line = 0; FileStack[i].LB.orig_char = 0;
 
+    InputFiles[file_no-1].initial_buffering = FALSE;
+    
     CurrentLB = &(FileStack[i].LB);
     CF = &(FileStack[i]);
 

--- a/memory.c
+++ b/memory.c
@@ -582,8 +582,10 @@ static void set_trace_option(char *command)
 {
     char *cx;
     int value = 1;
+
+    /* Parse options of the form STRING or STRING=NUM. (The $! has already been eaten.) */
     
-    if (!strlen(command)) {
+    if (!command || *command == '\0') {
         printf("### trace help\n");
         //### list all (with current values if set?)
         return;

--- a/memory.c
+++ b/memory.c
@@ -591,8 +591,8 @@ static void set_trace_option(char *command)
         printf("    ASM=2: also show hex dumps\n");
         printf("    ASM=3: also show branch optimization info\n");
         printf("    ASM=4: more verbose branch info\n");
-        printf("  MAKEABBREVS: show selection decisions during abbreviation optimization (-u mode)\n");
-        printf("    MAKEABBREVS=2: also show three-letter-block decisions\n");
+        printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only applies in -u mode)\n");
+        printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
@@ -629,7 +629,7 @@ static void set_trace_option(char *command)
     else if (strcmp(command, "ASSEMBLY")==0 || strcmp(command, "ASM")==0) {
         asm_trace_setting = value;
     }
-    else if (strcmp(command, "MAKEABBREV")==0 || strcmp(command, "MAKEABBREVS")==0) {
+    else if (strcmp(command, "FINDABBREV")==0 || strcmp(command, "FINDABBREVS")==0) {
         optabbrevs_trace_setting = value;
     }
     else {

--- a/memory.c
+++ b/memory.c
@@ -591,6 +591,8 @@ static void set_trace_option(char *command)
         printf("  ASM=2: ...also show hex dumps\n");
         printf("  ASM=3: ...also show branch optimization info\n");
         printf("  ASM=4: ...more verbose branch info\n");
+        printf("  MAKEABBREVS: show selection decisions during abbreviation optimization (-u mode)\n");
+        printf("  MAKEABBREVS=2: ...also show three-letter-block decisions\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("  MAP=2: ...also show percentage of VM that each segment occupies\n");
         printf("  STATS: give compilation statistics (same as -s)\n");

--- a/memory.c
+++ b/memory.c
@@ -597,6 +597,7 @@ static void set_trace_option(char *command)
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
+        printf("  VERBS: display the verb grammar table\n");
         //### more
         return;
     }
@@ -637,6 +638,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
         statistics_switch = value;
+    }
+    else if (strcmp(command, "VERBS")==0 || strcmp(command, "VERB")==0) {
+        list_verbs_setting = value;
     }
     else {
         printf("Unrecognized $! trace command \"%s\"\n", command);

--- a/memory.c
+++ b/memory.c
@@ -605,6 +605,9 @@ static void set_trace_option(char *command)
         printf("  STATS: give compilation statistics (same as -s)\n");
         printf("  SYMBOLS: display the symbol table\n");
         printf("    SYMBOLS=2: also show compiler-defined symbols\n");
+        printf("  TOKENS: show token lexing\n");
+        printf("    TOKENS=2: also show token types\n");
+        printf("    TOKENS=3: also show lexical context\n");
         printf("  VERBS: display the verb grammar table\n");
         //### more
         return;
@@ -658,6 +661,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "SYMBOLS")==0 || strcmp(command, "SYMBOL")==0) {
         list_symbols_setting = value;
+    }
+    else if (strcmp(command, "TOKEN")==0 || strcmp(command, "TOKENS")==0) {
+        tokens_trace_setting = value;
     }
     else if (strcmp(command, "VERBS")==0 || strcmp(command, "VERB")==0) {
         list_verbs_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -591,8 +591,9 @@ static void set_trace_option(char *command)
         printf("    ASM=2: also show hex dumps\n");
         printf("    ASM=3: also show branch optimization info\n");
         printf("    ASM=4: more verbose branch info\n");
-        printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only applies in -u mode)\n");
+        printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only meaningful with -u)\n");
         printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
+        printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
@@ -620,17 +621,22 @@ static void set_trace_option(char *command)
         *cx = '\0';
     }
 
-    if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
-        statistics_switch = value;
-    }
-    else if (strcmp(command, "MAP")==0) {
-        memory_map_setting = value;
-    }
-    else if (strcmp(command, "ASSEMBLY")==0 || strcmp(command, "ASM")==0) {
+    /* We accept some reasonable synonyms, including plausible singular/plural confusion. */
+    
+    if (strcmp(command, "ASSEMBLY")==0 || strcmp(command, "ASM")==0) {
         asm_trace_setting = value;
     }
     else if (strcmp(command, "FINDABBREV")==0 || strcmp(command, "FINDABBREVS")==0) {
         optabbrevs_trace_setting = value;
+    }
+    else if (strcmp(command, "FREQUENCY")==0 || strcmp(command, "FREQUENCIES")==0 || strcmp(command, "FREQ")==0) {
+        frequencies_setting = value;
+    }
+    else if (strcmp(command, "MAP")==0) {
+        memory_map_setting = value;
+    }
+    else if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
+        statistics_switch = value;
     }
     else {
         printf("Unrecognized $! trace command \"%s\"\n", command);

--- a/memory.c
+++ b/memory.c
@@ -618,8 +618,6 @@ static void set_trace_option(char *command)
         *cx = '\0';
     }
 
-    printf("### trace parsed '%s' = %d\n", command, value);
-
     if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
         statistics_switch = value;
     }

--- a/memory.c
+++ b/memory.c
@@ -602,6 +602,7 @@ static void set_trace_option(char *command)
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
+        printf("  MEM: show internal memory allocations\n");
         printf("  OBJECTS: display the object table\n");
         printf("  PROPS: show attributes and properties defined\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
@@ -614,7 +615,6 @@ static void set_trace_option(char *command)
         //### more
         //### LINES (line_trace_level)
         //### LINKER (linker_trace_level, -y)
-        //### MEM (memout_switch, -m)
         //### ? (listing_switch, -l)
         return;
     }
@@ -661,6 +661,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "MAP")==0) {
         memory_map_setting = value;
+    }
+    else if (strcmp(command, "MEM")==0 || strcmp(command, "MEMORY")==0) {
+        memout_switch = value;
     }
     else if (strcmp(command, "OBJECTS")==0 || strcmp(command, "OBJECT")==0 || strcmp(command, "OBJS")==0 || strcmp(command, "OBJ")==0) {
         list_objects_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -587,6 +587,10 @@ static void set_trace_option(char *command)
     
     if (!command || *command == '\0') {
         printf("The full list of trace options:\n\n");
+        printf("  ASM: trace assembly (same as -a)\n");
+        printf("  ASM=2: ...also show hex dumps\n");
+        printf("  ASM=3: ...also show branch optimization info\n");
+        printf("  ASM=4: ...more verbose branch info\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("  MAP=2: ...also show percentage of VM that each segment occupies\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
@@ -621,6 +625,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "MAP")==0) {
         memory_map_setting = value;
+    }
+    else if (strcmp(command, "ASSEMBLY")==0 || strcmp(command, "ASM")==0) {
+        asm_trace_setting = value;
     }
     else {
         printf("Unrecognized $! trace command \"%s\"\n", command);

--- a/memory.c
+++ b/memory.c
@@ -588,13 +588,13 @@ static void set_trace_option(char *command)
     if (!command || *command == '\0') {
         printf("The full list of trace options:\n\n");
         printf("  ASM: trace assembly (same as -a)\n");
-        printf("  ASM=2: ...also show hex dumps\n");
-        printf("  ASM=3: ...also show branch optimization info\n");
-        printf("  ASM=4: ...more verbose branch info\n");
+        printf("    ASM=2: also show hex dumps\n");
+        printf("    ASM=3: also show branch optimization info\n");
+        printf("    ASM=4: more verbose branch info\n");
         printf("  MAKEABBREVS: show selection decisions during abbreviation optimization (-u mode)\n");
-        printf("  MAKEABBREVS=2: ...also show three-letter-block decisions\n");
+        printf("    MAKEABBREVS=2: also show three-letter-block decisions\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
-        printf("  MAP=2: ...also show percentage of VM that each segment occupies\n");
+        printf("    MAP=2: also show percentage of VM that each segment occupies\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
         //### more
         return;

--- a/memory.c
+++ b/memory.c
@@ -603,7 +603,8 @@ static void set_trace_option(char *command)
         printf("    ASM=2: also show hex dumps\n");
         printf("    ASM=3: also show branch optimization info\n");
         printf("    ASM=4: more verbose branch info\n");
-        printf("  BPATCH: trace backpatch markers\n");
+        printf("  BPATCH: trace backpatch results\n");
+        printf("    BPATCH=2: also show markers added\n");
         printf("  DICT: display the dictionary table\n");
         printf("    DICT=2: also the byte encoding of entries\n");
         printf("  EXPR: show expression trees\n");

--- a/memory.c
+++ b/memory.c
@@ -610,6 +610,11 @@ static void set_trace_option(char *command)
         printf("    TOKENS=3: also show lexical context\n");
         printf("  VERBS: display the verb grammar table\n");
         //### more
+        //### LINES (line_trace_level)
+        //### LINKER (linker_trace_level, -y)
+        //### MEM (memout_switch, -m)
+        //### ? (printprops_switch, -n)
+        //### ? (listing_switch, -l)
         return;
     }
 

--- a/memory.c
+++ b/memory.c
@@ -578,6 +578,11 @@ static void add_predefined_symbol(char *command)
     add_config_symbol_definition(command, value);
 }
 
+static void set_trace_option(char *command)
+{
+    printf("### trace '%s'\n", command);
+}
+
 /* Handle a dollar-sign command option: $LIST, $FOO=VAL, and so on.
    The option may come from the command line, an ICL file, or a header
    comment.
@@ -596,6 +601,7 @@ extern void memory_command(char *command)
 
     if (command[0]=='?') { explain_parameter(command+1); return; }
     if (command[0]=='#') { add_predefined_symbol(command+1); return; }
+    if (command[0]=='!') { set_trace_option(command+1); return; }
 
     if (strcmp(command, "HUGE")==0
         || strcmp(command, "LARGE")==0

--- a/memory.c
+++ b/memory.c
@@ -603,6 +603,7 @@ static void set_trace_option(char *command)
         printf("    ASM=2: also show hex dumps\n");
         printf("    ASM=3: also show branch optimization info\n");
         printf("    ASM=4: more verbose branch info\n");
+        printf("  BPATCH: trace backpatch markers\n");
         printf("  DICT: display the dictionary table\n");
         printf("    DICT=2: also the byte encoding of entries\n");
         printf("  EXPR: show expression trees\n");
@@ -657,6 +658,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "ACTION")==0 || strcmp(command, "ACTIONS")==0) {
         printactions_switch = value;
+    }
+    else if (strcmp(command, "BPATCH")==0 || strcmp(command, "BACKPATCH")==0) {
+        bpatch_trace_setting = value;
     }
     else if (strcmp(command, "DICTIONARY")==0 || strcmp(command, "DICT")==0) {
         list_dict_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -586,8 +586,11 @@ static void set_trace_option(char *command)
     /* Parse options of the form STRING or STRING=NUM. (The $! has already been eaten.) If the string is null or empty, show help. */
     
     if (!command || *command == '\0') {
-        printf("### trace help\n");
-        //### list all (with current values if set?)
+        printf("The full list of trace options:\n\n");
+        printf("  MAP: print memory map of the virtual machine (same as -z)\n");
+        printf("  MAP=2: ...also show percentage of VM that each segment occupies\n");
+        printf("  STATS: give compilation statistics (same as -s)\n");
+        //### more
         return;
     }
 

--- a/memory.c
+++ b/memory.c
@@ -621,6 +621,9 @@ static void set_trace_option(char *command)
         printf("  MEM: show internal memory allocations\n");
         printf("  OBJECTS: display the object table\n");
         printf("  PROPS: show attributes and properties defined\n");
+        printf("  RUNTIME: show game function calls at runtime (same as -g)\n");
+        printf("    RUNTIME=2: also show library calls (not supported in Glulx)\n");
+        printf("    RUNTIME=3: also show veneer calls (not supported in Glulx)\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
         printf("  SYMBOLS: display the symbol table\n");
         printf("    SYMBOLS=2: also show compiler-defined symbols\n");
@@ -629,7 +632,6 @@ static void set_trace_option(char *command)
         printf("    TOKENS=2: also show token types\n");
         printf("    TOKENS=3: also show lexical context\n");
         printf("  VERBS: display the verb grammar table\n");
-        //### trace_fns_setting (-g)
         return;
     }
 
@@ -693,6 +695,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "PROP")==0 || strcmp(command, "PROPERTY")==0 || strcmp(command, "PROPS")==0 || strcmp(command, "PROPERTIES")==0) {
         printprops_switch = value;
+    }
+    else if (strcmp(command, "RUNTIME")==0) {
+        trace_fns_setting = value;
     }
     else if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
         statistics_switch = value;

--- a/memory.c
+++ b/memory.c
@@ -617,7 +617,7 @@ static void set_trace_option(char *command)
         statistics_switch = value;
     }
     else if (strcmp(command, "MAP")==0) {
-        memory_map_switch = value;
+        memory_map_setting = value;
     }
     else {
         printf("Unrecognized $! trace command \"%s\"\n", command);

--- a/memory.c
+++ b/memory.c
@@ -593,6 +593,9 @@ static void set_trace_option(char *command)
         printf("    ASM=4: more verbose branch info\n");
         printf("  DICT: display the dictionary table\n");
         printf("    DICT=2: also the byte encoding of entries\n");
+        printf("  EXPR: show expression trees\n");
+        printf("    EXPR=2: more verbose\n");
+        printf("    EXPR=3: even more verbose\n");
         printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only meaningful with -u)\n");
         printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
@@ -634,6 +637,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "DICTIONARY")==0 || strcmp(command, "DICT")==0) {
         list_dict_setting = value;
+    }
+    else if (strcmp(command, "EXPR")==0 || strcmp(command, "EXPRESSION")==0 || strcmp(command, "EXPRESSIONS")==0) {
+        expr_trace_setting = value;
     }
     else if (strcmp(command, "FINDABBREV")==0 || strcmp(command, "FINDABBREVS")==0) {
         optabbrevs_trace_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -580,7 +580,35 @@ static void add_predefined_symbol(char *command)
 
 static void set_trace_option(char *command)
 {
-    printf("### trace '%s'\n", command);
+    char *cx;
+    int value = 1;
+    
+    if (!strlen(command)) {
+        printf("### trace help\n");
+        //### list all (with current values if set?)
+        return;
+    }
+
+    for (cx=command; *cx && *cx != '='; cx++) {
+        if (!(*cx >= 'A' && *cx <= 'Z')) {
+            printf("Invalid $! trace command \"%s\"\n", command);
+            return;
+        }
+    }
+
+    if (*cx == '=') {
+        char *ex;
+        value = strtol(cx+1, &ex, 10);
+        
+        if (ex == cx+1 || *ex != '\0' || value < 0) {
+            printf("Bad numerical setting in $! trace command \"%s\"\n", command);
+            return;
+        }
+        
+        *cx = '\0';
+    }
+
+    printf("### trace parsed '%s' = %d\n", command, value);
 }
 
 /* Handle a dollar-sign command option: $LIST, $FOO=VAL, and so on.

--- a/memory.c
+++ b/memory.c
@@ -603,7 +603,7 @@ static void set_trace_option(char *command)
         printf("    ASM=2: also show hex dumps\n");
         printf("    ASM=3: also show branch optimization info\n");
         printf("    ASM=4: more verbose branch info\n");
-        printf("  BPATCH: trace backpatch results\n");
+        printf("  BPATCH: show backpatch results\n");
         printf("    BPATCH=2: also show markers added\n");
         printf("  DICT: display the dictionary table\n");
         printf("    DICT=2: also the byte encoding of entries\n");
@@ -624,6 +624,7 @@ static void set_trace_option(char *command)
         printf("  STATS: give compilation statistics (same as -s)\n");
         printf("  SYMBOLS: display the symbol table\n");
         printf("    SYMBOLS=2: also show compiler-defined symbols\n");
+        printf("  SYMDEF: show when symbols are noticed and defined\n");
         printf("  TOKENS: show token lexing\n");
         printf("    TOKENS=2: also show token types\n");
         printf("    TOKENS=3: also show lexical context\n");
@@ -698,6 +699,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "SYMBOLS")==0 || strcmp(command, "SYMBOL")==0) {
         list_symbols_setting = value;
+    }
+    else if (strcmp(command, "SYMDEF")==0 || strcmp(command, "SYMBOLDEF")==0) {
+        symdef_trace_setting = value;
     }
     else if (strcmp(command, "TOKEN")==0 || strcmp(command, "TOKENS")==0) {
         tokens_trace_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -600,7 +600,7 @@ static void set_trace_option(char *command)
         printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only meaningful with -u)\n");
         printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
-        printf("  LINES: show lines compiled (not implemented)\n");
+        printf("  LINES: show lines compiled (currently only Include file begin/end)\n");
         printf("  LINKER: show module linking info\n");
         printf("    LINKER=2: more verbose (or 3, 4 for even more)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
@@ -615,6 +615,7 @@ static void set_trace_option(char *command)
         printf("    TOKENS=2: also show token types\n");
         printf("    TOKENS=3: also show lexical context\n");
         printf("  VERBS: display the verb grammar table\n");
+        //### trace_fns_setting (-g)
         return;
     }
 

--- a/memory.c
+++ b/memory.c
@@ -598,7 +598,10 @@ static void set_trace_option(char *command)
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
+        printf("  OBJECTS: display the object table\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
+        printf("  SYMBOLS: display the symbol table\n");
+        printf("    SYMBOLS=2: also show compiler-defined symbols\n");
         printf("  VERBS: display the verb grammar table\n");
         //### more
         return;
@@ -641,8 +644,14 @@ static void set_trace_option(char *command)
     else if (strcmp(command, "MAP")==0) {
         memory_map_setting = value;
     }
+    else if (strcmp(command, "OBJECTS")==0 || strcmp(command, "OBJECT")==0 || strcmp(command, "OBJS")==0 || strcmp(command, "OBJ")==0) {
+        list_objects_setting = value;
+    }
     else if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
         statistics_switch = value;
+    }
+    else if (strcmp(command, "SYMBOLS")==0 || strcmp(command, "SYMBOL")==0) {
+        list_symbols_setting = value;
     }
     else if (strcmp(command, "VERBS")==0 || strcmp(command, "VERB")==0) {
         list_verbs_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -600,6 +600,7 @@ static void set_trace_option(char *command)
         printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only meaningful with -u)\n");
         printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
+        printf("  LINES: show lines compiled (not implemented)\n");
         printf("  LINKER: show module linking info\n");
         printf("    LINKER=2: more verbose (or 3, 4 for even more)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
@@ -614,8 +615,6 @@ static void set_trace_option(char *command)
         printf("    TOKENS=2: also show token types\n");
         printf("    TOKENS=3: also show lexical context\n");
         printf("  VERBS: display the verb grammar table\n");
-        //### more
-        //### LINES (line_trace_level) (listing_switch, -l)
         return;
     }
 
@@ -658,6 +657,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "FREQUENCY")==0 || strcmp(command, "FREQUENCIES")==0 || strcmp(command, "FREQ")==0) {
         frequencies_setting = value;
+    }
+    else if (strcmp(command, "LINE")==0 || strcmp(command, "LINES")==0) {
+        line_trace_setting = value;
     }
     else if (strcmp(command, "LINK")==0 || strcmp(command, "LINKER")==0) {
         linker_trace_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -587,6 +587,7 @@ static void set_trace_option(char *command)
     
     if (!command || *command == '\0') {
         printf("The full list of trace options:\n\n");
+        printf("  ACTIONS: show actions defined\n");
         printf("  ASM: trace assembly (same as -a)\n");
         printf("    ASM=2: also show hex dumps\n");
         printf("    ASM=3: also show branch optimization info\n");
@@ -602,6 +603,7 @@ static void set_trace_option(char *command)
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
         printf("  OBJECTS: display the object table\n");
+        printf("  PROPS: show attributes and properties defined\n");
         printf("  STATS: give compilation statistics (same as -s)\n");
         printf("  SYMBOLS: display the symbol table\n");
         printf("    SYMBOLS=2: also show compiler-defined symbols\n");
@@ -613,7 +615,6 @@ static void set_trace_option(char *command)
         //### LINES (line_trace_level)
         //### LINKER (linker_trace_level, -y)
         //### MEM (memout_switch, -m)
-        //### ? (printprops_switch, -n)
         //### ? (listing_switch, -l)
         return;
     }
@@ -643,6 +644,9 @@ static void set_trace_option(char *command)
     if (strcmp(command, "ASSEMBLY")==0 || strcmp(command, "ASM")==0) {
         asm_trace_setting = value;
     }
+    else if (strcmp(command, "ACTION")==0 || strcmp(command, "ACTIONS")==0) {
+        printactions_switch = value;
+    }
     else if (strcmp(command, "DICTIONARY")==0 || strcmp(command, "DICT")==0) {
         list_dict_setting = value;
     }
@@ -660,6 +664,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "OBJECTS")==0 || strcmp(command, "OBJECT")==0 || strcmp(command, "OBJS")==0 || strcmp(command, "OBJ")==0) {
         list_objects_setting = value;
+    }
+    else if (strcmp(command, "PROP")==0 || strcmp(command, "PROPERTY")==0 || strcmp(command, "PROPS")==0 || strcmp(command, "PROPERTIES")==0) {
+        printprops_switch = value;
     }
     else if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
         statistics_switch = value;

--- a/memory.c
+++ b/memory.c
@@ -627,6 +627,9 @@ static void set_trace_option(char *command)
     else if (strcmp(command, "ASSEMBLY")==0 || strcmp(command, "ASM")==0) {
         asm_trace_setting = value;
     }
+    else if (strcmp(command, "MAKEABBREV")==0 || strcmp(command, "MAKEABBREVS")==0) {
+        optabbrevs_trace_setting = value;
+    }
     else {
         printf("Unrecognized $! trace command \"%s\"\n", command);
     }

--- a/memory.c
+++ b/memory.c
@@ -591,6 +591,8 @@ static void set_trace_option(char *command)
         printf("    ASM=2: also show hex dumps\n");
         printf("    ASM=3: also show branch optimization info\n");
         printf("    ASM=4: more verbose branch info\n");
+        printf("  DICT: display the dictionary table\n");
+        printf("    DICT=2: also the byte encoding of entries\n");
         printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only meaningful with -u)\n");
         printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
@@ -626,6 +628,9 @@ static void set_trace_option(char *command)
     
     if (strcmp(command, "ASSEMBLY")==0 || strcmp(command, "ASM")==0) {
         asm_trace_setting = value;
+    }
+    else if (strcmp(command, "DICTIONARY")==0 || strcmp(command, "DICT")==0) {
+        list_dict_setting = value;
     }
     else if (strcmp(command, "FINDABBREV")==0 || strcmp(command, "FINDABBREVS")==0) {
         optabbrevs_trace_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -597,10 +597,10 @@ static void set_trace_option(char *command)
         printf("  EXPR: show expression trees\n");
         printf("    EXPR=2: more verbose\n");
         printf("    EXPR=3: even more verbose\n");
+        printf("  FILES: show files opened\n");
         printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only meaningful with -u)\n");
         printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
-        printf("  LINES: show lines compiled (currently only Include file begin/end)\n");
         printf("  LINKER: show module linking info\n");
         printf("    LINKER=2: more verbose (or 3, 4 for even more)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
@@ -653,14 +653,14 @@ static void set_trace_option(char *command)
     else if (strcmp(command, "EXPR")==0 || strcmp(command, "EXPRESSION")==0 || strcmp(command, "EXPRESSIONS")==0) {
         expr_trace_setting = value;
     }
+    else if (strcmp(command, "FILE")==0 || strcmp(command, "FILES")==0) {
+        files_trace_setting = value;
+    }
     else if (strcmp(command, "FINDABBREV")==0 || strcmp(command, "FINDABBREVS")==0) {
         optabbrevs_trace_setting = value;
     }
     else if (strcmp(command, "FREQUENCY")==0 || strcmp(command, "FREQUENCIES")==0 || strcmp(command, "FREQ")==0) {
         frequencies_setting = value;
-    }
-    else if (strcmp(command, "LINE")==0 || strcmp(command, "LINES")==0) {
-        line_trace_setting = value;
     }
     else if (strcmp(command, "LINK")==0 || strcmp(command, "LINKER")==0) {
         linker_trace_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -616,6 +616,9 @@ static void set_trace_option(char *command)
     if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
         statistics_switch = value;
     }
+    else if (strcmp(command, "MAP")==0) {
+        memory_map_switch = value;
+    }
     else {
         printf("Unrecognized $! trace command \"%s\"\n", command);
     }

--- a/memory.c
+++ b/memory.c
@@ -600,6 +600,8 @@ static void set_trace_option(char *command)
         printf("  FINDABBREVS: show selection decisions during abbreviation optimization\n    (only meaningful with -u)\n");
         printf("    FINDABBREVS=2: also show three-letter-block decisions\n");
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
+        printf("  LINKER: show module linking info\n");
+        printf("    LINKER=2: more verbose (or 3, 4 for even more)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
         printf("  MEM: show internal memory allocations\n");
@@ -613,9 +615,7 @@ static void set_trace_option(char *command)
         printf("    TOKENS=3: also show lexical context\n");
         printf("  VERBS: display the verb grammar table\n");
         //### more
-        //### LINES (line_trace_level)
-        //### LINKER (linker_trace_level, -y)
-        //### ? (listing_switch, -l)
+        //### LINES (line_trace_level) (listing_switch, -l)
         return;
     }
 
@@ -658,6 +658,9 @@ static void set_trace_option(char *command)
     }
     else if (strcmp(command, "FREQUENCY")==0 || strcmp(command, "FREQUENCIES")==0 || strcmp(command, "FREQ")==0) {
         frequencies_setting = value;
+    }
+    else if (strcmp(command, "LINK")==0 || strcmp(command, "LINKER")==0) {
+        linker_trace_setting = value;
     }
     else if (strcmp(command, "MAP")==0) {
         memory_map_setting = value;

--- a/memory.c
+++ b/memory.c
@@ -581,9 +581,9 @@ static void add_predefined_symbol(char *command)
 static void set_trace_option(char *command)
 {
     char *cx;
-    int value = 1;
+    int value;
 
-    /* Parse options of the form STRING or STRING=NUM. (The $! has already been eaten.) */
+    /* Parse options of the form STRING or STRING=NUM. (The $! has already been eaten.) If the string is null or empty, show help. */
     
     if (!command || *command == '\0') {
         printf("### trace help\n");
@@ -598,6 +598,7 @@ static void set_trace_option(char *command)
         }
     }
 
+    value = 1;
     if (*cx == '=') {
         char *ex;
         value = strtol(cx+1, &ex, 10);
@@ -611,6 +612,13 @@ static void set_trace_option(char *command)
     }
 
     printf("### trace parsed '%s' = %d\n", command, value);
+
+    if (strcmp(command, "STATISTICS")==0 || strcmp(command, "STATS")==0 || strcmp(command, "STAT")==0) {
+        statistics_switch = value;
+    }
+    else {
+        printf("Unrecognized $! trace command \"%s\"\n", command);
+    }
 }
 
 /* Handle a dollar-sign command option: $LIST, $FOO=VAL, and so on.

--- a/objects.c
+++ b/objects.c
@@ -83,13 +83,19 @@ int no_attributes,                 /* Number of attributes defined so far    */
                                       others itself, so the variable begins
                                       the compilation pass set to 4)         */
 
+/* Print a PROPS trace line. The f flag is 0 for an attribute, 1 for
+   a common property, 2 for an individual property. */
 static void trace_s(char *name, int32 number, int f)
 {   if (!printprops_switch) return;
-    printf("%s  %02ld  ",(f==0)?"Attr":"Prop",(long int) number);
-    if (f==0) printf("  ");
+    char *stype = "";
+    if (f == 0) stype = "Attr";
+    else if (f == 1) stype = "Prop";
+    else if (f == 2) stype = "Indiv";
+    printf("%-5s  %02ld  ", stype, (long int) number);
+    if (f != 1) printf("  ");
     else      printf("%s%s",(commonprops[number].is_long)?"L":" ",
                             (commonprops[number].is_additive)?"A":" ");
-    printf("  %s\n",name);
+    printf("  %s\n", name);
 }
 
 extern void make_attribute(void)
@@ -279,6 +285,7 @@ extern void make_property(void)
                 ("<value>%d</value>", this_identifier_number);
             debug_file_printf("</property>");
         }
+        trace_s(name, symbols[i].value, 2);
         return;        
     }
 
@@ -1156,6 +1163,7 @@ static void properties_segment_z(int this_segment)
                     debug_file_printf("</property>");
                 }
 
+                trace_s(token_text, symbols[token_value].value, 2);
             }
             else
             {   if (symbols[token_value].type==INDIVIDUAL_PROPERTY_T)
@@ -1430,6 +1438,7 @@ static void properties_segment_g(int this_segment)
                     debug_file_printf("</property>");
                 }
 
+                trace_s(token_text, symbols[token_value].value, 2);
             }
             else
             {   if (symbols[token_value].type==INDIVIDUAL_PROPERTY_T)

--- a/objects.c
+++ b/objects.c
@@ -459,6 +459,7 @@ memory_list   class_info_memlist;
 
 extern void list_object_tree(void)
 {   int i;
+    /* TODO: include the object names in this list. */
     printf("Object tree:\n");
     printf("obj   par nxt chl:\n");
     for (i=0; i<no_objects; i++) {

--- a/objects.c
+++ b/objects.c
@@ -459,10 +459,18 @@ memory_list   class_info_memlist;
 
 extern void list_object_tree(void)
 {   int i;
-    printf("obj   par nxt chl   Object tree:\n");
-    for (i=0; i<no_objects; i++)
-        printf("%3d   %3d %3d %3d\n",
-            i+1,objectsz[i].parent,objectsz[i].next, objectsz[i].child);
+    printf("Object tree:\n");
+    printf("obj   par nxt chl:\n");
+    for (i=0; i<no_objects; i++) {
+        if (!glulx_mode) {
+            printf("%3d   %3d %3d %3d\n",
+                i+1,objectsz[i].parent,objectsz[i].next, objectsz[i].child);
+        }
+        else {
+            printf("%3d   %3d %3d %3d\n",
+                i+1,objectsg[i].parent,objectsg[i].next, objectsg[i].child);
+        }
+    }
 }
 
 /* ------------------------------------------------------------------------- */

--- a/objects.c
+++ b/objects.c
@@ -2133,9 +2133,6 @@ extern void make_object(int nearby_flag,
     if (internal_name_symbol > 0)
         assign_symbol(internal_name_symbol, no_objects + 1, OBJECT_T);
 
-    if (listobjects_switch)
-        printf("%3d \"%s\"\n", no_objects+1,
-            (textual_name==NULL)?"(with no short name)":textual_name);
     if (textual_name == NULL)
     {   if (internal_name_symbol > 0)
             sprintf(shortname_buffer, "(%s)",

--- a/symbols.c
+++ b/symbols.c
@@ -259,6 +259,9 @@ extern int symbol_index(char *p, int hashcode)
         this = symbols[this].next_entry;
     } while (this != -1);
 
+    if (symdef_trace_setting)
+        printf("Encountered symbol %d '%s'\n", no_symbols, p);
+    
     ensure_memory_list_available(&symbols_memlist, no_symbols+1);
     if (debugfile_switch)
         ensure_memory_list_available(&symbol_debug_info_memlist, no_symbols+1);
@@ -636,12 +639,16 @@ extern void assign_symbol(int index, int32 value, int type)
 {
     assign_symbol_base(index, value, type);
     symbols[index].marker = 0;
+    if (symdef_trace_setting)
+        printf("Defined symbol %d '%s' as %d (%s)\n", index, symbols[index].name, value, typename(type));
 }
 
 extern void assign_marked_symbol(int index, int marker, int32 value, int type)
 {
     assign_symbol_base(index, value, type);
     symbols[index].marker = marker;
+    if (symdef_trace_setting)
+        printf("Defined symbol %d '%s' as %s %d (%s)\n", index, symbols[index].name, describe_mv(marker), value, typename(type));
 }
 
 static void emit_debug_information_for_predefined_symbol

--- a/symbols.c
+++ b/symbols.c
@@ -392,7 +392,7 @@ extern void describe_symbol(int k)
 extern void list_symbols(int level)
 {   int k;
     for (k=0; k<no_symbols; k++)
-    {   if ((level==2) ||
+    {   if ((level>=2) ||
             ((symbols[k].flags & (SYSTEM_SFLAG + UNKNOWN_SFLAG + INSF_SFLAG)) == 0))
         {   describe_symbol(k); printf("\n");
         }

--- a/tables.c
+++ b/tables.c
@@ -1853,7 +1853,7 @@ printf("  extn  +---------------------+   %06lx\n", (long int) Out_Size+MEMORY_M
                 for (j=0; abbrev_string[j]!=0; j++)
                     if (abbrev_string[j]==' ') abbrev_string[j]='_';
                 printf("%10s %5d/%5d   ",abbrev_string,abbreviations[i].freq,
-                    2*((abbreviations[i].freq-1)*abbreviations[i].quality)/3);
+                    (abbreviations[i].freq-1)*abbreviations[i].quality);
                 if ((i%3)==2) printf("\n");
             }
             if ((i%3)!=0) printf("\n");

--- a/tables.c
+++ b/tables.c
@@ -1104,7 +1104,7 @@ printf("        +---------------------+   %05lx\n", (long int) Out_Size);
 
 static void construct_storyfile_g(void)
 {   uchar *p;
-    int32 i, j, k, l, mark, strings_length, limit;
+    int32 i, j, k, l, mark, strings_length;
     int32 globals_at, dictionary_at, actions_at, preactions_at,
           abbrevs_at, prop_defaults_at, object_tree_at, object_props_at,
           grammar_table_at, arrays_at, static_arrays_at;
@@ -1452,7 +1452,6 @@ table format requested (producing number 2 format instead)");
     RAM_Size = mark;
 
     Out_Size = Write_RAM_At + RAM_Size;
-    limit=1024*1024;
 
     /*  --------------------------- Offsets -------------------------------- */
 

--- a/tables.c
+++ b/tables.c
@@ -1892,11 +1892,17 @@ extern void construct_storyfile(void)
     if (frequencies_setting)
         display_frequencies();
 
+    if (list_symbols_setting)
+        list_symbols(list_symbols_setting);
+    
     if (list_dict_setting)
         show_dictionary(list_dict_setting);
     
     if (list_verbs_setting)
         list_verb_table();
+
+    if (list_objects_setting)
+        list_object_tree();
     
     if (statistics_switch) {
         if (!glulx_mode)

--- a/tables.c
+++ b/tables.c
@@ -1892,6 +1892,9 @@ extern void construct_storyfile(void)
     if (frequencies_setting)
         display_frequencies();
 
+    if (list_dict_setting)
+        show_dictionary(list_dict_setting);
+    
     if (list_verbs_setting)
         list_verb_table();
     

--- a/tables.c
+++ b/tables.c
@@ -1045,31 +1045,6 @@ Out:   Version %d \"%s\" %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
         }
     }
 
-    if (offsets_switch)
-    {
-        {   printf(
-"\nOffsets in %s:\n\
-%05lx Synonyms     %05lx Defaults     %05lx Objects    %05lx Properties\n\
-%05lx Variables    %05lx Parse table  %05lx Actions    %05lx Preactions\n\
-%05lx Adjectives   %05lx Dictionary   %05lx Code       %05lx Strings\n",
-            output_called,
-            (long int) abbrevs_at,
-            (long int) prop_defaults_at,
-            (long int) object_tree_at,
-            (long int) object_props_at,
-            (long int) globals_at,
-            (long int) grammar_table_at,
-            (long int) actions_at,
-            (long int) preactions_at,
-            (long int) adjectives_offset,
-            (long int) dictionary_at,
-            (long int) Write_Code_At,
-            (long int) Write_Strings_At);
-            if (module_switch)
-                printf("%05lx Linking data\n",(long int) link_table_at);
-        }
-    }
-
     if (debugfile_switch)
     {   begin_writing_debug_sections();
         write_debug_section("abbreviations", 64);
@@ -1738,29 +1713,6 @@ Out:   %s %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
                  (long int)
                       (((long int) (limit*1024L)) - ((long int) Out_Size)));
 
-        }
-    }
-
-    if (offsets_switch)
-    {
-        {   printf(
-"\nOffsets in %s:\n\
-%05lx Synonyms     %05lx Defaults     %05lx Objects    %05lx Properties\n\
-%05lx Variables    %05lx Parse table  %05lx Actions    %05lx Preactions\n\
-%05lx Adjectives   %05lx Dictionary   %05lx Code       %05lx Strings\n",
-            output_called,
-            (long int) abbrevs_at,
-            (long int) prop_defaults_at,
-            (long int) object_tree_at,
-            (long int) object_props_at,
-            (long int) globals_at,
-            (long int) grammar_table_at,
-            (long int) actions_at,
-            (long int) preactions_at,
-            (long int) adjectives_offset,
-            (long int) dictionary_at,
-            (long int) Write_Code_At,
-            (long int) Write_Strings_At);
         }
     }
 

--- a/tables.c
+++ b/tables.c
@@ -1185,7 +1185,7 @@ printf("        +---------------------+   %05lx\n", (long int) Out_Size);
         }
     }
 
-    if (frequencies_switch)
+    if (frequencies_setting)
     {
         {   printf("How frequently abbreviations were used, and roughly\n");
             printf("how many bytes they saved:  ('_' denotes spaces)\n");
@@ -1842,7 +1842,7 @@ printf("  extn  +---------------------+   %06lx\n", (long int) Out_Size+MEMORY_M
     }
 
 
-    if (frequencies_switch)
+    if (frequencies_setting)
     {
         {   printf("How frequently abbreviations were used, and roughly\n");
             printf("how many bytes they saved:  ('_' denotes spaces)\n");

--- a/tables.c
+++ b/tables.c
@@ -113,7 +113,7 @@ static char percentage_buffer[32];
 
 static char *show_percentage(int32 x, int32 total)
 {
-    if (!percentages_switch) {
+    if (memory_map_switch < 2) {
         percentage_buffer[0] = '\0';
     }
     else {

--- a/tables.c
+++ b/tables.c
@@ -116,6 +116,9 @@ static char *show_percentage(int32 x, int32 total)
     if (memory_map_setting < 2) {
         percentage_buffer[0] = '\0';
     }
+    else if (x == 0) {
+        sprintf(percentage_buffer, "  ( --- )");
+    }
     else {
         sprintf(percentage_buffer, "  (%.1f %%)", (float)x * 100.0 / (float)total);
     }

--- a/tables.c
+++ b/tables.c
@@ -1684,7 +1684,7 @@ static void display_statistics_z()
     char *k_str = "";
     uchar *p = (uchar *) zmachine_paged_memory;
     char *output_called = (module_switch)?"module":"story file";
-    int limit;
+    int limit = 0;
 
     /* Yeah, we're repeating this calculation from construct_storyfile_z() */
     switch(version_number)

--- a/tables.c
+++ b/tables.c
@@ -113,7 +113,7 @@ static char percentage_buffer[32];
 
 static char *show_percentage(int32 x, int32 total)
 {
-    if (memory_map_switch < 2) {
+    if (memory_map_setting < 2) {
         percentage_buffer[0] = '\0';
     }
     else {
@@ -639,7 +639,7 @@ table format requested (producing number 2 format instead)");
 size of the Z-machine format. See the memory map below: the start \
 of the area marked \"above readable memory\" must be brought down to $FFFE \
 or less.");
-        memory_map_switch = TRUE;
+        memory_map_setting = 1;
         /* Backpatching the grammar tables requires us to trust some of the */
         /* addresses we've written into Z-machine memory, but they may have */
         /* been truncated to 16 bits, so we can't do it.                    */
@@ -1096,7 +1096,7 @@ Out:   Version %d \"%s\" %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
         end_writing_debug_sections(Out_Size);
     }
 
-    if (memory_map_switch)
+    if (memory_map_setting)
     {
         int32 addr;
         {
@@ -1798,7 +1798,7 @@ Out:   %s %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
         end_writing_debug_sections(Out_Size + MEMORY_MAP_EXTENSION);
     }
 
-    if (memory_map_switch)
+    if (memory_map_setting)
     {
         int32 addr;
         {

--- a/tables.c
+++ b/tables.c
@@ -1885,12 +1885,16 @@ extern void construct_storyfile(void)
     /* Display all the trace/stats info that came out of compilation.
 
        (Except for the memory map, which uses a bunch of local variables
-       from construct_storyfile_z/g(), so it's easier to do that above.)
+       from construct_storyfile_z/g(), so it's easier to do that inside
+       that function.)
     */
     
     if (frequencies_setting)
         display_frequencies();
 
+    if (list_verbs_setting)
+        list_verb_table();
+    
     if (statistics_switch) {
         if (!glulx_mode)
             display_statistics_z();

--- a/tables.c
+++ b/tables.c
@@ -961,90 +961,6 @@ or less.");
 
     /*  ---- From here on, it's all reportage: construction is finished ---- */
 
-    if (statistics_switch)
-    {   int32 k_long, rate; char *k_str="";
-        k_long=(Out_Size/1024);
-        if ((Out_Size-1024*k_long) >= 512) { k_long++; k_str=""; }
-        else if ((Out_Size-1024*k_long) > 0) { k_str=".5"; }
-        if (total_bytes_trans == 0) rate = 0;
-        else rate=total_bytes_trans*1000/total_chars_trans;
-
-        {   printf("In:\
-%3d source code files            %6d syntactic lines\n\
-%6d textual lines              %8ld characters ",
-            total_input_files, no_syntax_lines,
-            total_source_line_count, (long int) total_chars_read);
-            if (character_set_unicode) printf("(UTF-8)\n");
-            else if (character_set_setting == 0) printf("(plain ASCII)\n");
-            else
-            {   printf("(ISO 8859-%d %s)\n", character_set_setting,
-                    name_of_iso_set(character_set_setting));
-            }
-
-            printf("Allocated:\n\
-%6d symbols                    %8ld bytes of memory\n\
-Out:   Version %d \"%s\" %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
-                 no_symbols,
-                 (long int) malloced_bytes,
-                 version_number,
-                 version_name(version_number),
-                 output_called,
-                 release_number, p[18], p[19], p[20], p[21], p[22], p[23],
-                 (long int) k_long, k_str);
-
-            printf("\
-%6d classes                      %6d objects\n\
-%6d global vars (maximum 233)    %6d variable/array space\n",
-                 no_classes,
-                 no_objects,
-                 no_globals,
-                 dynamic_array_area_size);
-
-            printf(
-"%6d verbs                        %6d dictionary entries\n\
-%6d grammar lines (version %d)    %6d grammar tokens (unlimited)\n\
-%6d actions                      %6d attributes (maximum %2d)\n\
-%6d common props (maximum %2d)    %6d individual props (unlimited)\n",
-                 no_Inform_verbs,
-                 dict_entries,
-                 no_grammar_lines, grammar_version_number,
-                 no_grammar_tokens,
-                 no_actions,
-                 no_attributes, ((version_number==3)?32:48),
-                 no_properties-3, ((version_number==3)?29:61),
-                 no_individual_properties - 64);
-
-            if (track_unused_routines)
-            {
-                uint32 diff = df_total_size_before_stripping - df_total_size_after_stripping;
-                printf(
-"%6ld bytes of Z-code              %6ld unused bytes %s (%.1f%%)\n",
-                 (long int) df_total_size_before_stripping, (long int) diff,
-                 (OMIT_UNUSED_ROUTINES ? "stripped out" : "detected"),
-                 100 * (float)diff / (float)df_total_size_before_stripping);
-            }
-
-            printf(
-"%6ld characters used in text      %6ld bytes compressed (rate %d.%3ld)\n\
-%6d abbreviations (maximum %d)   %6d routines (unlimited)\n\
-%6ld instructions of Z-code       %6d sequence points\n\
-%6ld bytes readable memory used (maximum 65536)\n\
-%6ld bytes used in Z-machine      %6ld bytes free in Z-machine\n",
-                 (long int) total_chars_trans,
-                 (long int) total_bytes_trans,
-                 (total_chars_trans>total_bytes_trans)?0:1,
-                 (long int) rate,
-                 no_abbreviations, MAX_ABBREVS,
-                 no_routines,
-                 (long int) no_instructions, no_sequence_points,
-                 (long int) Write_Code_At,
-                 (long int) Out_Size,
-                 (long int)
-                      (((long int) (limit*1024L)) - ((long int) Out_Size)));
-
-        }
-    }
-
     if (debugfile_switch)
     {   begin_writing_debug_sections();
         write_debug_section("abbreviations", 64);
@@ -1193,7 +1109,6 @@ static void construct_storyfile_g(void)
           abbrevs_at, prop_defaults_at, object_tree_at, object_props_at,
           grammar_table_at, arrays_at, static_arrays_at;
     int32 threespaces, code_length;
-    char *output_called = (module_switch)?"module":"story file";
 
     ASSERT_GLULX();
 
@@ -1608,95 +1523,6 @@ table format requested (producing number 2 format instead)");
 
     /*  ---- From here on, it's all reportage: construction is finished ---- */
 
-    if (statistics_switch)
-    {   int32 k_long, rate; char *k_str="";
-        k_long=(Out_Size/1024);
-        if ((Out_Size-1024*k_long) >= 512) { k_long++; k_str=""; }
-        else if ((Out_Size-1024*k_long) > 0) { k_str=".5"; }
-        if (strings_length == 0) rate = 0;
-        else rate=strings_length*1000/total_chars_trans;
-
-        {   printf("In:\
-%3d source code files            %6d syntactic lines\n\
-%6d textual lines              %8ld characters ",
-            total_input_files, no_syntax_lines,
-            total_source_line_count, (long int) total_chars_read);
-            if (character_set_unicode) printf("(UTF-8)\n");
-            else if (character_set_setting == 0) printf("(plain ASCII)\n");
-            else
-            {   printf("(ISO 8859-%d %s)\n", character_set_setting,
-                    name_of_iso_set(character_set_setting));
-            }
-
-            {char serialnum[8];
-            write_serial_number(serialnum);
-            printf("Allocated:\n\
-%6d symbols                    %8ld bytes of memory\n\
-Out:   %s %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
-                 no_symbols,
-                 (long int) malloced_bytes,
-                 version_name(version_number),
-                 output_called,
-                 release_number,
-                 serialnum[0], serialnum[1], serialnum[2],
-                 serialnum[3], serialnum[4], serialnum[5],
-                 (long int) k_long, k_str);
-            } 
-
-            printf("\
-%6d classes                      %6d objects\n\
-%6d global vars                  %6d variable/array space\n",
-                 no_classes,
-                 no_objects,
-                 no_globals,
-                 dynamic_array_area_size);
-
-            printf(
-"%6d verbs                        %6d dictionary entries\n\
-%6d grammar lines (version %d)    %6d grammar tokens (unlimited)\n\
-%6d actions                      %6d attributes (maximum %2d)\n\
-%6d common props (maximum %3d)   %6d individual props (unlimited)\n",
-                 no_Inform_verbs,
-                 dict_entries,
-                 no_grammar_lines, grammar_version_number,
-                 no_grammar_tokens,
-                 no_actions,
-                 no_attributes, NUM_ATTR_BYTES*8,
-                 no_properties-3, INDIV_PROP_START-3,
-                 no_individual_properties - INDIV_PROP_START);
-
-            if (track_unused_routines)
-            {
-                uint32 diff = df_total_size_before_stripping - df_total_size_after_stripping;
-                printf(
-"%6ld bytes of code                %6ld unused bytes %s (%.1f%%)\n",
-                 (long int) df_total_size_before_stripping, (long int) diff,
-                 (OMIT_UNUSED_ROUTINES ? "stripped out" : "detected"),
-                 100 * (float)diff / (float)df_total_size_before_stripping);
-            }
-
-            printf(
-"%6ld characters used in text      %6ld bytes compressed (rate %d.%3ld)\n\
-%6d abbreviations (maximum %d)   %6d routines (unlimited)\n\
-%6ld instructions of code         %6d sequence points\n\
-%6ld bytes writable memory used   %6ld bytes read-only memory used\n\
-%6ld bytes used in machine    %10ld bytes free in machine\n",
-                 (long int) total_chars_trans,
-                 (long int) strings_length,
-                 (total_chars_trans>strings_length)?0:1,
-                 (long int) rate,
-                 no_abbreviations, MAX_ABBREVS,
-                 no_routines,
-                 (long int) no_instructions, no_sequence_points,
-                 (long int) (Out_Size - Write_RAM_At),
-                 (long int) Write_RAM_At,
-                 (long int) Out_Size,
-                 (long int)
-                      (((long int) (limit*1024L)) - ((long int) Out_Size)));
-
-        }
-    }
-
     if (debugfile_switch)
     {   begin_writing_debug_sections();
         write_debug_section("memory layout id", GLULX_HEADER_SIZE);
@@ -1852,6 +1678,203 @@ static void display_frequencies()
     if (no_abbreviations==0) printf("None were declared.\n");
 }
 
+static void display_statistics_z()
+{
+    int32 k_long, rate;
+    char *k_str = "";
+    uchar *p = (uchar *) zmachine_paged_memory;
+    char *output_called = (module_switch)?"module":"story file";
+    int limit;
+
+    /* Yeah, we're repeating this calculation from construct_storyfile_z() */
+    switch(version_number)
+    {   case 3: limit = 128; break;
+        case 4:
+        case 5: limit = 256; break;
+        case 6:
+        case 7:
+        case 8: limit = 512; break;
+    }
+
+    k_long=(Out_Size/1024);
+    if ((Out_Size-1024*k_long) >= 512) { k_long++; k_str=""; }
+    else if ((Out_Size-1024*k_long) > 0) { k_str=".5"; }
+    if (total_bytes_trans == 0) rate = 0;
+    else rate=total_bytes_trans*1000/total_chars_trans;
+    
+    {   printf("In:\
+%3d source code files            %6d syntactic lines\n\
+%6d textual lines              %8ld characters ",
+               total_input_files, no_syntax_lines,
+               total_source_line_count, (long int) total_chars_read);
+        if (character_set_unicode) printf("(UTF-8)\n");
+        else if (character_set_setting == 0) printf("(plain ASCII)\n");
+        else
+            {   printf("(ISO 8859-%d %s)\n", character_set_setting,
+                       name_of_iso_set(character_set_setting));
+            }
+
+        printf("Allocated:\n\
+%6d symbols                    %8ld bytes of memory\n\
+Out:   Version %d \"%s\" %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
+               no_symbols,
+               (long int) malloced_bytes,
+               version_number,
+               version_name(version_number),
+               output_called,
+               release_number, p[18], p[19], p[20], p[21], p[22], p[23],
+               (long int) k_long, k_str);
+
+        printf("\
+%6d classes                      %6d objects\n\
+%6d global vars (maximum 233)    %6d variable/array space\n",
+               no_classes,
+               no_objects,
+               no_globals,
+               dynamic_array_area_size);
+
+        printf(
+               "%6d verbs                        %6d dictionary entries\n\
+%6d grammar lines (version %d)    %6d grammar tokens (unlimited)\n\
+%6d actions                      %6d attributes (maximum %2d)\n\
+%6d common props (maximum %2d)    %6d individual props (unlimited)\n",
+               no_Inform_verbs,
+               dict_entries,
+               no_grammar_lines, grammar_version_number,
+               no_grammar_tokens,
+               no_actions,
+               no_attributes, ((version_number==3)?32:48),
+               no_properties-3, ((version_number==3)?29:61),
+               no_individual_properties - 64);
+
+        if (track_unused_routines)
+            {
+                uint32 diff = df_total_size_before_stripping - df_total_size_after_stripping;
+                printf(
+                       "%6ld bytes of Z-code              %6ld unused bytes %s (%.1f%%)\n",
+                       (long int) df_total_size_before_stripping, (long int) diff,
+                       (OMIT_UNUSED_ROUTINES ? "stripped out" : "detected"),
+                       100 * (float)diff / (float)df_total_size_before_stripping);
+            }
+
+        printf(
+               "%6ld characters used in text      %6ld bytes compressed (rate %d.%3ld)\n\
+%6d abbreviations (maximum %d)   %6d routines (unlimited)\n\
+%6ld instructions of Z-code       %6d sequence points\n\
+%6ld bytes readable memory used (maximum 65536)\n\
+%6ld bytes used in Z-machine      %6ld bytes free in Z-machine\n",
+               (long int) total_chars_trans,
+               (long int) total_bytes_trans,
+               (total_chars_trans>total_bytes_trans)?0:1,
+               (long int) rate,
+               no_abbreviations, MAX_ABBREVS,
+               no_routines,
+               (long int) no_instructions, no_sequence_points,
+               (long int) Write_Code_At,
+               (long int) Out_Size,
+               (long int)
+               (((long int) (limit*1024L)) - ((long int) Out_Size)));
+
+    }
+}
+
+static void display_statistics_g()
+{
+    int32 k_long, rate;
+    char *k_str = "";
+    int32 limit = 1024*1024;
+    int32 strings_length = compression_table_size + compression_string_size;
+    char *output_called = (module_switch)?"module":"story file";
+    
+    k_long=(Out_Size/1024);
+    if ((Out_Size-1024*k_long) >= 512) { k_long++; k_str=""; }
+    else if ((Out_Size-1024*k_long) > 0) { k_str=".5"; }
+    
+    if (strings_length == 0) rate = 0;
+    else rate=strings_length*1000/total_chars_trans;
+
+    {   printf("In:\
+%3d source code files            %6d syntactic lines\n\
+%6d textual lines              %8ld characters ",
+               total_input_files, no_syntax_lines,
+               total_source_line_count, (long int) total_chars_read);
+        if (character_set_unicode) printf("(UTF-8)\n");
+        else if (character_set_setting == 0) printf("(plain ASCII)\n");
+        else
+            {   printf("(ISO 8859-%d %s)\n", character_set_setting,
+                       name_of_iso_set(character_set_setting));
+            }
+
+        {char serialnum[8];
+            write_serial_number(serialnum);
+            printf("Allocated:\n\
+%6d symbols                    %8ld bytes of memory\n\
+Out:   %s %s %d.%c%c%c%c%c%c (%ld%sK long):\n",
+                   no_symbols,
+                   (long int) malloced_bytes,
+                   version_name(version_number),
+                   output_called,
+                   release_number,
+                   serialnum[0], serialnum[1], serialnum[2],
+                   serialnum[3], serialnum[4], serialnum[5],
+                   (long int) k_long, k_str);
+        } 
+
+        printf("\
+%6d classes                      %6d objects\n\
+%6d global vars                  %6d variable/array space\n",
+               no_classes,
+               no_objects,
+               no_globals,
+               dynamic_array_area_size);
+
+        printf(
+               "%6d verbs                        %6d dictionary entries\n\
+%6d grammar lines (version %d)    %6d grammar tokens (unlimited)\n\
+%6d actions                      %6d attributes (maximum %2d)\n\
+%6d common props (maximum %3d)   %6d individual props (unlimited)\n",
+               no_Inform_verbs,
+               dict_entries,
+               no_grammar_lines, grammar_version_number,
+               no_grammar_tokens,
+               no_actions,
+               no_attributes, NUM_ATTR_BYTES*8,
+               no_properties-3, INDIV_PROP_START-3,
+               no_individual_properties - INDIV_PROP_START);
+
+        if (track_unused_routines)
+            {
+                uint32 diff = df_total_size_before_stripping - df_total_size_after_stripping;
+                printf(
+                       "%6ld bytes of code                %6ld unused bytes %s (%.1f%%)\n",
+                       (long int) df_total_size_before_stripping, (long int) diff,
+                       (OMIT_UNUSED_ROUTINES ? "stripped out" : "detected"),
+                       100 * (float)diff / (float)df_total_size_before_stripping);
+            }
+
+        printf(
+               "%6ld characters used in text      %6ld bytes compressed (rate %d.%3ld)\n\
+%6d abbreviations (maximum %d)   %6d routines (unlimited)\n\
+%6ld instructions of code         %6d sequence points\n\
+%6ld bytes writable memory used   %6ld bytes read-only memory used\n\
+%6ld bytes used in machine    %10ld bytes free in machine\n",
+               (long int) total_chars_trans,
+               (long int) strings_length,
+               (total_chars_trans>strings_length)?0:1,
+               (long int) rate,
+               no_abbreviations, MAX_ABBREVS,
+               no_routines,
+               (long int) no_instructions, no_sequence_points,
+               (long int) (Out_Size - Write_RAM_At),
+               (long int) Write_RAM_At,
+               (long int) Out_Size,
+               (long int)
+               (((long int) (limit*1024L)) - ((long int) Out_Size)));
+
+    }
+}
+
+
 extern void construct_storyfile(void)
 {
     if (!glulx_mode)
@@ -1867,6 +1890,13 @@ extern void construct_storyfile(void)
     
     if (frequencies_setting)
         display_frequencies();
+
+    if (statistics_switch) {
+        if (!glulx_mode)
+            display_statistics_z();
+        else
+            display_statistics_g();
+    }
 }
 
 /* ========================================================================= */

--- a/tables.c
+++ b/tables.c
@@ -1184,25 +1184,6 @@ printf("        | module linking data |   %s\n",
 printf("        +---------------------+   %05lx\n", (long int) Out_Size);
         }
     }
-
-    if (frequencies_setting)
-    {
-        {   printf("How frequently abbreviations were used, and roughly\n");
-            printf("how many bytes they saved:  ('_' denotes spaces)\n");
-            for (i=0; i<no_abbreviations; i++)
-            {   char abbrev_string[MAX_ABBREV_LENGTH];
-                strcpy(abbrev_string,
-                    (char *)abbreviations_at+i*MAX_ABBREV_LENGTH);
-                for (j=0; abbrev_string[j]!=0; j++)
-                    if (abbrev_string[j]==' ') abbrev_string[j]='_';
-                printf("%10s %5d/%5d   ",abbrev_string,abbreviations[i].freq,
-                    2*((abbreviations[i].freq-1)*abbreviations[i].quality)/3);
-                if ((i%3)==2) printf("\n");
-            }
-            if ((i%3)!=0) printf("\n");
-            if (no_abbreviations==0) printf("None were declared.\n");
-        }
-    }
 }
 
 static void construct_storyfile_g(void)
@@ -1840,34 +1821,52 @@ printf("  extn  +---------------------+   %06lx\n", (long int) Out_Size+MEMORY_M
         }
 
     }
+}
 
-
-    if (frequencies_setting)
-    {
-        {   printf("How frequently abbreviations were used, and roughly\n");
-            printf("how many bytes they saved:  ('_' denotes spaces)\n");
-            for (i=0; i<no_abbreviations; i++)
-            {   char abbrev_string[MAX_ABBREV_LENGTH];
-                strcpy(abbrev_string,
-                    (char *)abbreviations_at+i*MAX_ABBREV_LENGTH);
-                for (j=0; abbrev_string[j]!=0; j++)
-                    if (abbrev_string[j]==' ') abbrev_string[j]='_';
-                printf("%10s %5d/%5d   ",abbrev_string,abbreviations[i].freq,
-                    (abbreviations[i].freq-1)*abbreviations[i].quality);
-                if ((i%3)==2) printf("\n");
-            }
-            if ((i%3)!=0) printf("\n");
-            if (no_abbreviations==0) printf("None were declared.\n");
-        }
+static void display_frequencies()
+{
+    int i, j;
+    
+    printf("How frequently abbreviations were used, and roughly\n");
+    printf("how many bytes they saved:  ('_' denotes spaces)\n");
+    
+    for (i=0; i<no_abbreviations; i++) {
+        int32 saving;
+        if (!glulx_mode)
+            saving = 2*((abbreviations[i].freq-1)*abbreviations[i].quality)/3;
+        else
+            saving = (abbreviations[i].freq-1)*abbreviations[i].quality;
+        
+        char abbrev_string[MAX_ABBREV_LENGTH];
+        strcpy(abbrev_string,
+               (char *)abbreviations_at+i*MAX_ABBREV_LENGTH);
+        for (j=0; abbrev_string[j]!=0; j++)
+            if (abbrev_string[j]==' ') abbrev_string[j]='_';
+        
+        printf("%10s %5d/%5d   ",abbrev_string,abbreviations[i].freq, saving);
+        
+        if ((i%3)==2) printf("\n");
     }
+    if ((i%3)!=0) printf("\n");
+    
+    if (no_abbreviations==0) printf("None were declared.\n");
 }
 
 extern void construct_storyfile(void)
 {
-  if (!glulx_mode)
-    construct_storyfile_z();
-  else
-    construct_storyfile_g();
+    if (!glulx_mode)
+        construct_storyfile_z();
+    else
+        construct_storyfile_g();
+
+    /* Display all the trace/stats info that came out of compilation.
+
+       (Except for the memory map, which uses a bunch of local variables
+       from construct_storyfile_z/g(), so it's easier to do that above.)
+    */
+    
+    if (frequencies_setting)
+        display_frequencies();
 }
 
 /* ========================================================================= */

--- a/text.c
+++ b/text.c
@@ -2400,6 +2400,7 @@ static void recursively_show_z(int node, int level)
     for (; cprinted < 4 + ((version_number==3)?6:9); cprinted++)
         show_char(' ');
 
+    /* If level==0, d_show_buf is non-NULL. */
     if (d_show_buf == NULL)
     {
         if (level >= 2) {
@@ -2458,6 +2459,7 @@ static void recursively_show_g(int node, int level)
     for (; cprinted<DICT_WORD_SIZE+4; cprinted++)
         show_char(' ');
 
+    /* If level==0, d_show_buf is non-NULL. */
     if (d_show_buf == NULL)
     {   int flagpos = (DICT_CHAR_SIZE == 1) ? (DICT_WORD_SIZE+1) : (DICT_WORD_BYTES+4);
         int flags = (p[flagpos+0] << 8) | (p[flagpos+1]);
@@ -2508,7 +2510,8 @@ static void show_alphabet(int i)
 
 extern void show_dictionary(int level)
 {
-    /* Level 1: show words and flags. Level 2: also show bytes. */
+    /* Level 0: show words only. Level 1: show words and flags.
+       Level 2: also show bytes.*/
     printf("Dictionary contains %d entries:\n",dict_entries);
     if (dict_entries != 0)
     {   d_show_len = 0; d_show_buf = NULL; 
@@ -2540,9 +2543,9 @@ extern void write_dictionary_to_transcript(void)
     if (dict_entries != 0)
     {
         if (!glulx_mode)    
-            recursively_show_z(root, 1);
+            recursively_show_z(root, 0);
         else
-            recursively_show_g(root, 1);
+            recursively_show_g(root, 0);
     }
     if (d_show_len != 0) write_to_transcript_file(d_show_buf, STRCTX_DICT);
 

--- a/text.c
+++ b/text.c
@@ -899,6 +899,7 @@ string; substituting '?'.");
       }
     }
     write_z_char_g(0);
+    zchars_trans_in_last_string=total_zchars_trans-zchars_trans_in_last_string;
 
   }
 

--- a/text.c
+++ b/text.c
@@ -1338,9 +1338,11 @@ static void optimise_pass(void)
                 }
             }
 #endif
-            printf("Pass %d, %4ld/%ld '%s' (%ld occurrences) ",
-                pass_no, (long int) i, (long int) no_occs, tlbtab[i].text,
-                (long int) tlbtab[i].occurrences);
+            if (optabbrevs_trace_setting >= 2) {
+                printf("Pass %d, %4ld/%ld '%s' (%ld occurrences) ",
+                    pass_no, (long int) i, (long int) no_occs, tlbtab[i].text,
+                    (long int) tlbtab[i].occurrences);
+            }
             TIMEVALUE_NOW(&t1);
             for (j=0; j<tlbtab[i].occurrences; j++)
             {   for (j2=0; j2<tlbtab[i].occurrences; j2++) grandflags[j2]=1;
@@ -1398,9 +1400,11 @@ static void optimise_pass(void)
                 }
                 FinishEarly: ;
             }
-            TIMEVALUE_NOW(&t2);
-            duration = TIMEVALUE_DIFFERENCE(&t1, &t2);
-            printf(" (%.4f seconds)\n", duration);
+            if (optabbrevs_trace_setting >= 2) {
+                TIMEVALUE_NOW(&t2);
+                duration = TIMEVALUE_DIFFERENCE(&t1, &t2);
+                printf(" (%.4f seconds)\n", duration);
+            }
         }
     }
 }
@@ -1534,8 +1538,10 @@ extern void optimise_abbreviations(void)
     grandflags=my_calloc(sizeof(int), max, "grandflags");
 
 
-    printf("Cross-reference table (%ld entries) built...\n",
-        (long int) no_occs);
+    if (optabbrevs_trace_setting >= 1) {
+        printf("Cross-reference table (%ld entries) built...\n",
+            (long int) no_occs);
+    }
     /*  for (i=0; i<no_occs; i++)
             printf("%4d %4d '%s' %d\n",i,tlbtab[i].intab,tlbtab[i].text,
                 tlbtab[i].occurrences);
@@ -1544,8 +1550,12 @@ extern void optimise_abbreviations(void)
     for (i=0; i<MAX_ABBREVS; i++) bestyet2[i].length=0;
     available=MAX_BESTYET;
     while ((available>0)&&(selected<MAX_ABBREVS))
-    {   printf("Pass %d\n", ++pass_no);
-
+    {
+        pass_no++;
+        if (optabbrevs_trace_setting >= 1) {
+            printf("Pass %d\n", pass_no);
+        }
+        
         optimise_pass();
         available=0;
         for (i=0; i<MAX_BESTYET; i++)
@@ -1578,11 +1588,13 @@ extern void optimise_abbreviations(void)
                 char testtext[4];
                 bestyet2[selected++]=bestyet[maxat];
 
-                printf(
-                    "Selection %2ld: '%s' (repeated %ld times, scoring %ld)\n",
-                    (long int) selected,bestyet[maxat].text,
-                    (long int) bestyet[maxat].popularity,
-                    (long int) bestyet[maxat].score);
+                if (optabbrevs_trace_setting >= 1) {
+                    printf(
+                        "Selection %2ld: '%s' (repeated %ld times, scoring %ld)\n",
+                        (long int) selected,bestyet[maxat].text,
+                        (long int) bestyet[maxat].popularity,
+                        (long int) bestyet[maxat].score);
+                }
 
                 testtext[0]=bestyet[maxat].text[0];
                 testtext[1]=bestyet[maxat].text[1];

--- a/text.c
+++ b/text.c
@@ -2400,8 +2400,8 @@ static void recursively_show_z(int node, int level)
     for (; cprinted < 4 + ((version_number==3)?6:9); cprinted++)
         show_char(' ');
 
-    /* If level==0, d_show_buf is non-NULL. */
-    if (d_show_buf == NULL)
+    /* The level-1 info can only be printfed (d_show_buf must be null). */
+    if (d_show_buf == NULL && level >= 1)
     {
         if (level >= 2) {
             for (i=0; i<DICT_ENTRY_BYTE_LENGTH; i++) printf("%02x ",p[i]);
@@ -2459,8 +2459,8 @@ static void recursively_show_g(int node, int level)
     for (; cprinted<DICT_WORD_SIZE+4; cprinted++)
         show_char(' ');
 
-    /* If level==0, d_show_buf is non-NULL. */
-    if (d_show_buf == NULL)
+    /* The level-1 info can only be printfed (d_show_buf must be null). */
+    if (d_show_buf == NULL && level >= 1)
     {   int flagpos = (DICT_CHAR_SIZE == 1) ? (DICT_WORD_SIZE+1) : (DICT_WORD_BYTES+4);
         int flags = (p[flagpos+0] << 8) | (p[flagpos+1]);
         int verbnum = (p[flagpos+2] << 8) | (p[flagpos+3]);

--- a/verbs.c
+++ b/verbs.c
@@ -271,6 +271,7 @@ static void list_grammar_line_v2(int mark)
 extern void list_verb_table(void)
 {
     int verb, lx;
+    printf("Grammar table: %d verbs\n", no_Inform_verbs);
     for (verb=0; verb<no_Inform_verbs; verb++) {
         char *verbword = find_verb_by_number(verb);
         printf("Verb '%s'\n", verbword);

--- a/verbs.c
+++ b/verbs.c
@@ -299,7 +299,7 @@ static void new_action(char *b, int c)
         by using make_action above, or the Fake_Action directive, or by
         the linker).  At present just a hook for some tracing code.          */
 
-    if (printprops_switch)
+    if (printactions_switch)
         printf("Action '%s' is numbered %d\n",b,c);
 }
 


### PR DESCRIPTION
This is the big argument rewrite described in https://github.com/DavidKinder/Inform6/issues/103 . It's entirely about the compiler's command-line interface, not code generation. Nonetheless, it's big enough that I suggest calling the next release "Inform 6.40".

(Once this is in, I intend to move forward on other significant functionality changes like https://github.com/DavidKinder/Inform6/issues/95 and https://github.com/DavidKinder/Inform6/issues/94 . Those are also 6.40-ish-level changes.)

I'm afraid my usual incremental PR approach doesn't make sense here. I've added a whole new argument subsystem and updated a bunch of the old arguments to use it. So this is a big messy changelist.

The central change is a new command-line arg format: `$!TRACEOPT` or `$!TRACEOPT=N`. The Unix-style equivalent is `--trace TRACEOPT` or `--trace TRACEOPT=N`. You can also do `$!` by itself or `--helptrace` to list all available trace options.

Trace option names are case-insensitive. I've tried to make sure that reasonable synonyms work. (E.g. `OBJ`, `OBJECT`, `OBJS`, `OBJECTS`.)

The optional `N` is always an integer. 0 always means off, 1 is the base level, 2 or more may increase verbosity. As a general rule, setting `N` to a high number is not an error; it just does the same thing as the highest supported number for that option. (This lets us add more verbosity levels to any option without worrying about compatibility errors.)

Four trace settings can be changed in mid-compile with the `Trace` directive. (This has always been true but now it's handled consistently across them.) `Trace assembly`, `Trace expressions`, `Trace tokens`, and `Trace linker` are equivalent to `--trace asm`, `--trace expr`, `--trace tokens`, and `--trace linker` respectively. As with the command-line version, you can optionally specify 0 to turn off that setting or 2 or more for more verbosity.

Four more trace directives do an immediate info dump: `Trace dictionary`, `Trace objects`, `Trace symbols`, and `Trace verbs`. It's not very useful to do this in the middle of compilation, but you can if you really want to. The command-line equivalents `--trace dict`, `--trace objects`, `--trace symbols`, and `--trace verbs` do the same dump at the *end* of compilation. 

(Note: I have an upcoming change which will allow `--trace objects` to show the object *names* as well as numbers. That will be way more useful.)

The following single-letter options have been removed and replaced with trace options:

- `-j`: Replaced by `--trace OBJECTS`
- `-m`: Replaced by `--trace MEM`
- `-n`: Replaced by `--trace PROPS` (for property info) and `--trace ACTIONS` (for action numbers)
- `-p`: Replaced by `--trace MAP=2`
- `-t`: Replaced by `--trace ASM=2`
- `-y`: Replaced by `--trace LINKER`

The following single-letter options still exist, but are now aliases for trace options:

- `-a`: Same as `--trace ASM`
- `-f`: Same as `--trace FREQ`
- `-g`: Same as `--trace RUNTIME`
- `-s`: Same as `--trace STATS`
- `-z`: Same as `--trace MAP`

The following single-letter options have been removed entirely:
- `-b`: Hasn't done anything since Inform 5, I think.
- `-l`: Was supposed to list all statements compiled, but it was never implemented.
- `-o`: Showed the same information as `-z` or `--trace MAP`.

The `-l` option *did* show include files being opened; this is now a separate trace setting, `--trace FILES`.

Some of the info that used to be under `-a4` is now a separate trace setting, `--trace BPATCH`.

In addition, I've handled https://github.com/DavidKinder/Inform6/issues/102 . The `-u` option now just outputs computed abbreviations. If you want the verbose calculation info that it used to print, use `--trace FINDABBREVS` or `--trace FINDABBREVS=2`.

I've also refactored the construct_storyfile() sequence a bit. A lot of the infodump that used to follow "From here on, it's all reportage" has been consolidated in construct_storyfile(). This is tidier and easier to follow.

Whew! That's everything here, I think.
