### PR TITLE
Extended undo opcodes

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -52,6 +52,8 @@ int uses_acceleration_features;    /* Makes use of Glulx acceleration (3.1.1)
                                       features?                              */
 int uses_float_features;           /* Makes use of Glulx floating-point (3.1.2)
                                       features?                              */
+int uses_extundo_features;         /* Makes use of Glulx extended undo (3.1.3)
+                                      features?                              */
 
 debug_location statement_debug_location;
                                    /* Location of current statement          */
@@ -488,6 +490,7 @@ typedef struct opcodeg
 #define GOP_MemHeap      2   /* uses_memheap_features */
 #define GOP_Acceleration 4   /* uses_acceleration_features */
 #define GOP_Float        8   /* uses_float_features */
+#define GOP_ExtUndo     16   /* uses_extundo_features */
 
     /* Codes for the number of operands */
 
@@ -785,6 +788,8 @@ static opcodeg opcodes_table_g[] = {
   { (uchar *) "jfge",       0x1C5,  Br, GOP_Float, 3 },
   { (uchar *) "jisnan",     0x1C8,  Br, GOP_Float, 2 },
   { (uchar *) "jisinf",     0x1C9,  Br, GOP_Float, 2 },
+  { (uchar *) "hasundo",    0x128,  St, GOP_ExtUndo, 1 },
+  { (uchar *) "discardundo",0x129,   0, GOP_ExtUndo, 0 },
 };
 
 /* The opmacros table is used for fake opcodes. The opcode numbers are
@@ -1319,6 +1324,9 @@ extern void assembleg_instruction(const assembly_instruction *AI)
     }
     if (opco.op_rules & GOP_Float) {
         uses_float_features = TRUE;
+    }
+    if (opco.op_rules & GOP_ExtUndo) {
+        uses_extundo_features = TRUE;
     }
 
     no_operands_given = AI->operand_count;
@@ -3409,6 +3417,7 @@ extern void init_asm_vars(void)
     uses_memheap_features = FALSE;
     uses_acceleration_features = FALSE;
     uses_float_features = FALSE;
+    uses_extundo_features = FALSE;
 
     labels = NULL;
     sequence_points = NULL;

--- a/files.c
+++ b/files.c
@@ -668,6 +668,9 @@ static void output_file_g(void)
     if (uses_float_features) {
       VersionNum = 0x00030102;
     }
+    if (uses_extundo_features) {
+      VersionNum = 0x00030103;
+    }
 
     /* And check if the user has requested a specific version. */
     if (requested_glulx_version) {

--- a/header.h
+++ b/header.h
@@ -2162,7 +2162,8 @@ extern int32 zmachine_pc;
 extern int32 no_instructions;
 extern int   sequence_point_follows;
 extern int   uses_unicode_features, uses_memheap_features, 
-    uses_acceleration_features, uses_float_features;
+    uses_acceleration_features, uses_float_features,
+    uses_extundo_features;
 extern debug_location statement_debug_location;
 extern int   execution_never_reaches_here;
 extern variableinfo *variables;

--- a/lexer.c
+++ b/lexer.c
@@ -455,6 +455,7 @@ static char *opcode_list_g[] = {
     "sqrt", "exp", "log", "pow",
     "sin", "cos", "tan", "asin", "acos", "atan", "atan2",
     "jfeq", "jfne", "jflt", "jfle", "jfgt", "jfge", "jisnan", "jisinf",
+    "hasundo", "discardundo",
     ""
 };
 


### PR DESCRIPTION
Adds support for two new opcodes:

`@hasundo S1`: Test whether a VM state is available in temporary storage. S1 is set to 0 if a state is available, 1 if not. If this returns 0, then restoreundo is expected to succeed.

`@discardundo`: Discard a VM state (the most recently saved) from temporary storage. If none is available, this does nothing.

