### PR TITLE
Omit grammar table entries which have no verb, with a warning

### DIFF
--- a/errors.c
+++ b/errors.c
@@ -417,6 +417,19 @@ extern void warning_named(char *s1, char *s2)
     message(2,error_message_buff);
 }
 
+extern void warning_at(char *name, brief_location report_line)
+{   int i;
+    ErrorPosition E = ErrorReport;
+    if (nowarnings_switch) { no_suppressed_warnings++; return; }
+    export_brief_location(report_line, &ErrorReport);
+    snprintf(error_message_buff, ERROR_BUFLEN, "%s", name);
+    ellipsize_error_message_buff();
+    i = concise_switch; concise_switch = TRUE;
+    message(2,error_message_buff);
+    concise_switch = i;
+    ErrorReport = E;
+}
+
 extern void symtype_warning(char *context, char *name, char *type, char *wanttype)
 {
     if (nowarnings_switch) { no_suppressed_warnings++; return; }

--- a/header.h
+++ b/header.h
@@ -647,6 +647,13 @@ typedef struct memory_list_s
     size_t count;       /* number of items allocated */
 } memory_list;
 
+typedef struct brief_location_s
+{   int32 file_index;
+    int32 line_number;
+    int32 orig_file_index;
+    int32 orig_line_number;
+} brief_location;
+
 typedef struct identstruct_s
 {
     char text[MAX_IDENTIFIER_LENGTH+1];
@@ -673,6 +680,7 @@ typedef struct verbt {
     int *l; /* alloced array of grammar line indexes
                (positions in grammar_lines[]) */
     int size; /* allocated size of l */
+    brief_location line; /* originally defined at */
     int used; /* only set at locate_dead_grammar_lines() time */
 } verbt;
 
@@ -790,13 +798,6 @@ typedef struct debug_locations_s
     struct debug_locations_s *next;
     int reference_count;
 } debug_locations;
