### PR TITLE
Avoid invalid/incorrect values being passed to @set_cursor

### DIFF
--- a/veneer.c
+++ b/veneer.c
@@ -111,10 +111,9 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
          w = 0 -> 33;\
          if (w == 0) w=80;\
          w2 = (w - maxw)/2;\
-         if (w2 < 1) w2 = 1;\
+         if (w2 < 3) w2 = 3;\
          style reverse;\
          @sub w2 2 -> w;\
-         if (w < 1) w = 1;\
          line = 5;\
          lc = 1;\
          @set_cursor 4 w;\

--- a/veneer.c
+++ b/veneer.c
@@ -110,7 +110,7 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
          @set_window 1;\
          w = 0 -> 33;\
          if (w == 0) w=80;\
-         w2 = (w - maxw)/2 + 1;\
+         w2 = (w - maxw)/2;\
          if (w2 < 1) w2 = 1;\
          style reverse;\
          @sub w2 2 -> w;\

--- a/veneer.c
+++ b/veneer.c
@@ -110,9 +110,11 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
          @set_window 1;\
          w = 0 -> 33;\
          if (w == 0) w=80;\
-         w2 = (w - maxw)/2;\
+         w2 = (w - maxw)/2 + 1;\
+         if (w2 < 1) w2 = 1;\
          style reverse;\
          @sub w2 2 -> w;\
+         if (w < 1) w = 1;\
          line = 5;\
          lc = 1;\
          @set_cursor 4 w;\


### PR DESCRIPTION
For a complete discussion see https://intfiction.org/t/bug-in-inform-6s-box-statement/56884/7

In short, when trying to center text, this routine will calculate
negative values for the cursor's X position: the user passes in a "maxw"
argument which is used with the screen width (w, from 0->33), to
calculate the X position:

    w2 = (w - max2)/2

But if the screen width is smaller than the max width, this will be
negative, which is not a valid value to pass to @set_cursor.

The same happens as w is recalculated:

    @sub w2 2 -> w;

This change simply ensures that, if these values are negative (or
rather, less than 1, since @set_cursor is 1-based), they're pulled back
to being 1.

At the same time a small bugfix is included: the calculation above
assumes a 0-based coordinate system, meaning boxes are always shifted
too far to the left. The change here adds 1 to the result in order to
accommodate the Z-machine's 1-based coordinate system.