### PR TITLE
Separate Global and Array directives; accept "Global glob val"

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -395,9 +395,9 @@ extern void make_global()
                 2*globalnum);
     }
     else {
-    if (AO.marker != 0)
-        backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
-            4*globalnum);
+        if (AO.marker != 0)
+            backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
+                4*globalnum);
     }
     
     if (globalnum < 0 || globalnum >= global_initial_value_memlist.count)

--- a/arrays.c
+++ b/arrays.c
@@ -412,7 +412,7 @@ extern void make_global()
     }
 }
 
-extern void make_array(int array_flag)
+extern void make_array()
 {
     int32 i;
     int name_length;

--- a/arrays.c
+++ b/arrays.c
@@ -399,7 +399,11 @@ extern void make_global()
         backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
             4*globalnum);
     }
+    
+    if (globalnum < 0 || globalnum >= global_initial_value_memlist.count)
+        compiler_error("Globalnum out of range");
     global_initial_value[globalnum] = AO.value;
+    
     if (debugfile_switch)
     {
         char *global_name = current_array_name.data;

--- a/arrays.c
+++ b/arrays.c
@@ -352,6 +352,7 @@ extern void make_global()
 
     if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
     {
+        /* No initial value. */
         put_token_back();
         if (debugfile_switch)
         {
@@ -377,15 +378,11 @@ extern void make_global()
         error("use 'Array' to define arrays, not 'Global'");
         return;
     }
-    
+
+    /* Skip "=" if present. */
     if (!((token_type == SEP_TT) && (token_value == SETEQUALS_SEP)))
-    {
-        ebf_error("'=' or ';'", token_text);
-        //### but the equals can be optional?
-        //###error("use 'Array' to define arrays, not 'Global'");
-        return;
-    }
-            
+        put_token_back();
+
     AO = parse_expression(CONSTANT_CONTEXT);
     if (!glulx_mode) {
         if (AO.marker != 0)

--- a/arrays.c
+++ b/arrays.c
@@ -414,8 +414,6 @@ extern void make_global()
 
 extern void make_array(int array_flag)
 {
-    /*  array_flag is TRUE for an Array directive, FALSE for a Global.       */
-
     int32 i;
     int name_length;
     int array_type, data_type;
@@ -437,162 +435,57 @@ extern void make_array(int array_flag)
     ensure_memory_list_available(&current_array_name, name_length);
     strncpy(current_array_name.data, token_text, name_length);
 
-    if (!glulx_mode) {
-        if ((token_type==SYMBOL_TT) && (symbols[i].type==GLOBAL_VARIABLE_T)
-            && (symbols[i].value >= LOWEST_SYSTEM_VAR_NUMBER))
-            goto RedefinitionOfSystemVar;
-    }
-    else {
-        if ((token_type==SYMBOL_TT) && (symbols[i].type==GLOBAL_VARIABLE_T))
-            goto RedefinitionOfSystemVar;
-    }
-
     if (token_type != SYMBOL_TT)
     {   discard_token_location(beginning_debug_location);
-        if (array_flag)
-            ebf_error("new array name", token_text);
-        else ebf_error("new global variable name", token_text);
+        ebf_error("new array name", token_text);
         panic_mode_error_recovery(); return;
     }
 
     if (!(symbols[i].flags & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
-        if (array_flag)
-            ebf_symbol_error("new array name", token_text, typename(symbols[i].type), symbols[i].line);
-        else ebf_symbol_error("new global variable name", token_text, typename(symbols[i].type), symbols[i].line);
+        ebf_symbol_error("new array name", token_text, typename(symbols[i].type), symbols[i].line);
         panic_mode_error_recovery(); return;
     }
-
-    if ((!array_flag) && (symbols[i].flags & USED_SFLAG))
-        error_named("Variable must be defined before use:", token_text);
 
     directive_keywords.enabled = TRUE;
     get_next_token();
     directive_keywords.enabled = FALSE;
     if ((token_type==DIR_KEYWORD_TT)&&(token_value==STATIC_DK)) {
-        if (array_flag) {
-            is_static = TRUE;
-        }
-        else {
-            error("Global variables cannot be static");
-        }
+        is_static = TRUE;
     }
     else {
         put_token_back();
     }
     
-    if (array_flag)
-    {   if (!is_static) {
-            assign_symbol(i, dynamic_array_area_size, ARRAY_T);
-        }
-        else {
-            assign_symbol(i, static_array_area_size, STATIC_ARRAY_T);
-        }
-        ensure_memory_list_available(&arrays_memlist, no_arrays+1);
-        arrays[no_arrays].symbol = i;
+    if (!is_static) {
+        assign_symbol(i, dynamic_array_area_size, ARRAY_T);
     }
-    else
-    {   if (!glulx_mode && no_globals==233)
-        {   discard_token_location(beginning_debug_location);
-            error("All 233 global variables already declared");
-            panic_mode_error_recovery();
-            return;
-        }
-        
-        ensure_memory_list_available(&variables_memlist, MAX_LOCAL_VARIABLES+no_globals+1);
-        variables[MAX_LOCAL_VARIABLES+no_globals].token = i;
-        variables[MAX_LOCAL_VARIABLES+no_globals].usage = FALSE;
-        assign_symbol(i, MAX_LOCAL_VARIABLES+no_globals, GLOBAL_VARIABLE_T);
-
-        ensure_memory_list_available(&global_initial_value_memlist, no_globals+1);
-        global_initial_value[no_globals++]=0;
+    else {
+        assign_symbol(i, static_array_area_size, STATIC_ARRAY_T);
     }
+    ensure_memory_list_available(&arrays_memlist, no_arrays+1);
+    arrays[no_arrays].symbol = i;
 
     directive_keywords.enabled = TRUE;
-
-    RedefinitionOfSystemVar:
 
     get_next_token();
 
     if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
-    {   if (array_flag)
-        {   discard_token_location(beginning_debug_location);
-            ebf_error("array definition", token_text);
-        }
-        put_token_back();
-        if (debugfile_switch && !array_flag)
-        {
-            char *global_name = current_array_name.data;
-            debug_file_printf("<global-variable>");
-            debug_file_printf("<identifier>%s</identifier>", global_name);
-            debug_file_printf("<address>");
-            write_debug_global_backpatch(symbols[global_symbol].value);
-            debug_file_printf("</address>");
-            write_debug_locations
-                (get_token_location_end(beginning_debug_location));
-            debug_file_printf("</global-variable>");
-        }
-        return;
-    }
-
-    if (!array_flag)
     {
-        /* is_static is always false in this case */
-        if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
-        {   AO = parse_expression(CONSTANT_CONTEXT);
-            if (!glulx_mode) {
-                if (AO.marker != 0)
-                    backpatch_zmachine(AO.marker, DYNAMIC_ARRAY_ZA,
-                        2*(no_globals-1));
-            }
-            else {
-            if (AO.marker != 0)
-                backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
-                4*(no_globals-1));
-            }
-            global_initial_value[no_globals-1] = AO.value;
-            if (debugfile_switch)
-            {
-                char *global_name = current_array_name.data;
-                debug_file_printf("<global-variable>");
-                debug_file_printf("<identifier>%s</identifier>", global_name);
-                debug_file_printf("<address>");
-                write_debug_global_backpatch(symbols[global_symbol].value);
-                debug_file_printf("</address>");
-                write_debug_locations
-                    (get_token_location_end(beginning_debug_location));
-                debug_file_printf("</global-variable>");
-            }
-            return;
-        }
-
-        obsolete_warning("more modern to use 'Array', not 'Global'");
-
-        if (!glulx_mode) {
-            backpatch_zmachine(ARRAY_MV, DYNAMIC_ARRAY_ZA, 2*(no_globals-1));
-            global_initial_value[no_globals-1]
-                = dynamic_array_area_size+variables_offset;
-        }
-        else {
-            backpatch_zmachine(ARRAY_MV, GLOBALVAR_ZA, 4*(no_globals-1));
-            global_initial_value[no_globals-1]
-                = dynamic_array_area_size;
-        }
+        discard_token_location(beginning_debug_location);
+        ebf_error("array definition", token_text);
+        put_token_back();
+        return;
     }
 
     array_type = BYTE_ARRAY; data_type = UNSPECIFIED_AI;
 
-         if ((!array_flag) &&
-             ((token_type==DIR_KEYWORD_TT)&&(token_value==DATA_DK)))
-                 data_type=NULLS_AI;
-    else if ((!array_flag) &&
-             ((token_type==DIR_KEYWORD_TT)&&(token_value==INITIAL_DK)))
-                 data_type=DATA_AI;
-    else if ((!array_flag) &&
-             ((token_type==DIR_KEYWORD_TT)&&(token_value==INITSTR_DK)))
-                 data_type=ASCII_AI;
+    /* The keywords "data", "initial", and "initstr" used to be accepted
+       here -- but only in a Global directive, not Array. The Global directive
+       no longer calls here, so those keywords are now (more) obsolete.
+    */
 
-    else if ((token_type==SEP_TT)&&(token_value==ARROW_SEP))
+    if      ((token_type==SEP_TT)&&(token_value==ARROW_SEP))
              array_type = BYTE_ARRAY;
     else if ((token_type==SEP_TT)&&(token_value==DARROW_SEP))
              array_type = WORD_ARRAY;
@@ -604,12 +497,8 @@ extern void make_array(int array_flag)
              array_type = BUFFER_ARRAY;
     else
     {   discard_token_location(beginning_debug_location);
-        if (array_flag)
-            ebf_error
-              ("'->', '-->', 'string', 'table' or 'buffer'", token_text);
-        else
-            ebf_error
-              ("'=', '->', '-->', 'string', 'table' or 'buffer'", token_text);
+        ebf_error
+            ("'->', '-->', 'string', 'table' or 'buffer'", token_text);
         panic_mode_error_recovery();
         return;
     }

--- a/arrays.c
+++ b/arrays.c
@@ -279,6 +279,7 @@ extern void make_global()
     int name_length;
     assembly_operand AO;
 
+    int32 globalnum;
     int32 global_symbol;
     debug_location_beginning beginning_debug_location =
         get_token_location_beginning();
@@ -294,12 +295,16 @@ extern void make_global()
 
     if (!glulx_mode) {
         if ((token_type==SYMBOL_TT) && (symbols[i].type==GLOBAL_VARIABLE_T)
-            && (symbols[i].value >= LOWEST_SYSTEM_VAR_NUMBER))
+            && (symbols[i].value >= LOWEST_SYSTEM_VAR_NUMBER)) {
+            globalnum = symbols[i].value - MAX_LOCAL_VARIABLES;
             goto RedefinitionOfSystemVar;
+        }
     }
     else {
-        if ((token_type==SYMBOL_TT) && (symbols[i].type==GLOBAL_VARIABLE_T))
+        if ((token_type==SYMBOL_TT) && (symbols[i].type==GLOBAL_VARIABLE_T)) {
+            globalnum = symbols[i].value - MAX_LOCAL_VARIABLES;
             goto RedefinitionOfSystemVar;
+        }
     }
 
     if (token_type != SYMBOL_TT)
@@ -333,6 +338,8 @@ extern void make_global()
         panic_mode_error_recovery();
         return;
     }
+
+    globalnum = no_globals;
     
     ensure_memory_list_available(&variables_memlist, MAX_LOCAL_VARIABLES+no_globals+1);
     variables[MAX_LOCAL_VARIABLES+no_globals].token = i;
@@ -385,14 +392,14 @@ extern void make_global()
     if (!glulx_mode) {
         if (AO.marker != 0)
             backpatch_zmachine(AO.marker, DYNAMIC_ARRAY_ZA,
-                2*(no_globals-1));
+                2*globalnum);
     }
     else {
     if (AO.marker != 0)
         backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
-        4*(no_globals-1));
+            4*globalnum);
     }
-    global_initial_value[no_globals-1] = AO.value;
+    global_initial_value[globalnum] = AO.value;
     if (debugfile_switch)
     {
         char *global_name = current_array_name.data;

--- a/arrays.c
+++ b/arrays.c
@@ -277,15 +277,9 @@ extern void set_variable_value(int i, int32 v)
 
 extern void make_global(int array_flag)
 {
-    /*  array_flag is TRUE for an Array directive, FALSE for a Global.       */
-
     int32 i;
     int name_length;
-    int array_type, data_type;
-    int is_static = FALSE;
     assembly_operand AO;
-    
-    int extraspace;
 
     int32 global_symbol;
     debug_location_beginning beginning_debug_location =
@@ -312,64 +306,43 @@ extern void make_global(int array_flag)
 
     if (token_type != SYMBOL_TT)
     {   discard_token_location(beginning_debug_location);
-        if (array_flag)
-            ebf_error("new array name", token_text);
-        else ebf_error("new global variable name", token_text);
+        ebf_error("new global variable name", token_text);
         panic_mode_error_recovery(); return;
     }
 
     if (!(symbols[i].flags & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
-        if (array_flag)
-            ebf_symbol_error("new array name", token_text, typename(symbols[i].type), symbols[i].line);
-        else ebf_symbol_error("new global variable name", token_text, typename(symbols[i].type), symbols[i].line);
+        ebf_symbol_error("new global variable name", token_text, typename(symbols[i].type), symbols[i].line);
         panic_mode_error_recovery(); return;
     }
 
-    if ((!array_flag) && (symbols[i].flags & USED_SFLAG))
+    if (symbols[i].flags & USED_SFLAG)
         error_named("Variable must be defined before use:", token_text);
 
     directive_keywords.enabled = TRUE;
     get_next_token();
     directive_keywords.enabled = FALSE;
     if ((token_type==DIR_KEYWORD_TT)&&(token_value==STATIC_DK)) {
-        if (array_flag) {
-            is_static = TRUE;
-        }
-        else {
-            error("Global variables cannot be static");
-        }
+        error("Global variables cannot be static");
     }
     else {
         put_token_back();
     }
     
-    if (array_flag)
-    {   if (!is_static) {
-            assign_symbol(i, dynamic_array_area_size, ARRAY_T);
-        }
-        else {
-            assign_symbol(i, static_array_area_size, STATIC_ARRAY_T);
-        }
-        ensure_memory_list_available(&arrays_memlist, no_arrays+1);
-        arrays[no_arrays].symbol = i;
+    if (!glulx_mode && no_globals==233)
+    {   discard_token_location(beginning_debug_location);
+        error("All 233 global variables already declared");
+        panic_mode_error_recovery();
+        return;
     }
-    else
-    {   if (!glulx_mode && no_globals==233)
-        {   discard_token_location(beginning_debug_location);
-            error("All 233 global variables already declared");
-            panic_mode_error_recovery();
-            return;
-        }
-        
-        ensure_memory_list_available(&variables_memlist, MAX_LOCAL_VARIABLES+no_globals+1);
-        variables[MAX_LOCAL_VARIABLES+no_globals].token = i;
-        variables[MAX_LOCAL_VARIABLES+no_globals].usage = FALSE;
-        assign_symbol(i, MAX_LOCAL_VARIABLES+no_globals, GLOBAL_VARIABLE_T);
+    
+    ensure_memory_list_available(&variables_memlist, MAX_LOCAL_VARIABLES+no_globals+1);
+    variables[MAX_LOCAL_VARIABLES+no_globals].token = i;
+    variables[MAX_LOCAL_VARIABLES+no_globals].usage = FALSE;
+    assign_symbol(i, MAX_LOCAL_VARIABLES+no_globals, GLOBAL_VARIABLE_T);
 
-        ensure_memory_list_available(&global_initial_value_memlist, no_globals+1);
-        global_initial_value[no_globals++]=0;
-    }
+    ensure_memory_list_available(&global_initial_value_memlist, no_globals+1);
+    global_initial_value[no_globals++]=0;
 
     directive_keywords.enabled = TRUE;
 
@@ -378,12 +351,9 @@ extern void make_global(int array_flag)
     get_next_token();
 
     if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP))
-    {   if (array_flag)
-        {   discard_token_location(beginning_debug_location);
-            ebf_error("array definition", token_text);
-        }
+    {
         put_token_back();
-        if (debugfile_switch && !array_flag)
+        if (debugfile_switch)
         {
             char *global_name = current_array_name.data;
             debug_file_printf("<global-variable>");
@@ -398,41 +368,35 @@ extern void make_global(int array_flag)
         return;
     }
 
-    if (!array_flag)
-    {
-        /* is_static is always false in this case */
-        if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
-        {   AO = parse_expression(CONSTANT_CONTEXT);
-            if (!glulx_mode) {
-                if (AO.marker != 0)
-                    backpatch_zmachine(AO.marker, DYNAMIC_ARRAY_ZA,
-                        2*(no_globals-1));
-            }
-            else {
+    if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
+    {   AO = parse_expression(CONSTANT_CONTEXT);
+        if (!glulx_mode) {
             if (AO.marker != 0)
-                backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
-                4*(no_globals-1));
-            }
-            global_initial_value[no_globals-1] = AO.value;
-            if (debugfile_switch)
-            {
-                char *global_name = current_array_name.data;
-                debug_file_printf("<global-variable>");
-                debug_file_printf("<identifier>%s</identifier>", global_name);
-                debug_file_printf("<address>");
-                write_debug_global_backpatch(symbols[global_symbol].value);
-                debug_file_printf("</address>");
-                write_debug_locations
-                    (get_token_location_end(beginning_debug_location));
-                debug_file_printf("</global-variable>");
-            }
-            return;
+                backpatch_zmachine(AO.marker, DYNAMIC_ARRAY_ZA,
+                    2*(no_globals-1));
         }
-
-        obsolete_warning("more modern to use 'Array', not 'Global'");
-        //### error
+        else {
+        if (AO.marker != 0)
+            backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
+            4*(no_globals-1));
+        }
+        global_initial_value[no_globals-1] = AO.value;
+        if (debugfile_switch)
+        {
+            char *global_name = current_array_name.data;
+            debug_file_printf("<global-variable>");
+            debug_file_printf("<identifier>%s</identifier>", global_name);
+            debug_file_printf("<address>");
+            write_debug_global_backpatch(symbols[global_symbol].value);
+            debug_file_printf("</address>");
+            write_debug_locations
+                (get_token_location_end(beginning_debug_location));
+            debug_file_printf("</global-variable>");
+        }
         return;
     }
+
+    error("use 'Array' to define arrays, not 'Global'");
 }
 
 extern void make_array(int array_flag)

--- a/arrays.c
+++ b/arrays.c
@@ -275,7 +275,7 @@ extern void set_variable_value(int i, int32 v)
 #define ASCII_AI        2
 #define BRACKET_AI      3
 
-extern void make_global(int array_flag)
+extern void make_global()
 {
     int32 i;
     int name_length;

--- a/arrays.c
+++ b/arrays.c
@@ -241,9 +241,7 @@ extern void array_entry(int32 i, int is_static, assembly_operand VAL)
 /* ------------------------------------------------------------------------- */
 /*   Global and Array directives.                                            */
 /*                                                                           */
-/*      Global <variablename> |                                              */
-/*                            | = <value>                                    */
-/*                            | <array specification>                        */
+/*      Global <variablename> [ [=] <value> ]                                */
 /*                                                                           */
 /*      Array <arrayname> [static] <array specification>                     */
 /*                                                                           */

--- a/arrays.c
+++ b/arrays.c
@@ -368,35 +368,48 @@ extern void make_global()
         return;
     }
 
-    if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
-    {   AO = parse_expression(CONSTANT_CONTEXT);
-        if (!glulx_mode) {
-            if (AO.marker != 0)
-                backpatch_zmachine(AO.marker, DYNAMIC_ARRAY_ZA,
-                    2*(no_globals-1));
-        }
-        else {
-        if (AO.marker != 0)
-            backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
-            4*(no_globals-1));
-        }
-        global_initial_value[no_globals-1] = AO.value;
-        if (debugfile_switch)
-        {
-            char *global_name = current_array_name.data;
-            debug_file_printf("<global-variable>");
-            debug_file_printf("<identifier>%s</identifier>", global_name);
-            debug_file_printf("<address>");
-            write_debug_global_backpatch(symbols[global_symbol].value);
-            debug_file_printf("</address>");
-            write_debug_locations
-                (get_token_location_end(beginning_debug_location));
-            debug_file_printf("</global-variable>");
-        }
+    if (((token_type==SEP_TT)&&(token_value==ARROW_SEP))
+        || ((token_type==SEP_TT)&&(token_value==DARROW_SEP))
+        || ((token_type==DIR_KEYWORD_TT)&&(token_value==STRING_DK))
+        || ((token_type==DIR_KEYWORD_TT)&&(token_value==TABLE_DK))
+        || ((token_type==DIR_KEYWORD_TT)&&(token_value==BUFFER_DK)))
+    {
+        error("use 'Array' to define arrays, not 'Global'");
         return;
     }
-
-    error("use 'Array' to define arrays, not 'Global'");
+    
+    if (!((token_type == SEP_TT) && (token_value == SETEQUALS_SEP)))
+    {
+        ebf_error("'=' or ';'", token_text);
+        //### but the equals can be optional?
+        //###error("use 'Array' to define arrays, not 'Global'");
+        return;
+    }
+            
+    AO = parse_expression(CONSTANT_CONTEXT);
+    if (!glulx_mode) {
+        if (AO.marker != 0)
+            backpatch_zmachine(AO.marker, DYNAMIC_ARRAY_ZA,
+                2*(no_globals-1));
+    }
+    else {
+    if (AO.marker != 0)
+        backpatch_zmachine(AO.marker, GLOBALVAR_ZA,
+        4*(no_globals-1));
+    }
+    global_initial_value[no_globals-1] = AO.value;
+    if (debugfile_switch)
+    {
+        char *global_name = current_array_name.data;
+        debug_file_printf("<global-variable>");
+        debug_file_printf("<identifier>%s</identifier>", global_name);
+        debug_file_printf("<address>");
+        write_debug_global_backpatch(symbols[global_symbol].value);
+        debug_file_printf("</address>");
+        write_debug_locations
+            (get_token_location_end(beginning_debug_location));
+        debug_file_printf("</global-variable>");
+    }
 }
 
 extern void make_array(int array_flag)

--- a/directs.c
+++ b/directs.c
@@ -124,7 +124,7 @@ extern int parse_given_directive(int internal_flag)
     /*   Array arrayname array...                                            */
     /* --------------------------------------------------------------------- */
 
-    case ARRAY_CODE: make_array(TRUE); break;              /* See "arrays.c" */
+    case ARRAY_CODE: make_array(); break;                  /* See "arrays.c" */
 
     /* --------------------------------------------------------------------- */
     /*   Attribute newname [alias oldname]                                   */

--- a/directs.c
+++ b/directs.c
@@ -121,7 +121,7 @@ extern int parse_given_directive(int internal_flag)
         } while (TRUE);
 
     /* --------------------------------------------------------------------- */
-    /*   Array arrayname array...                                            */
+    /*   Array <arrayname> [static] <array specification>                    */
     /* --------------------------------------------------------------------- */
 
     case ARRAY_CODE: make_array(); break;                  /* See "arrays.c" */

--- a/directs.c
+++ b/directs.c
@@ -360,7 +360,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         make_fake_action(); break;                          /* see "verbs.c" */
 
     /* --------------------------------------------------------------------- */
-    /*   Global variable [= value / array...]                                */
+    /*   Global <variablename> [ [=] <value> ]                               */
     /* --------------------------------------------------------------------- */
 
     case GLOBAL_CODE: make_global(); break;                /* See "arrays.c" */

--- a/directs.c
+++ b/directs.c
@@ -124,7 +124,7 @@ extern int parse_given_directive(int internal_flag)
     /*   Array arrayname array...                                            */
     /* --------------------------------------------------------------------- */
 
-    case ARRAY_CODE: make_global(TRUE); break;             /* See "tables.c" */
+    case ARRAY_CODE: make_array(TRUE); break;              /* See "arrays.c" */
 
     /* --------------------------------------------------------------------- */
     /*   Attribute newname [alias oldname]                                   */
@@ -363,7 +363,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     /*   Global variable [= value / array...]                                */
     /* --------------------------------------------------------------------- */
 
-    case GLOBAL_CODE: make_global(FALSE); break;           /* See "tables.c" */
+    case GLOBAL_CODE: make_global(FALSE); break;           /* See "arrays.c" */
 
     /* --------------------------------------------------------------------- */
     /*   If...                                                               */

--- a/directs.c
+++ b/directs.c
@@ -363,7 +363,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
     /*   Global variable [= value / array...]                                */
     /* --------------------------------------------------------------------- */
 
-    case GLOBAL_CODE: make_global(FALSE); break;           /* See "arrays.c" */
+    case GLOBAL_CODE: make_global(); break;                /* See "arrays.c" */
 
     /* --------------------------------------------------------------------- */
     /*   If...                                                               */

--- a/header.h
+++ b/header.h
@@ -2098,9 +2098,9 @@ extern memory_list static_array_area_memlist;
 extern int32 *global_initial_value;
 extern arrayinfo *arrays;
 
-extern void make_array(int array_flag);
-extern void make_global(int array_flag);
+extern void make_global(void);
 extern void set_variable_value(int i, int32 v);
+extern void make_array(int array_flag);
 extern void check_globals(void);
 extern int32 begin_table_array(void);
 extern int32 begin_word_array(void);

--- a/header.h
+++ b/header.h
@@ -2100,7 +2100,7 @@ extern arrayinfo *arrays;
 
 extern void make_global(void);
 extern void set_variable_value(int i, int32 v);
-extern void make_array(int array_flag);
+extern void make_array(void);
 extern void check_globals(void);
 extern int32 begin_table_array(void);
 extern int32 begin_word_array(void);

--- a/header.h
+++ b/header.h
@@ -2098,6 +2098,7 @@ extern memory_list static_array_area_memlist;
 extern int32 *global_initial_value;
 extern arrayinfo *arrays;
 
+extern void make_array(int array_flag);
 extern void make_global(int array_flag);
 extern void set_variable_value(int i, int32 v);
 extern void check_globals(void);


### PR DESCRIPTION
This change removes the (extremely deprecated) forms

    Global array --> size;
    Global array data ...;
    Global array initial ...;
    Global array initstr ...;

...and other uses of the Global directive to define arrays. (I don't even remember what `data`, `initial`, or `initstr` meant.) That is, the Global and Array directives no longer overlap at all.

I have therefore divided the make_global(array_flag) function into separate functions make_global() and make_array(), to the considerable simplification of both.

(Git's diffs are not very informative, mind you. Compare the [original function](https://github.com/DavidKinder/Inform6/blob/a5c8edbf7b3f1486ac9c0069e90109f23866b30b/arrays.c#L278) side-by-side with the new ones.)

With *that* change in place, I was able to make the `=` sign in the Global directive optional, just as it is in the Constant directive. So all of these are now legal:

```
Constant c1 11;
Constant c2 = 22;
Global g1 33;
Global g2 = 44;
```

Fixes https://github.com/DavidKinder/Inform6/issues/190 .

I also fixed https://github.com/DavidKinder/Inform6/issues/194 while I was at it.
