### PR TITLE
Full expressions for switch cases

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -1304,7 +1304,7 @@ static void assembleg_macro(const assembly_instruction *AI)
             AMO_1 = AI->operand[1];
             AMO_2 = AI->operand[2];
             if ((AMO_0.type == LOCALVAR_OT) && (AMO_0.value == 0)) {
-                // addr is on the stack
+                /* addr is on the stack */
                 assembleg_store(temp_var3, stack_pointer);
                 assembleg_3(aload_gc, temp_var3, one_operand, AMO_1);
                 assembleg_3(aload_gc, temp_var3, zero_operand, AMO_2);
@@ -1320,7 +1320,7 @@ static void assembleg_macro(const assembly_instruction *AI)
             AMO_1 = AI->operand[1];
             AMO_2 = AI->operand[2];
             if ((AMO_0.type == LOCALVAR_OT) && (AMO_0.value == 0)) {
-                // addr is on the stack
+                /* addr is on the stack */
                 assembleg_store(temp_var3, stack_pointer);
                 assembleg_3(astore_gc, temp_var3, zero_operand, AMO_1);
                 assembleg_3(astore_gc, temp_var3, one_operand, AMO_2);

--- a/expressc.c
+++ b/expressc.c
@@ -2988,7 +2988,7 @@ assembly_operand code_generate(assembly_operand AO, int context, int label)
     }
 
     if (expr_trace_level >= 2)
-    {   printf("Raw parse tree:\n"); show_tree(AO, FALSE);
+    {   printf("Raw parse tree:\n"); show_tree(&AO, FALSE);
     }
 
     if (context == CONDITION_CONTEXT)
@@ -3008,7 +3008,7 @@ assembly_operand code_generate(assembly_operand AO, int context, int label)
             default: printf("* ILLEGAL *"); break;
         }
         printf(" context with annotated tree:\n");
-        show_tree(AO, TRUE);
+        show_tree(&AO, TRUE);
     }
 
     generate_code_from(AO.value, (context==VOID_CONTEXT));

--- a/expressp.c
+++ b/expressp.c
@@ -1468,10 +1468,10 @@ static void show_node(int n, int depth, int annotate)
     if (ET[n].right != -1) show_node(ET[n].right, depth, annotate);
 }
 
