### PR TITLE
Ignore Abbreviate directive when -e mode is off

### DIFF
--- a/text.c
+++ b/text.c
@@ -211,6 +211,10 @@ static int try_abbreviations_from(unsigned char *text, int i, int from)
 
 extern void make_abbreviation(char *text)
 {
+    /* If -e mode is off, we won't waste space creating an abbreviation entry. */
+    if (!economy_switch)
+        return;
+    
     ensure_memory_list_available(&abbreviations_memlist, no_abbreviations+1);
     ensure_memory_list_available(&abbreviations_at_memlist, no_abbreviations+1);
     


### PR DESCRIPTION
When the economy (-e) switch is not used, we ignore the Abbreviate directive.

More precisely, we parse it and check for valid syntax, but we don't create an abbreviation or enter anything into the abbreviation table. This saves a small amount of space if the author uses the Abbreviate directive but not -e. It has no effect on games without the Abbreviate directive.

(A consequence of this is that "too many abbreviations" errors and "does not save any characters" warnings will not appear unless you use `-e`.)

Fixes https://github.com/DavidKinder/Inform6/issues/129 .
