### PR TITLE
Reject quoted symbols in various places

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -924,7 +924,7 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         dont_enter_into_symbol_table = TRUE;
         get_next_token();
         dont_enter_into_symbol_table = FALSE;
-        if (token_type != DQ_TT)
+        if (token_type != UQ_TT)
             return ebf_error_recover("string of switches", token_text);
         if (!ignore_switches_switch)
         {

--- a/header.h
+++ b/header.h
@@ -1232,6 +1232,7 @@ typedef struct operator_s
 #define SQ_TT        3                      /* no value                      */
 #define SEP_TT       4                      /* value = the _SEP code         */
 #define EOF_TT       5                      /* no value                      */
+#define UQ_TT        6                      /* no value                      */
 
 #define STATEMENT_TT      100               /* a statement keyword           */
 #define SEGMENT_MARKER_TT 101               /* with/has/class etc.           */

--- a/header.h
+++ b/header.h
@@ -1226,13 +1226,23 @@ typedef struct operator_s
 #define dstore_gm 3
 
 
-#define SYMBOL_TT    0                      /* value = index in symbol table */
-#define NUMBER_TT    1                      /* value = the number            */
-#define DQ_TT        2                      /* no value                      */
-#define SQ_TT        3                      /* no value                      */
-#define SEP_TT       4                      /* value = the _SEP code         */
-#define EOF_TT       5                      /* no value                      */
-#define UQ_TT        6                      /* no value                      */
+#define SYMBOL_TT    0                      /* symbol.
+                                               value = index in symbol table */
+#define NUMBER_TT    1                      /* number (including hex, float,
+                                               etc).
+                                               value = the number            */
+#define DQ_TT        2                      /* double-quoted string.
+                                               no value; look at the text    */
+#define SQ_TT        3                      /* single-quoted string.
+                                               no value                      */
+#define UQ_TT        4                      /* unquoted string; only when
+                                               dont_enter_into_symbol_table
+                                               is true.
+                                               no value                      */
+#define SEP_TT       5                      /* separator (punctuation).
+                                               value = the _SEP code         */
+#define EOF_TT       6                      /* end of file.
+                                               no value                      */
 
 #define STATEMENT_TT      100               /* a statement keyword           */
 #define SEGMENT_MARKER_TT 101               /* with/has/class etc.           */

--- a/lexer.c
+++ b/lexer.c
@@ -16,10 +16,9 @@ int total_source_line_count,            /* Number of source lines so far     */
                                            (generally as a result of an error
                                            message or the start of pass)     */
     dont_enter_into_symbol_table,       /* Return names as text (with
-                                           token type DQ_TT, i.e., as if
-                                           they had double-quotes around)
-                                           and not as entries in the symbol
-                                           table, when TRUE. If -2, only the
+                                           token type UQ_TT) and not as
+                                           entries in the symbol table,
+                                           when TRUE. If -2, only the
                                            keyword table is searched.        */
     return_sp_as_variable;              /* When TRUE, the word "sp" denotes
                                            the stack pointer variable
@@ -323,6 +322,8 @@ extern void describe_token_triple(const char *text, int32 value, int type)
         case DQ_TT:              printf("string \"%s\"", text);
                                  break;
         case SQ_TT:              printf("string '%s'", text);
+                                 break;
+        case UQ_TT:              printf("barestring %s", text);
                                  break;
         case SEP_TT:             printf("separator '%s'", text);
                                  break;
@@ -1936,7 +1937,7 @@ extern void get_next_token(void)
             }
 
             if (dont_enter_into_symbol_table)
-            {   circle[circle_position].type = DQ_TT;
+            {   circle[circle_position].type = UQ_TT;
                 circle[circle_position].value = 0;
                 if (dont_enter_into_symbol_table == -2)
                     interpret_identifier(lextexts[lex_index].text, circle_position, TRUE);

--- a/states.c
+++ b/states.c
@@ -85,7 +85,11 @@ static void parse_action(void)
         codegen_action = TRUE;
     }
     else
-    {   codegen_action = FALSE;
+    {
+        if (token_type != UQ_TT) {
+            ebf_error("name of action", token_text);
+        }
+        codegen_action = FALSE;
         AO2 = action_of_name(token_text);
     }
 

--- a/syntax.c
+++ b/syntax.c
@@ -455,7 +455,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         {   debug_flag = TRUE; continue;
         }
 
-        if (token_type != DQ_TT)
+        if (token_type != UQ_TT)
         {   if ((token_type == SEP_TT)
                 && (token_value == SEMICOLON_SEP)) break;
             ebf_error("local variable name or ';'", token_text);

--- a/verbs.c
+++ b/verbs.c
@@ -885,7 +885,7 @@ tokens in any line (unless you're compiling with library 6/3 or later)");
     get_next_token();
     dont_enter_into_symbol_table = FALSE;
 
-    if (token_type != DQ_TT)
+    if (token_type != UQ_TT)
     {   discard_token_location(beginning_debug_location);
         ebf_error("name of new or existing action", token_text);
         panic_mode_error_recovery();


### PR DESCRIPTION
- Local variable declarations
- Action names in `<Foo>` statements
- Action names in `Verb` directives
- The switches string in a `Switches` directive

The compiler was treating `"foo"` interchangeably with `foo` in those cases. This was never documented and I doubt it's in use anywhere. The quotes are now rejected.

To do this, get_next_token() now generates a new token type `UQ_TT` when it encounters an unquoted string *if* dont_enter_into_symbol_table is true. (If false, it generates `SYMBOL_TT` as before.)

Addresses https://github.com/DavidKinder/Inform6/issues/210 .
