### PR TITLE
Change the "too many dynamic strings" error to use the modern form

### DIFF
--- a/errors.c
+++ b/errors.c
@@ -366,13 +366,13 @@ extern void unicode_char_error(char *s, int32 uni)
 extern void error_max_dynamic_strings(int index)
 {
     if (index >= 96 && !glulx_mode)
-        snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @95 may be used in Z-code");
+        snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @(00) to @(95) may be used in Z-code");
     else if (MAX_DYNAMIC_STRINGS == 0)
         snprintf(error_message_buff, ERROR_BUFLEN, "Dynamic strings may not be used, because $MAX_DYNAMIC_STRINGS has been set to 0. Increase MAX_DYNAMIC_STRINGS.");
     else if (MAX_DYNAMIC_STRINGS == 32 && !glulx_mode)
-        snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @%02d may be used, because $MAX_DYNAMIC_STRINGS has its default value of %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS-1, MAX_DYNAMIC_STRINGS);
+        snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @(00) to @(%02d) may be used, because $MAX_DYNAMIC_STRINGS has its default value of %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS-1, MAX_DYNAMIC_STRINGS);
     else
-        snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @00 to @%02d may be used, because $MAX_DYNAMIC_STRINGS has been set to %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS-1, MAX_DYNAMIC_STRINGS);
+        snprintf(error_message_buff, ERROR_BUFLEN, "Only dynamic strings @(00) to @(%02d) may be used, because $MAX_DYNAMIC_STRINGS has been set to %d. Increase MAX_DYNAMIC_STRINGS.", MAX_DYNAMIC_STRINGS-1, MAX_DYNAMIC_STRINGS);
 
     ellipsize_error_message_buff();
     error(error_message_buff);


### PR DESCRIPTION
Change the "too many dynamic strings" error to use the modern form, with parens:

    Only dynamic strings @(00) to @(99) may be used...

The paren form is better, and also makes sense for three-digit values. (Previously you could make the compiler complain about `"strings @00 to @100"`, which was misleading.)

This only affects the error message.