### PR TITLE
List object names in --trace OBJ

### DIFF
--- a/header.h
+++ b/header.h
@@ -771,6 +771,8 @@ typedef struct classinfo_s {
     int object_number;
     /* The offset of properties block for this class (always an offset inside the properties table) */
     int32 begins_at;
+    /* Class name symbol number */
+    int32 symbol;
 } classinfo;
 
 /* Common property information. */
@@ -795,6 +797,7 @@ typedef struct fpropt {
     uchar atts[6];
     int l;
     prop pp[64];
+    int32 symbol; /* name symbol or 0 */
 } fpropt;
 
 /* Constructed object (Z). */
@@ -802,6 +805,7 @@ typedef struct objecttz {
     uchar atts[6];
     int parent, next, child;
     int propsize;
+    int32 symbol; /* name symbol or 0 */
 } objecttz;
 
 /* Property entry record (G). */
@@ -826,6 +830,7 @@ typedef struct fproptg {
     int32 finalpropaddr;
     /* It's safe to use memory_lists in this object because there's just
        one and it's static. */
+    int32 symbol; /* name symbol or 0 */
 } fproptg;
 
 /* Constructed object (G). */
@@ -835,6 +840,7 @@ typedef struct objecttg {
     int32 parent, next, child;
     int32 propaddr;
     int32 propsize;
+    int32 symbol; /* name symbol or 0 */
 } objecttg;
 
 typedef struct abbreviation_s {

--- a/objects.c
+++ b/objects.c
@@ -466,7 +466,6 @@ memory_list   class_info_memlist;
 
 extern void list_object_tree(void)
 {   int i;
-    /* TODO: include the object names in this list. */
     printf("Object tree:\n");
     printf("obj name                             par nxt chl:\n");
     for (i=0; i<no_objects; i++) {

--- a/objects.c
+++ b/objects.c
@@ -460,15 +460,21 @@ memory_list   class_info_memlist;
 extern void list_object_tree(void)
 {   int i;
     printf("Object tree:\n");
-    printf("obj   par nxt chl:\n");
+    printf("obj name                             par nxt chl:\n");
     for (i=0; i<no_objects; i++) {
         if (!glulx_mode) {
-            printf("%3d   %3d %3d %3d\n",
-                i+1,objectsz[i].parent,objectsz[i].next, objectsz[i].child);
+            int sym = objectsz[i].symbol;
+            char *symname = ((sym > 0) ? symbols[sym].name : "...");
+            printf("%3d %-32s %3d %3d %3d\n",
+                i+1, symname,
+                objectsz[i].parent, objectsz[i].next, objectsz[i].child);
         }
         else {
-            printf("%3d   %3d %3d %3d\n",
-                i+1,objectsg[i].parent,objectsg[i].next, objectsg[i].child);
+            int sym = objectsg[i].symbol;
+            char *symname = ((sym > 0) ? symbols[sym].name : "...");
+            printf("%3d %-32s %3d %3d %3d\n",
+                i+1, symname,
+                objectsg[i].parent, objectsg[i].next, objectsg[i].child);
         }
     }
 }
@@ -1010,6 +1016,8 @@ static void manufacture_object_z(void)
     directives.enabled = TRUE;
 
     ensure_memory_list_available(&objectsz_memlist, no_objects+1);
+
+    objectsz[no_objects].symbol = full_object.symbol;
     
     property_inheritance_z();
 
@@ -1052,6 +1060,8 @@ static void manufacture_object_g(void)
 
     ensure_memory_list_available(&objectsg_memlist, no_objects+1);
     ensure_memory_list_available(&objectatts_memlist, no_objects+1);
+    
+    objectsg[no_objects].symbol = full_object_g.symbol;
     
     property_inheritance_g();
 
@@ -1819,6 +1829,7 @@ static void initialise_full_object(void)
 {
   int i;
   if (!glulx_mode) {
+    full_object.symbol = 0;
     full_object.l = 0;
     full_object.atts[0] = 0;
     full_object.atts[1] = 0;
@@ -1828,6 +1839,7 @@ static void initialise_full_object(void)
     full_object.atts[5] = 0;
   }
   else {
+    full_object_g.symbol = 0;
     full_object_g.numprops = 0;
     full_object_g.propdatasize = 0;
     for (i=0; i<NUM_ATTR_BYTES; i++)
@@ -1898,6 +1910,8 @@ inconvenience, please contact the maintainers.");
     else parent_of_this_obj = (module_switch)?MAXINTWORD:1;
 
     class_info[no_classes].object_number = class_number;
+    class_info[no_classes].symbol = current_classname_symbol;
+    class_info[no_classes].begins_at = 0;
 
     initialise_full_object();
 
@@ -1907,6 +1921,7 @@ inconvenience, please contact the maintainers.");
         since property 2 is always set to "additive" -- see below)           */
 
     if (!glulx_mode) {
+      full_object.symbol = current_classname_symbol;
       full_object.l = 1;
       full_object.pp[0].num = 2;
       full_object.pp[0].l = 1;
@@ -1914,6 +1929,7 @@ inconvenience, please contact the maintainers.");
       full_object.pp[0].ao[0].marker = OBJECT_MV;
     }
     else {
+      full_object_g.symbol = current_classname_symbol;
       full_object_g.numprops = 1;
       ensure_memory_list_available(&full_object_g.props_memlist, 1);
       full_object_g.props[0].num = 2;
@@ -2199,6 +2215,11 @@ extern void make_object(int nearby_flag,
     }
 
     initialise_full_object();
+    if (!glulx_mode)
+        full_object.symbol = internal_name_symbol;
+    else
+        full_object_g.symbol = internal_name_symbol;
+
     if (instance_of != -1) add_class_to_inheritance_list(instance_of);
 
     if (specified_class == -1) parse_body_of_definition();


### PR DESCRIPTION
Small improvement to the `--trace OBJ` output; show the class or object name.


