### PR TITLE
Display the name of a label in the "unreachable label" error

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -2187,7 +2187,10 @@ static void transfer_routine_z(void)
             offset_of_next = new_pc + long_form + 1;
 
             if (labels[j].offset < 0) {
-                error("Attempt to jump to an unreachable label");
+                char *lname = "(anon)";
+                if (labels[j].symbol >= 0 && labels[j].symbol < no_symbols)
+                    lname = symbols[labels[j].symbol].name;
+                error_named("Attempt to jump to an unreachable label", lname);
                 addr = 0;
             }
             else {
@@ -2215,7 +2218,10 @@ static void transfer_routine_z(void)
           case LABEL_MV:
             j = 256*zcode_holding_area[i] + zcode_holding_area[i+1];
             if (labels[j].offset < 0) {
-                error("Attempt to jump to an unreachable label");
+                char *lname = "(anon)";
+                if (labels[j].symbol >= 0 && labels[j].symbol < no_symbols)
+                    lname = symbols[labels[j].symbol].name;
+                error_named("Attempt to jump to an unreachable label", lname);
                 addr = 0;
             }
             else {
@@ -2415,7 +2421,10 @@ static void transfer_routine_g(void)
         offset_of_next = new_pc + form_len;
 
         if (labels[j].offset < 0) {
-            error("Attempt to jump to an unreachable label");
+            char *lname = "(anon)";
+            if (labels[j].symbol >= 0 && labels[j].symbol < no_symbols)
+                lname = symbols[labels[j].symbol].name;
+            error_named("Attempt to jump to an unreachable label", lname);
             addr = 0;
         }
         else {


### PR DESCRIPTION
Added the label name to this error message:

> Error:  Attempt to jump to an unreachable label "Inside"

The error line is always the end of the function, because that's when we resolve jumps. I considered calling error_named_at(), but all we have is the symbol location, which could be either the label line or the jump line (whichever comes first). Decided it wasn't worth the confusion.

(Came up in discussion with Graham.)