-
-typedef struct brief_location_s
-{   int32 file_index;
-    int32 line_number;
-    int32 orig_file_index;
-    int32 orig_line_number;
-} brief_location;
 
 typedef struct debug_location_beginning_s
 {   debug_locations *head;
@@ -2322,6 +2323,7 @@ extern void no_such_label(char *lname);
 extern void warning(char *s);
 extern void warning_numbered(char *s1, int val);
 extern void warning_named(char *s1, char *s2);
+extern void warning_at(char *name, brief_location report_line);
 extern void symtype_warning(char *context, char *name, char *type, char *wanttype);
 extern void dbnu_warning(char *type, char *name, brief_location report_line);
 extern void uncalled_routine_warning(char *type, char *name, brief_location report_line);

--- a/header.h
+++ b/header.h
@@ -670,7 +670,8 @@ typedef struct variableinfo_s {
 
 typedef struct verbt {
     int lines;
-    int *l; /* alloced array */
+    int *l; /* alloced array of grammar line indexes
+               (positions in grammar_lines[]) */
     int size; /* allocated size of l */
 } verbt;
 

--- a/header.h
+++ b/header.h
@@ -673,6 +673,7 @@ typedef struct verbt {
     int *l; /* alloced array of grammar line indexes
                (positions in grammar_lines[]) */
     int size; /* allocated size of l */
+    int used; /* only set at locate_dead_grammar_lines() time */
 } verbt;
 
 typedef struct actioninfo_s {
@@ -2837,6 +2838,7 @@ extern int32 *grammar_token_routine,
 extern void find_the_actions(void);
 extern void make_fake_action(void);
 extern assembly_operand action_of_name(char *name);
+extern void locate_dead_grammar_lines(void);
 extern void make_verb(void);
 extern void extend_verb(void);
 extern void list_verb_table(void);

--- a/inform.c
+++ b/inform.c
@@ -1028,6 +1028,7 @@ static void run_pass(void)
     sort_dictionary();
     if (track_unused_routines)
         locate_dead_functions();
+    locate_dead_grammar_lines();
     construct_storyfile();
 }
 

--- a/memory.c
+++ b/memory.c
@@ -616,6 +616,7 @@ static void set_trace_option(char *command)
         printf("  FREQ: show how efficient abbreviations were (same as -f)\n    (only meaningful with -e)\n");
         printf("  MAP: print memory map of the virtual machine (same as -z)\n");
         printf("    MAP=2: also show percentage of VM that each segment occupies\n");
+        printf("    MAP=3: also show number of bytes that each segment occupies\n");
         printf("  MEM: show internal memory allocations\n");
         printf("  OBJECTS: display the object table\n");
         printf("  PROPS: show attributes and properties defined\n");

--- a/tables.c
+++ b/tables.c
@@ -520,6 +520,12 @@ table format requested (producing number 2 format instead)");
     for (i=0; i<no_Inform_verbs; i++)
     {   p[grammar_table_at + i*2] = (mark/256);
         p[grammar_table_at + i*2 + 1] = (mark%256);
+        if (!Inform_verbs[i].used) {
+            /* This verb was marked unused at locate_dead_grammar_lines()
+               time. Omit the grammar lines. */
+            p[mark++] = 0;
+            continue;
+        }
         p[mark++] = Inform_verbs[i].lines;
         for (j=0; j<Inform_verbs[i].lines; j++)
         {   k = Inform_verbs[i].l[j];
@@ -1313,6 +1319,12 @@ table format requested (producing number 2 format instead)");
     for (i=0; i<no_Inform_verbs; i++) {
       j = mark + Write_RAM_At;
       WriteInt32(p+(grammar_table_at+4+i*4), j);
+      if (!Inform_verbs[i].used) {
+          /* This verb was marked unused at locate_dead_grammar_lines()
+             time. Omit the grammar lines. */
+          p[mark++] = 0;
+          continue;
+      }
       p[mark++] = Inform_verbs[i].lines;
       for (j=0; j<Inform_verbs[i].lines; j++) {
         int tok;

--- a/tables.c
+++ b/tables.c
@@ -109,7 +109,7 @@ extern void write_serial_number(char *buffer)
 #endif
 }
 
-static char percentage_buffer[32];
+static char percentage_buffer[64];
 
 static char *show_percentage(int32 x, int32 total)
 {
@@ -119,8 +119,11 @@ static char *show_percentage(int32 x, int32 total)
     else if (x == 0) {
         sprintf(percentage_buffer, "  ( --- )");
     }
-    else {
+    else if (memory_map_setting < 3) {
         sprintf(percentage_buffer, "  (%.1f %%)", (float)x * 100.0 / (float)total);
+    }
+    else {
+        sprintf(percentage_buffer, "  (%.1f %%, %d bytes)", (float)x * 100.0 / (float)total, x);
     }
     return percentage_buffer;
 }

--- a/verbs.c
+++ b/verbs.c
@@ -612,7 +612,7 @@ void locate_dead_grammar_lines()
 
     for (verb=0; verb<no_Inform_verbs; verb++) {
         if (!Inform_verbs[verb].used) {
-            warning_at("Verb declaration no longer has any verbs associated", Inform_verbs[verb].line);
+            warning_at("Verb declaration no longer has any verbs associated. Use \"Extend replace\" instead of \"Extend only\"?", Inform_verbs[verb].line);
         }
     }
 }

--- a/verbs.c
+++ b/verbs.c
@@ -525,7 +525,7 @@ static char *find_verb_by_number(int num)
     p=English_verb_list;
     while (p < English_verb_list+English_verb_list_size)
     {
-        int val = (p[1] << 8) | p[2];
+        int val = ((uchar)p[1] << 8) | (uchar)p[2];
         if (val == num) {
             return p+3;
         }

--- a/verbs.c
+++ b/verbs.c
@@ -612,7 +612,7 @@ void locate_dead_grammar_lines()
 
     for (verb=0; verb<no_Inform_verbs; verb++) {
         if (!Inform_verbs[verb].used) {
-            //### warning
+            warning_at("Verb declaration no longer has any verbs associated", Inform_verbs[verb].line);
         }
     }
 }
@@ -1005,6 +1005,7 @@ extern void make_verb(void)
         Inform_verbs[no_Inform_verbs].lines = 0;
         Inform_verbs[no_Inform_verbs].size = 4;
         Inform_verbs[no_Inform_verbs].l = my_malloc(sizeof(int) * Inform_verbs[no_Inform_verbs].size, "grammar lines for one verb");
+        Inform_verbs[no_Inform_verbs].line = get_brief_location(&ErrorReport);
         Inform_verbs[no_Inform_verbs].used = FALSE;
     }
 
@@ -1090,6 +1091,7 @@ extern void extend_verb(void)
         Inform_verbs[no_Inform_verbs].l = my_malloc(sizeof(int) * Inform_verbs[no_Inform_verbs].size, "grammar lines for one verb");
         for (k=0; k<l; k++)
             Inform_verbs[no_Inform_verbs].l[k] = Inform_verbs[Inform_verb].l[k];
+        Inform_verbs[no_Inform_verbs].line = get_brief_location(&ErrorReport);
         Inform_verbs[no_Inform_verbs].used = FALSE;
         Inform_verb = no_Inform_verbs++;
     }

--- a/verbs.c
+++ b/verbs.c
@@ -584,6 +584,39 @@ static int get_verb(void)
     return -1;
 }
 
+void locate_dead_grammar_lines()
+{
+    /* Run through the grammar table and check whether each entry is
+       associated with a verb word. (Some might have been detached by
+       "Extend only".)
+    */
+    int verb;
+    char *p;
+
+    for (verb=0; verb<no_Inform_verbs; verb++) {
+        Inform_verbs[verb].used = FALSE;
+    }
+    
+    p=English_verb_list;
+    while (p < English_verb_list+English_verb_list_size)
+    {
+        verb = ((uchar)p[1] << 8) | (uchar)p[2];
+        if (verb < 0 || verb >= no_Inform_verbs) {
+            error_named("An entry in the English verb list had an invalid verb number", p+3);
+        }
+        else {
+            Inform_verbs[verb].used = TRUE;
+        }
+        p=p+(uchar)p[0];
+    }
+
+    for (verb=0; verb<no_Inform_verbs; verb++) {
+        if (!Inform_verbs[verb].used) {
+            //### warning
+        }
+    }
+}
+
 /* ------------------------------------------------------------------------- */
 /*   Grammar lines for Verb/Extend directives.                               */
 /* ------------------------------------------------------------------------- */
@@ -972,6 +1005,7 @@ extern void make_verb(void)
         Inform_verbs[no_Inform_verbs].lines = 0;
         Inform_verbs[no_Inform_verbs].size = 4;
         Inform_verbs[no_Inform_verbs].l = my_malloc(sizeof(int) * Inform_verbs[no_Inform_verbs].size, "grammar lines for one verb");
+        Inform_verbs[no_Inform_verbs].used = FALSE;
     }
 
     for (i=0, pos=0; i<no_given; i++) {
@@ -1056,6 +1090,7 @@ extern void extend_verb(void)
         Inform_verbs[no_Inform_verbs].l = my_malloc(sizeof(int) * Inform_verbs[no_Inform_verbs].size, "grammar lines for one verb");
         for (k=0; k<l; k++)
             Inform_verbs[no_Inform_verbs].l[k] = Inform_verbs[Inform_verb].l[k];
+        Inform_verbs[no_Inform_verbs].used = FALSE;
         Inform_verb = no_Inform_verbs++;
     }
     else

--- a/verbs.c
+++ b/verbs.c
@@ -963,6 +963,10 @@ extern void make_verb(void)
             error("Z-code is limited to 255 verbs.");
             panic_mode_error_recovery(); return;
         }