-extern void show_tree(assembly_operand AO, int annotate)
-{   if (AO.type == EXPRESSION_OT) show_node(AO.value, 0, annotate);
+extern void show_tree(const assembly_operand *AO, int annotate)
+{   if (AO->type == EXPRESSION_OT) show_node(AO->value, 0, annotate);
     else
-    {   printf("Constant: "); print_operand(&AO, annotate);
+    {   printf("Constant: "); print_operand(AO, annotate);
         printf("\n");
     }
 }
@@ -1948,7 +1948,7 @@ extern assembly_operand parse_expression(int context)
             if (AO.type == EXPRESSION_OT)
             {   if (expr_trace_level >= 3)
                 {   printf("Tree before lvalue checking:\n");
-                    show_tree(AO, FALSE);
+                    show_tree(&AO, FALSE);
                 }
                 if (!glulx_mode)
                     check_property_operator(AO.value);

--- a/header.h
+++ b/header.h
@@ -2686,6 +2686,7 @@ extern void  parse_code_block(int break_label, int continue_label,
 
 extern void  match_close_bracket(void);
 extern void  parse_statement(int break_label, int continue_label);
+extern void  parse_statement_singleexpr(assembly_operand AO);
 extern int   parse_label(void);
 
 /* ------------------------------------------------------------------------- */

--- a/header.h
+++ b/header.h
@@ -2369,7 +2369,7 @@ extern int glulx_system_constant_list[];
 extern int32 value_of_system_constant(int t);
 extern char *name_of_system_constant(int t);
 extern void clear_expression_space(void);
-extern void show_tree(assembly_operand AO, int annotate);
+extern void show_tree(const assembly_operand *AO, int annotate);
 extern assembly_operand parse_expression(int context);
 extern int test_for_incdec(assembly_operand AO);
 
@@ -2516,6 +2516,7 @@ extern void discard_token_location(debug_location_beginning beginning);
 extern debug_locations get_token_location_end(debug_location_beginning beginning);
 
 extern void describe_token_triple(const char *text, int32 value, int type);
+#define describe_current_token() describe_token_triple(token_text, token_value, token_type)
 /* The describe_token() macro works on both token_data and lexeme_data structs. */
 #define describe_token(t) describe_token_triple((t)->text, (t)->value, (t)->type)
 

--- a/header.h
+++ b/header.h
@@ -2372,6 +2372,7 @@ extern void clear_expression_space(void);
 extern void show_tree(const assembly_operand *AO, int annotate);
 extern assembly_operand parse_expression(int context);
 extern int test_for_incdec(assembly_operand AO);
+extern int  is_constant_op_list(const assembly_operand *o);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "files"                                          */

--- a/header.h
+++ b/header.h
@@ -2372,7 +2372,7 @@ extern void clear_expression_space(void);
 extern void show_tree(const assembly_operand *AO, int annotate);
 extern assembly_operand parse_expression(int context);
 extern int test_for_incdec(assembly_operand AO);
-extern int  is_constant_op_list(const assembly_operand *o);
+extern int  test_constant_op_list(const assembly_operand *AO, assembly_operand *ops_found, int max_ops_found);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "files"                                          */

--- a/states.c
+++ b/states.c
@@ -2743,6 +2743,39 @@ extern void parse_statement(int break_label, int continue_label)
         execution_never_reaches_here &= ~EXECSTATE_ENTIRE;
 }
 
+extern void parse_statement_singleexpr(assembly_operand AO)
+{
+    int res;
+    int saved_entire_flag;
+    
+    res = parse_named_label_statements();
+    if (!res)
+        return;
+
+    saved_entire_flag = (execution_never_reaches_here & EXECSTATE_ENTIRE);
+    if (execution_never_reaches_here)
+        execution_never_reaches_here |= EXECSTATE_ENTIRE;
+
+    code_generate(AO, VOID_CONTEXT, -1);
+    
+    if (vivc_flag) {
+        panic_mode_error_recovery();
+    }
+    else {
+        /* StatementTerminator... */
+        get_next_token();
+        if ((token_type != SEP_TT) || (token_value != SEMICOLON_SEP))
+        {   ebf_error("';'", token_text);
+            put_token_back();
+        }
+    }
+
+    if (saved_entire_flag)
+        execution_never_reaches_here |= EXECSTATE_ENTIRE;
+    else
+        execution_never_reaches_here &= ~EXECSTATE_ENTIRE;
+}
+
 /* ========================================================================= */
 /*   Data structure management routines                                      */
 /* ------------------------------------------------------------------------- */

--- a/states.c
+++ b/states.c
@@ -813,6 +813,8 @@ static void parse_statement_z(int break_label, int continue_label)
     if (token_type == EOF_TT)
     {   ebf_error("statement", token_text); return; }
 
+    /* If we don't see a keyword, this must be a function call or
+       other expression-with-side-effects. */
     if (token_type != STATEMENT_TT)
     {   put_token_back();
         AO = parse_expression(VOID_CONTEXT);
@@ -1783,6 +1785,8 @@ static void parse_statement_g(int break_label, int continue_label)
     if (token_type == EOF_TT)
     {   ebf_error("statement", token_text); return; }
 
+    /* If we don't see a keyword, this must be a function call or
+       other expression-with-side-effects. */
     if (token_type != STATEMENT_TT)
     {   put_token_back();
         AO = parse_expression(VOID_CONTEXT);
@@ -2743,6 +2747,15 @@ extern void parse_statement(int break_label, int continue_label)
         execution_never_reaches_here &= ~EXECSTATE_ENTIRE;
 }
 
+/* This does the same work as parse_statement(), but it's called if you've
+   already parsed an expression (in void context) and you want to generate
+   it as a statement. Essentially it's a copy of parse_statement() and
+   parse_statement_z/g(), except we skip straight to the "expression-with-
+   side-effects" bit and omit everything else.
+
+   The caller doesn't need to pass break_label/continue_label; they're
+   not used for this code path.
+*/
 extern void parse_statement_singleexpr(assembly_operand AO)
 {
     int res;

--- a/syntax.c
+++ b/syntax.c
@@ -726,6 +726,11 @@ extern void parse_code_block(int break_label, int continue_label,
                         
                         /* The rest of this is parallel to the
                            parse_switch_spec() case below. */
+                        /* Before you ask: yes, the spec_stacks values
+                           appear in the reverse order from how
+                           parse_switch_spec() would do it. The results
+                           are the same because we're just comparing
+                           temp_var1 with a bunch of constants. */
                         if (default_clause_made)
                             error("'default' must be the last 'switch' case");
                         

--- a/syntax.c
+++ b/syntax.c
@@ -256,7 +256,9 @@ extern int parse_directive(int internal_flag)
     return !(parse_given_directive(internal_flag));
 }
 
-/* Check what's coming up after a switch case value. */
+/* Check what's coming up after a switch case value.
+   (This is "switch sign" in the sense of "worm sign", not like a signed
+   variable.) */
 static int switch_sign(void)
 {
     if ((token_type == SEP_TT)&&(token_value == COLON_SEP))   return 1;
@@ -555,7 +557,9 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         /*  Only check for the form of a case switch if the initial token
             isn't double-quoted text, as that would mean it was a print_ret
             statement: this is a mild ambiguity in the grammar. 
-            Action statements also cannot be cases. */
+            Action statements also cannot be cases.
+            We don't try to handle parenthesized expressions as cases
+            at the top level. */
 
         if ((token_type != DQ_TT) && (token_type != SEP_TT))
         {   get_next_token();

--- a/syntax.c
+++ b/syntax.c
@@ -434,12 +434,6 @@ static void generate_switch_spec(assembly_operand switch_value, int label, int s
 
     sequence_point_follows = FALSE;
 
-    if (spec_sp >= MAX_SPEC_STACK)
-    {   error("At most 32 values can be given in a single 'switch' case");
-        panic_mode_error_recovery();
-        return;
-    }
-
     if ((spec_sp > max_equality_args) && (label_after == -1))
         label_after = next_label++;
 
@@ -771,6 +765,13 @@ extern void parse_code_block(int break_label, int continue_label,
                     constcount = test_constant_op_list(&AO, spec_stack, MAX_SPEC_STACK);
                     if (constcount && ((token_type == SEP_TT)&&(token_value == COLON_SEP))) {
                         int ix;
+
+                        if (constcount > MAX_SPEC_STACK)
+                        {   error("At most 32 values can be given in a single 'switch' case");
+                            panic_mode_error_recovery();
+                            continue;
+                        }
+
                         get_next_token();
                         /* Gotta fill in the spec_type values for the
                            spec_stacks. */

--- a/syntax.c
+++ b/syntax.c
@@ -341,9 +341,10 @@ static void parse_switch_spec(assembly_operand switch_value, int label,
                 ebf_error("action (or fake action) name", token_text);
             }
         }
-        else
+        else {
             spec_stack[spec_sp] =
       code_generate(parse_expression(CONSTANT_CONTEXT), CONSTANT_CONTEXT, -1);
+        }
 
         misc_keywords.enabled = TRUE;
         get_next_token();
@@ -677,7 +678,21 @@ extern void parse_code_block(int break_label, int continue_label,
                 /*  Decide: is this an ordinary statement, or the start
                     of a new case?  */
 
+                /*  Again, double-quoted text is a print_ret statement. */
                 if (token_type == DQ_TT) goto NotASwitchCase;
+
+                if ((token_type == SEP_TT)&&(token_value == OPENB_SEP)) {
+                    /* An open-paren means we need to parse a full
+                       expression. */
+                    assembly_operand AO;
+                    put_token_back();
+                    AO = parse_expression(VOID_CONTEXT);
+                    //### if this looks constant and is followed by colon/etc, get into parse_switch_spec and then continue
+                    /* Otherwise, treat this as a statement. */
+                    sequence_point_follows = TRUE;
+                    parse_statement_singleexpr(AO);
+                    continue;
+                }
 
                 unary_minus_flag
                     = ((token_type == SEP_TT)&&(token_value == MINUS_SEP));

--- a/syntax.c
+++ b/syntax.c
@@ -704,12 +704,16 @@ extern void parse_code_block(int break_label, int continue_label,
                     int constcount;
                     put_token_back();
                     AO = parse_expression(VOID_CONTEXT);
-                    /* If this expression is a constant or a list of constants,
-                       and it's followed by a colon, we'll handle it as a
-                       switch case. */
+                    /* If this expression is followed by a colon, we'll
+                       handle it as a switch case. */
                     constcount = test_constant_op_list(&AO, spec_stack, MAX_SPEC_STACK);
-                    if (constcount && ((token_type == SEP_TT)&&(token_value == COLON_SEP))) {
+                    if ((token_type == SEP_TT)&&(token_value == COLON_SEP)) {
                         int ix;
+
+                        if (!constcount)
+                        {
+                            ebf_error("constant", "<expression>");
+                        }
 
                         if (constcount > MAX_SPEC_STACK)
                         {   error("At most 32 values can be given in a single 'switch' case");


### PR DESCRIPTION
We can now handle switch cases which are full expressions, rather than just looking for bare literals and symbols. The expression must still evaluate to a constant, but now we can handle parentheses and constant-folded arithmetic.

```
Constant CONST = 5;

! These have always worked.
switch (x) {
  0: return 0;
  1: return 1;
  -2: return -2;
}

! These now also work.
switch (x) {
  (0): return 0;
  (-(1)): return -1;
  (CONST): return 5;
  (CONST+1): return 6;
}
```

For reasons of backwards compatibility, the expression must be wrapped in parens. `-(1):` would not be a valid case.

We also support lists of expressions. Expression parsing applies as long as the first value is wrapped in parens. Wrapping the entire list in parens also works, because of the way Inform parses comma expressions.

```
switch (x) {
  1, 2, 3: return 0;                   ! old style
  (4), (CONST), (CONST+1): return 1;   ! new style
  (10), CONST+6, CONST+7: return 2;    ! this also works
  (20, CONST+16, CONST+17): return 3;  ! as does this
}
```

Caveats: 

- The `to` keyword does not support expressions. You cannot say `(CONST) to (CONST+5):` as a case. (Inform's weak handling of contextual keywords causes a lot of parsing headaches -- c.f. https://github.com/DavidKinder/Inform6/issues/163 .)
- Case expressions only work within a `switch` statement. Top-level action cases must still be bare action names. 

Covers https://github.com/DavidKinder/Inform6/issues/211 .

Implementation:

- parse_code_block() has new code to recognize `EXPR:` as a case if `EXPR` starts with an open-paren.
- parse_switch_spec() has been divided into two stages, parse_switch_spec() and generate_switch_spec(). (The case-expression code does its own parsing and jumps straight to the generate_switch_spec() stage.)
- test_constant_op_list() is a utility function: examine a just-parsed expression to see if it's a constant or comma-separated list of constants. If so, return the values.
- parse_statement_singleexpr() is a cut-down version of parse_statement() which generates code for a expression that you just parsed. (We need this for when we look at an expression which turns out *not* to be a switch case.)

Also in this changelist:

- The show_tree() function now takes `const assembly_operand *`, consistent with print_operand().
- A describe_current_token() macro -- like describe_token() but for the current token. (Useful for debugging, but not currently used.)
- Comments here and there.

