### PR TITLE
Lexer size limits

### DIFF
--- a/header.h
+++ b/header.h
@@ -885,7 +885,7 @@ typedef struct debug_location_beginning_s
     int32 orig_beg_char_number;
 } debug_location_beginning;
 
-#define MAX_KEYWORD_GROUP_SIZE (159)
+#define MAX_KEYWORD_GROUP_SIZE (119)
 
 typedef struct keyword_group_s
 {   char *keywords[MAX_KEYWORD_GROUP_SIZE+1]; /* empty-string-terminated */

--- a/header.h
+++ b/header.h
@@ -885,8 +885,10 @@ typedef struct debug_location_beginning_s
     int32 orig_beg_char_number;
 } debug_location_beginning;
 
+#define MAX_KEYWORD_GROUP_SIZE (159)
+
 typedef struct keyword_group_s
-{   char *keywords[120];
+{   char *keywords[MAX_KEYWORD_GROUP_SIZE+1]; /* empty-string-terminated */
     int change_token_type;
     int enabled;
     int case_sensitive;

--- a/inform.c
+++ b/inform.c
@@ -155,6 +155,11 @@ static void select_target(int targ)
     }
   }
 
+  if (MAX_LOCAL_VARIABLES >= MAX_KEYWORD_GROUP_SIZE) {
+    compiler_error("MAX_LOCAL_VARIABLES cannot exceeed MAX_KEYWORD_GROUP_SIZE");
+    MAX_LOCAL_VARIABLES = MAX_KEYWORD_GROUP_SIZE;
+  }
+
   if (DICT_WORD_SIZE > MAX_DICT_WORD_SIZE) {
     DICT_WORD_SIZE = MAX_DICT_WORD_SIZE;
     warning_numbered(

--- a/inform.c
+++ b/inform.c
@@ -156,7 +156,7 @@ static void select_target(int targ)
   }
 
   if (MAX_LOCAL_VARIABLES >= MAX_KEYWORD_GROUP_SIZE) {
-    compiler_error("MAX_LOCAL_VARIABLES cannot exceeed MAX_KEYWORD_GROUP_SIZE");
+    compiler_error("MAX_LOCAL_VARIABLES cannot exceed MAX_KEYWORD_GROUP_SIZE");
     MAX_LOCAL_VARIABLES = MAX_KEYWORD_GROUP_SIZE;
   }
 

--- a/lexer.c
+++ b/lexer.c
@@ -661,11 +661,21 @@ static void make_keywords_tables(void)
     }
 
     for (j=0; *(oplist[j]); j++) {
+        if (j >= MAX_KEYWORD_GROUP_SIZE) {
+            /* Gotta increase MAX_KEYWORD_GROUP_SIZE */
+            compiler_error("opcode_list has overflowed opcode_names.keywords");
+            break;
+        }
         opcode_names.keywords[j] = oplist[j];
     }
     opcode_names.keywords[j] = "";
     
     for (j=0; *(maclist[j]); j++) {
+        if (j >= MAX_KEYWORD_GROUP_SIZE) {
+            /* Gotta increase MAX_KEYWORD_GROUP_SIZE */
+            compiler_error("opmacro_list has overflowed opcode_macros.keywords");
+            break;
+        }
         opcode_macros.keywords[j] = maclist[j];
     }
     opcode_macros.keywords[j] = "";

--- a/lexer.c
+++ b/lexer.c
@@ -396,7 +396,7 @@ extern void describe_token_triple(const char *text, int32 value, int type)
 
 /* This must exceed the total number of keywords across all groups, 
    including opcodes. */
-#define MAX_KEYWORDS (500)
+#define MAX_KEYWORDS (350)
 
 /* The values will be filled in at compile time, when we know
    which opcode set to use. */

--- a/lexer.c
+++ b/lexer.c
@@ -382,7 +382,7 @@ extern void describe_token_triple(const char *text, int32 value, int type)
 }
 
 /* ------------------------------------------------------------------------- */
-/*   All but one of the 280 Inform keywords (118 of them opcode names used   */
+/*   All but one of the Inform keywords (most of them opcode names used      */
 /*   only by the assembler).  (The one left over is "sp", a keyword used in  */
 /*   assembly language only.)                                                */
 /*                                                                           */
@@ -394,7 +394,9 @@ extern void describe_token_triple(const char *text, int32 value, int type)
 /*   "header.h" but is otherwise not significant.                            */
 /* ------------------------------------------------------------------------- */
 
-#define MAX_KEYWORDS 350
+/* This must exceed the total number of keywords across all groups, 
+   including opcodes. */
+#define MAX_KEYWORDS (500)
 
 /* The values will be filled in at compile time, when we know
    which opcode set to use. */
@@ -688,7 +690,13 @@ static void make_keywords_tables(void)
     for (i=1; i<=11; i++)
     {   keyword_group *kg = keyword_groups[i];
         for (j=0; *(kg->keywords[j]) != 0; j++)
-        {   h = hash_code_from_string(kg->keywords[j]);
+        {
+            if (tp >= MAX_KEYWORDS) {
+                /* Gotta increase MAX_KEYWORDS */
+                compiler_error("keywords_data_table has overflowed MAX_KEYWORDS");
+                break;
+            }
+            h = hash_code_from_string(kg->keywords[j]);
             if (keywords_hash_table[h] == -1)
                 keywords_hash_table[h] = tp;
             else


### PR DESCRIPTION
While working with the double opcodes, I ran over some hardwired array limits. These changes check the array limits and throw a compiler error. (As opposed to segfaulting.)

(It's an internal "should never occur" error because adding more opcodes is compiler maintenance.)