+        if (no_Inform_verbs >= 65535) {
+            error("Inform is limited to 65535 verbs.");
+            panic_mode_error_recovery(); return;
+        }
         ensure_memory_list_available(&Inform_verbs_memlist, no_Inform_verbs+1);
         Inform_verb = no_Inform_verbs;
         Inform_verbs[no_Inform_verbs].lines = 0;
@@ -1017,6 +1021,10 @@ extern void extend_verb(void)
     {
         if (!glulx_mode && no_Inform_verbs >= 255) {
             error("Z-code is limited to 255 verbs.");
+            panic_mode_error_recovery(); return;
+        }
+        if (no_Inform_verbs >= 65535) {
+            error("Inform is limited to 65535 verbs.");
             panic_mode_error_recovery(); return;
         }
         ensure_memory_list_available(&Inform_verbs_memlist, no_Inform_verbs+1);


### PR DESCRIPTION
See issue https://github.com/DavidKinder/Inform6/issues/205 .

To support this, we add two fields to the `verbt` structure: a flag for whether the verb is used, and the source location where the verb was originally declared.

The flag is set late in compilation, in the locate_dead_grammar_lines() function. We generate warnings at this time. The flag is then checked during game file generation in tables.c.

Miscellaneous changes:

- Move the declaration of `struct brief_location_s` earlier in header.h.
- We didn't have a warning_at(char*, location) function. Now we do.
- The code that read `English_verb_list` in find_verb_by_number() was incorrectly used signed arithmetic. The `--trace VERBS` output was therefore incorrect with more than 128 verbs. (Only affected trace output, not compiled code.)
- We use 16-bit fields for verb number (both Z-code and Glulx, and also in the compiler itself). So more than 65535 verbs will cause problems. Added checks for this.
- We now support `--trace MAP=3`, which shows the byte size of each memory segment in addition to the start address, end address, and percentage size.
