### PR TITLE
Added error_fmt() call

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -3111,10 +3111,9 @@ static void parse_assembly_z(void)
                 case TWO: max = 32; break;
             }
             if ((custom_opcode_z.code < min) || (custom_opcode_z.code >= max))
-            {   char range[32];
-                sprintf(range, "%d to %d", min, max-1);
-            error_named("For this operand type, opcode number must be in range",
-                    range);
+            {
+                error_fmt("For this operand type, opcode number must be in range %d to %d",
+                          min, max-1);
                 custom_opcode_z.code = min;
             }
         }

--- a/errors.c
+++ b/errors.c
@@ -215,7 +215,7 @@ extern void fatalerror_named(char *m, char *fn)
     fatalerror(error_message_buff);
 }
 
-extern void memory_out_error(int32 size, int32 howmany, char *name)
+extern void fatalerror_memory_out(int32 size, int32 howmany, char *name)
 {   if (howmany == 1)
         snprintf(error_message_buff, ERROR_BUFLEN,
             "Run out of memory allocating %d bytes for %s", size, name);

--- a/errors.c
+++ b/errors.c
@@ -416,13 +416,6 @@ extern void warning_fmt(const char *format, ...)
     message(2,error_message_buff);
 }
 
-extern void warning_numbered(char *s1, int val)
-{   if (nowarnings_switch) { no_suppressed_warnings++; return; }
-    snprintf(error_message_buff, ERROR_BUFLEN,"%s %d.", s1, val);
-    ellipsize_error_message_buff();
-    message(2,error_message_buff);
-}
-
 extern void warning_named(char *s1, char *s2)
 {
     if (nowarnings_switch) { no_suppressed_warnings++; return; }

--- a/errors.c
+++ b/errors.c
@@ -289,13 +289,6 @@ extern void error_named(char *s1, char *s2)
     error(error_message_buff);
 }
 
-extern void error_numbered(char *s1, int val)
-{
-    snprintf(error_message_buff, ERROR_BUFLEN,"%s %d.",s1,val);
-    ellipsize_error_message_buff();
-    error(error_message_buff);
-}
-
 extern void error_named_at(char *s1, char *s2, brief_location report_line)
 {   int i;
 

--- a/errors.c
+++ b/errors.c
@@ -405,6 +405,17 @@ extern void warning(char *s1)
     message(2,s1);
 }
 
+extern void warning_fmt(const char *format, ...)
+{
+    if (nowarnings_switch) { no_suppressed_warnings++; return; }
+    va_list argument_pointer;
+    va_start(argument_pointer, format);
+    vsnprintf(error_message_buff, ERROR_BUFLEN, format, argument_pointer);
+    va_end(argument_pointer);
+    ellipsize_error_message_buff();
+    message(2,error_message_buff);
+}
+
 extern void warning_numbered(char *s1, int val)
 {   if (nowarnings_switch) { no_suppressed_warnings++; return; }
     snprintf(error_message_buff, ERROR_BUFLEN,"%s %d.", s1, val);

--- a/errors.c
+++ b/errors.c
@@ -313,10 +313,6 @@ extern void error_named_at(char *s1, char *s2, brief_location report_line)
     ErrorReport = E; concise_switch = i;
 }
 
-extern void no_such_label(char *lname)
-{   error_named("No such label as",lname);
-}
-
 extern void ebf_error(char *s1, char *s2)
 {   snprintf(error_message_buff, ERROR_BUFLEN, "Expected %s but found %s", s1, s2);
     ellipsize_error_message_buff();

--- a/errors.c
+++ b/errors.c
@@ -199,6 +199,16 @@ extern void fatalerror(char *s)
     exit(1);
 }
 
+extern void fatalerror_fmt(const char *format, ...)
+{
+    va_list argument_pointer;
+    va_start(argument_pointer, format);
+    vsnprintf(error_message_buff, ERROR_BUFLEN, format, argument_pointer);
+    va_end(argument_pointer);
+    ellipsize_error_message_buff();
+    fatalerror(error_message_buff);
+}
+
 extern void fatalerror_named(char *m, char *fn)
 {   snprintf(error_message_buff, ERROR_BUFLEN, "%s \"%s\"", m, fn);
     ellipsize_error_message_buff();

--- a/errors.c
+++ b/errors.c
@@ -273,6 +273,16 @@ extern void error(char *s)
     message(1,s);
 }
 
+extern void error_fmt(const char *format, ...)
+{
+    va_list argument_pointer;
+    va_start(argument_pointer, format);
+    vsnprintf(error_message_buff, ERROR_BUFLEN, format, argument_pointer);
+    va_end(argument_pointer);
+    ellipsize_error_message_buff();
+    error(error_message_buff);
+}
+
 extern void error_named(char *s1, char *s2)
 {   snprintf(error_message_buff, ERROR_BUFLEN,"%s \"%s\"",s1,s2);
     ellipsize_error_message_buff();

--- a/expressp.c
+++ b/expressp.c
@@ -1379,23 +1379,24 @@ static void emit_token(const token_data *t)
        for 32-bit arithmetic. */
 
     if (!glulx_mode && ((x<-32768) || (x > 32767)))
-    {   char folding_error[40];
+    {
         int32 ov1 = (o1.value >= 0x8000) ? (o1.value - 0x10000) : o1.value;
         int32 ov2 = (o2.value >= 0x8000) ? (o2.value - 0x10000) : o2.value;
+        char op = '?';
         switch(t->value)
         {
             case PLUS_OP:
-                sprintf(folding_error, "%d + %d = %d", ov1, ov2, x);
+                op = '+';
                 break;
             case MINUS_OP:
-                sprintf(folding_error, "%d - %d = %d", ov1, ov2, x);
+                op = '-';
                 break;
             case TIMES_OP:
-                sprintf(folding_error, "%d * %d = %d", ov1, ov2, x);
+                op = '*';
                 break;
         }
-        error_named("Signed arithmetic on compile-time constants overflowed \
-the range -32768 to +32767:", folding_error);
+        error_fmt("Signed arithmetic on compile-time constants overflowed \
+the range -32768 to +32767 (%d %c %d = %d)", ov1, op, ov2, x);
     }
 
     FoldConstant:

--- a/files.c
+++ b/files.c
@@ -655,10 +655,8 @@ static void output_file_g(void)
     /* And check if the user has requested a specific version. */
     if (requested_glulx_version) {
       if (requested_glulx_version < VersionNum) {
-        static char error_message_buff[256];
-        sprintf(error_message_buff, "Version 0x%08lx requested, but \
-game features require version 0x%08lx", (long)requested_glulx_version, (long)VersionNum);
-        warning(error_message_buff);
+        warning_fmt("Version 0x%08lx requested, but game features require version 0x%08lx",
+                    (long)requested_glulx_version, (long)VersionNum);
       }
       else {
         VersionNum = requested_glulx_version;

--- a/header.h
+++ b/header.h
@@ -2318,6 +2318,7 @@ extern int  no_errors, no_warnings, no_suppressed_warnings, no_compiler_errors;
 extern ErrorPosition ErrorReport;
 
 extern void fatalerror(char *s) NORETURN;
+extern void fatalerror_fmt(const char *format, ...);
 extern void fatalerror_named(char *s1, char *s2) NORETURN;
 extern void memory_out_error(int32 size, int32 howmany, char *name) NORETURN;
 extern void error_max_dynamic_strings(int index);

--- a/header.h
+++ b/header.h
@@ -2323,6 +2323,7 @@ extern void memory_out_error(int32 size, int32 howmany, char *name) NORETURN;
 extern void error_max_dynamic_strings(int index);
 extern void error_max_abbreviations(int index);
 extern void error(char *s);
+extern void error_fmt(const char *format, ...);
 extern void error_named(char *s1, char *s2);
 extern void error_numbered(char *s1, int val);
 extern void error_named_at(char *s1, char *s2, brief_location report_line);

--- a/header.h
+++ b/header.h
@@ -2331,7 +2331,6 @@ extern void ebf_error(char *s1, char *s2);
 extern void ebf_symbol_error(char *s1, char *name, char *type, brief_location report_line);
 extern void char_error(char *s, int ch);
 extern void unicode_char_error(char *s, int32 uni);
-extern void no_such_label(char *lname);
 extern void warning(char *s);
 extern void warning_fmt(const char *format, ...);
 extern void warning_named(char *s1, char *s2);

--- a/header.h
+++ b/header.h
@@ -2321,8 +2321,7 @@ extern void fatalerror(char *s) NORETURN;
 extern void fatalerror_fmt(const char *format, ...) NORETURN;
 extern void fatalerror_named(char *s1, char *s2) NORETURN;
 extern void fatalerror_memory_out(int32 size, int32 howmany, char *name) NORETURN;
-extern void error_max_dynamic_strings(int index);
-extern void error_max_abbreviations(int index);
+
 extern void error(char *s);
 extern void error_fmt(const char *format, ...);
 extern void error_named(char *s1, char *s2);
@@ -2331,6 +2330,9 @@ extern void ebf_error(char *s1, char *s2);
 extern void ebf_symbol_error(char *s1, char *name, char *type, brief_location report_line);
 extern void char_error(char *s, int ch);
 extern void unicode_char_error(char *s, int32 uni);
+extern void error_max_dynamic_strings(int index);
+extern void error_max_abbreviations(int index);
+
 extern void warning(char *s);
 extern void warning_fmt(const char *format, ...);
 extern void warning_named(char *s1, char *s2);
@@ -2339,6 +2341,7 @@ extern void symtype_warning(char *context, char *name, char *type, char *wanttyp
 extern void dbnu_warning(char *type, char *name, brief_location report_line);
 extern void uncalled_routine_warning(char *type, char *name, brief_location report_line);
 extern void obsolete_warning(char *s1);
+
 extern int  compiler_error(char *s);
 extern int  compiler_error_named(char *s1, char *s2);
 extern void print_sorry_message(void);

--- a/header.h
+++ b/header.h
@@ -2325,7 +2325,6 @@ extern void error_max_abbreviations(int index);
 extern void error(char *s);
 extern void error_fmt(const char *format, ...);
 extern void error_named(char *s1, char *s2);
-extern void error_numbered(char *s1, int val);
 extern void error_named_at(char *s1, char *s2, brief_location report_line);
 extern void ebf_error(char *s1, char *s2);
 extern void ebf_symbol_error(char *s1, char *name, char *type, brief_location report_line);

--- a/header.h
+++ b/header.h
@@ -2332,6 +2332,7 @@ extern void char_error(char *s, int ch);
 extern void unicode_char_error(char *s, int32 uni);
 extern void no_such_label(char *lname);
 extern void warning(char *s);
+extern void warning_fmt(const char *format, ...);
 extern void warning_numbered(char *s1, int val);
 extern void warning_named(char *s1, char *s2);
 extern void warning_at(char *name, brief_location report_line);

--- a/header.h
+++ b/header.h
@@ -2318,7 +2318,7 @@ extern int  no_errors, no_warnings, no_suppressed_warnings, no_compiler_errors;
 extern ErrorPosition ErrorReport;
 
 extern void fatalerror(char *s) NORETURN;
-extern void fatalerror_fmt(const char *format, ...);
+extern void fatalerror_fmt(const char *format, ...) NORETURN;
 extern void fatalerror_named(char *s1, char *s2) NORETURN;
 extern void memory_out_error(int32 size, int32 howmany, char *name) NORETURN;
 extern void error_max_dynamic_strings(int index);

--- a/header.h
+++ b/header.h
@@ -2333,7 +2333,6 @@ extern void unicode_char_error(char *s, int32 uni);
 extern void no_such_label(char *lname);
 extern void warning(char *s);
 extern void warning_fmt(const char *format, ...);
-extern void warning_numbered(char *s1, int val);
 extern void warning_named(char *s1, char *s2);
 extern void warning_at(char *name, brief_location report_line);
 extern void symtype_warning(char *context, char *name, char *type, char *wanttype);

--- a/header.h
+++ b/header.h
@@ -2320,7 +2320,7 @@ extern ErrorPosition ErrorReport;
 extern void fatalerror(char *s) NORETURN;
 extern void fatalerror_fmt(const char *format, ...) NORETURN;
 extern void fatalerror_named(char *s1, char *s2) NORETURN;
-extern void memory_out_error(int32 size, int32 howmany, char *name) NORETURN;
+extern void fatalerror_memory_out(int32 size, int32 howmany, char *name) NORETURN;
 extern void error_max_dynamic_strings(int index);
 extern void error_max_abbreviations(int index);
 extern void error(char *s);

--- a/inform.c
+++ b/inform.c
@@ -141,17 +141,17 @@ static void select_target(int targ)
 
     if (INDIV_PROP_START < 256) {
         INDIV_PROP_START = 256;
-        warning_numbered("INDIV_PROP_START should be at least 256 in Glulx. Setting to", INDIV_PROP_START);
+        warning_fmt("INDIV_PROP_START should be at least 256 in Glulx; setting to %d", INDIV_PROP_START);
     }
 
     if (NUM_ATTR_BYTES % 4 != 3) {
       NUM_ATTR_BYTES += (3 - (NUM_ATTR_BYTES % 4)); 
-      warning_numbered("NUM_ATTR_BYTES must be a multiple of four, plus three. Increasing to", NUM_ATTR_BYTES);
+      warning_fmt("NUM_ATTR_BYTES must be a multiple of four, plus three; increasing to %d", NUM_ATTR_BYTES);
     }
 
     if (DICT_CHAR_SIZE != 1 && DICT_CHAR_SIZE != 4) {
       DICT_CHAR_SIZE = 4;
-      warning_numbered("DICT_CHAR_SIZE must be either 1 or 4. Setting to", DICT_CHAR_SIZE);
+      warning_fmt("DICT_CHAR_SIZE must be either 1 or 4; setting to %d", DICT_CHAR_SIZE);
     }
   }
 

--- a/inform.c
+++ b/inform.c
@@ -162,15 +162,15 @@ static void select_target(int targ)
 
   if (DICT_WORD_SIZE > MAX_DICT_WORD_SIZE) {
     DICT_WORD_SIZE = MAX_DICT_WORD_SIZE;
-    warning_numbered(
-      "DICT_WORD_SIZE cannot exceed MAX_DICT_WORD_SIZE; resetting", 
+    warning_fmt(
+      "DICT_WORD_SIZE cannot exceed MAX_DICT_WORD_SIZE; resetting to %d", 
       MAX_DICT_WORD_SIZE);
     /* MAX_DICT_WORD_SIZE can be increased in header.h without fear. */
   }
   if (NUM_ATTR_BYTES > MAX_NUM_ATTR_BYTES) {
     NUM_ATTR_BYTES = MAX_NUM_ATTR_BYTES;
-    warning_numbered(
-      "NUM_ATTR_BYTES cannot exceed MAX_NUM_ATTR_BYTES; resetting",
+    warning_fmt(
+      "NUM_ATTR_BYTES cannot exceed MAX_NUM_ATTR_BYTES; resetting to %d",
       MAX_NUM_ATTR_BYTES);
     /* MAX_NUM_ATTR_BYTES can be increased in header.h without fear. */
   }

--- a/lexer.c
+++ b/lexer.c
@@ -1922,11 +1922,10 @@ extern void get_next_token(void)
             lexaddc(0);
 
             if (n > MAX_IDENTIFIER_LENGTH)
-            {   char bad_length[100];
-                sprintf(bad_length,
-                    "Name exceeds the maximum length of %d characters:",
-                         MAX_IDENTIFIER_LENGTH);
-                error_named(bad_length, lextexts[lex_index].text);
+            {
+                error_fmt(
+                    "Name exceeds the maximum length of %d characters: \"%s\"",
+                    MAX_IDENTIFIER_LENGTH, lextexts[lex_index].text);
                 /* Eat any further extra characters in the identifier */
                 while (((tokeniser_grid[lookahead] == IDENTIFIER_CODE)
                         || (tokeniser_grid[lookahead] == DIGIT_CODE)))

--- a/memory.c
+++ b/memory.c
@@ -12,7 +12,7 @@ size_t malloced_bytes=0;               /* Total amount of memory allocated   */
 
 /* Wrappers for malloc(), realloc(), etc.
 
-   Note that all of these functions call memory_out_error() on failure.
+   Note that all of these functions call fatalerror_memory_out() on failure.
    This is a fatal error and does not return. However, we check my_malloc()
    return values anyway as a matter of good habit.
  */
@@ -26,7 +26,7 @@ extern void *my_malloc(size_t size, char *whatfor)
     if (size==0) return(NULL);
     c=(char _huge *)halloc(size,1);
     malloced_bytes+=size;
-    if (c==0) memory_out_error(size, 1, whatfor);
+    if (c==0) fatalerror_memory_out(size, 1, whatfor);
     return(c);
 }
 
@@ -39,7 +39,7 @@ extern void my_realloc(void *pointer, size_t oldsize, size_t size,
     }
     c=halloc(size,1);
     malloced_bytes+=(size-oldsize);
-    if (c==0) memory_out_error(size, 1, whatfor);
+    if (c==0) fatalerror_memory_out(size, 1, whatfor);
     if (memout_switch)
         printf("Increasing allocation from %ld to %ld bytes for %s was (%08lx) now (%08lx)\n",
             (long int) oldsize, (long int) size, whatfor,
@@ -58,7 +58,7 @@ extern void *my_calloc(size_t size, size_t howmany, char *whatfor)
     if ((size*howmany) == 0) return(NULL);
     c=(void _huge *)halloc(howmany*size,1);
     malloced_bytes+=size*howmany;
-    if (c==0) memory_out_error(size, howmany, whatfor);
+    if (c==0) fatalerror_memory_out(size, howmany, whatfor);
     return(c);
 }
 
@@ -71,7 +71,7 @@ extern void my_recalloc(void *pointer, size_t size, size_t oldhowmany,
     }
     c=(void _huge *)halloc(size*howmany,1);
     malloced_bytes+=size*(howmany-oldhowmany);
-    if (c==0) memory_out_error(size, howmany, whatfor);
+    if (c==0) fatalerror_memory_out(size, howmany, whatfor);
     if (memout_switch)
         printf("Increasing allocation from %ld to %ld bytes: array (%ld entries size %ld) for %s was (%08lx) now (%08lx)\n",
             ((long int)size) * ((long int)oldhowmany),
@@ -90,7 +90,7 @@ extern void *my_malloc(size_t size, char *whatfor)
     if (size==0) return(NULL);
     c=malloc(size);
     malloced_bytes+=size;
-    if (c==0) memory_out_error(size, 1, whatfor);
+    if (c==0) fatalerror_memory_out(size, 1, whatfor);
     if (memout_switch)
         printf("Allocating %ld bytes for %s at (%08lx)\n",
             (long int) size,whatfor,(long int) c);
@@ -106,7 +106,7 @@ extern void my_realloc(void *pointer, size_t oldsize, size_t size,
     }
     c=realloc(*(int **)pointer,  size);
     malloced_bytes+=(size-oldsize);
-    if (c==0) memory_out_error(size, 1, whatfor);
+    if (c==0) fatalerror_memory_out(size, 1, whatfor);
     if (memout_switch)
         printf("Increasing allocation from %ld to %ld bytes for %s was (%08lx) now (%08lx)\n",
             (long int) oldsize, (long int) size, whatfor,
@@ -120,7 +120,7 @@ extern void *my_calloc(size_t size, size_t howmany, char *whatfor)
     if (size*howmany==0) return(NULL);
     c=calloc(howmany, size);
     malloced_bytes+=size*howmany;
-    if (c==0) memory_out_error(size, howmany, whatfor);
+    if (c==0) fatalerror_memory_out(size, howmany, whatfor);
     if (memout_switch)
         printf("Allocating %ld bytes: array (%ld entries size %ld) \
 for %s at (%08lx)\n",
@@ -139,7 +139,7 @@ extern void my_recalloc(void *pointer, size_t size, size_t oldhowmany,
     }
     c=realloc(*(int **)pointer, size*howmany); 
     malloced_bytes+=size*(howmany-oldhowmany);
-    if (c==0) memory_out_error(size, howmany, whatfor);
+    if (c==0) fatalerror_memory_out(size, howmany, whatfor);
     if (memout_switch)
         printf("Increasing allocation from %ld to %ld bytes: array (%ld entries size %ld) for %s was (%08lx) now (%08lx)\n",
             ((long int)size) * ((long int)oldhowmany),

--- a/objects.c
+++ b/objects.c
@@ -120,8 +120,8 @@ game to get an extra 16)");
     if (no_attributes==NUM_ATTR_BYTES*8) {
       discard_token_location(beginning_debug_location);
       error_fmt(
-        "All attributes already declared -- increase NUM_ATTR_BYTES to use \
-more than %d", 
+        "All %d attributes already declared -- increase NUM_ATTR_BYTES to use \
+more", 
         NUM_ATTR_BYTES*8);
       panic_mode_error_recovery(); 
       put_token_back();

--- a/objects.c
+++ b/objects.c
@@ -1498,13 +1498,12 @@ not 'private':", token_text);
             }
             else
             if (symbols[defined_this_segment[i]].value == symbols[token_value].value)
-            {   char error_b[128+2*MAX_IDENTIFIER_LENGTH];
-                sprintf(error_b,
+            {
+                error_fmt(
                     "Property given twice in the same declaration, because \
-the names '%s' and '%s' actually refer to the same property",
+the names \"%s\" and \"%s\" actually refer to the same property",
                     symbols[defined_this_segment[i]].name,
                     symbols[token_value].name);
-                error(error_b);
             }
 
         property_name_symbol = token_value;

--- a/objects.c
+++ b/objects.c
@@ -347,12 +347,10 @@ Advanced game to get 32 more)");
     }
     else {
         if (no_properties==INDIV_PROP_START) {
-            char error_b[128];
             discard_token_location(beginning_debug_location);
-            sprintf(error_b,
+            error_fmt(
                 "All %d properties already declared (increase INDIV_PROP_START to get more)",
                 INDIV_PROP_START-3);
-            error(error_b);
             panic_mode_error_recovery(); 
             put_token_back();
             return;

--- a/objects.c
+++ b/objects.c
@@ -1233,13 +1233,12 @@ not 'private':", token_text);
             }
             else
             if (symbols[defined_this_segment[i]].value == symbols[token_value].value)
-            {   char error_b[128+2*MAX_IDENTIFIER_LENGTH];
-                sprintf(error_b,
+            {
+                error_fmt(
                     "Property given twice in the same declaration, because \
-the names '%s' and '%s' actually refer to the same property",
+the names \"%s\" and \"%s\" actually refer to the same property",
                     symbols[defined_this_segment[i]].name,
                     symbols[token_value].name);
-                error(error_b);
             }
 
         property_name_symbol = token_value;

--- a/objects.c
+++ b/objects.c
@@ -119,9 +119,9 @@ game to get an extra 16)");
  else {
     if (no_attributes==NUM_ATTR_BYTES*8) {
       discard_token_location(beginning_debug_location);
-      error_numbered(
+      error_fmt(
         "All attributes already declared -- increase NUM_ATTR_BYTES to use \
-more than", 
+more than %d", 
         NUM_ATTR_BYTES*8);
       panic_mode_error_recovery(); 
       put_token_back();

--- a/syntax.c
+++ b/syntax.c
@@ -716,7 +716,7 @@ extern void parse_code_block(int break_label, int continue_label,
                         }
 
                         if (constcount > MAX_SPEC_STACK)
-                        {   error("At most 32 values can be given in a single 'switch' case");
+                        {   error_fmt("At most %d values can be given in a single 'switch' case", MAX_SPEC_STACK);
                             panic_mode_error_recovery();
                             continue;
                         }

--- a/syntax.c
+++ b/syntax.c
@@ -470,7 +470,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         }
 
         if (no_locals == MAX_LOCAL_VARIABLES-1)
-        {   error_numbered("Too many local variables for a routine; max is",
+        {   error_fmt("Too many local variables for a routine; max is %d",
                 MAX_LOCAL_VARIABLES-1);
             panic_mode_error_recovery();
             break;

--- a/syntax.c
+++ b/syntax.c
@@ -323,7 +323,7 @@ static void parse_switch_spec(assembly_operand switch_value, int label,
 
     do
     {   if (spec_sp >= MAX_SPEC_STACK)
-        {   error("At most 32 values can be given in a single 'switch' case");
+        {   error_fmt("At most %d values can be given in a single 'switch' case", MAX_SPEC_STACK);
             panic_mode_error_recovery();
             return;
         }

--- a/tables.c
+++ b/tables.c
@@ -693,11 +693,10 @@ or less.");
     }
 
     if (excess > 0)
-    {   char memory_full_error[80];
-        sprintf(memory_full_error,
+    {
+        fatalerror_fmt(
             "The %s exceeds version-%d limit (%dK) by %d bytes",
              output_called, version_number, limit, excess);
-        fatalerror(memory_full_error);
     }
 
     /*  --------------------------- Offsets -------------------------------- */

--- a/tables.c
+++ b/tables.c
@@ -730,26 +730,24 @@ or less.");
          */
         excess = code_length + code_offset - (scale_factor*((int32) 0x10000L));
         if (excess > 0)
-        {   char code_full_error[80];
-            sprintf(code_full_error,
+        {
+            fatalerror_fmt(
                 "The code area limit has been exceeded by %d bytes",
                  excess);
-            fatalerror(code_full_error);
         }
 
         excess = strings_length + strings_offset - (scale_factor*((int32) 0x10000L));
         if (excess > 0)
-        {   char strings_full_error[140];
+        {
             if (oddeven_packing_switch)
-                sprintf(strings_full_error,
+                fatalerror_fmt(
                     "The strings area limit has been exceeded by %d bytes",
                      excess);
             else
-                sprintf(strings_full_error,
+                fatalerror_fmt(
                     "The code+strings area limit has been exceeded by %d bytes. \
  Try running Inform again with -B on the command line.",
                      excess);
-            fatalerror(strings_full_error);
         }
     }
     else

--- a/verbs.c
+++ b/verbs.c
@@ -552,7 +552,7 @@ static void register_verb(char *English_verb, int number)
        MAX_DICT_WORD_SIZE is 40.) */
     entrysize = strlen(English_verb)+4;
     if (entrysize > MAX_VERB_WORD_SIZE+4)
-        error_numbered("Verb word is too long -- max length is", MAX_VERB_WORD_SIZE);
+        error_fmt("Verb word is too long -- max length is %d", MAX_VERB_WORD_SIZE);
     ensure_memory_list_available(&English_verb_list_memlist, English_verb_list_size + entrysize);
     top = English_verb_list + English_verb_list_size;
     English_verb_list_size += entrysize;


### PR DESCRIPTION
Quite a few places in the code were using sprintf() to construct an error message in a temporary buffer, and then passing the buffer to error() or warning(), etc. This is untidy. Also you have to constantly think about buffer overflow.

I have replaced all of these with calls to new varargs functions:

```
extern void fatalerror_fmt(const char *format, ...) NORETURN
extern void error_fmt(const char *format, ...);
extern void warning_fmt(const char *format, ...);
```

These calls all call vsnprintf(), with a limit of ERROR_BUFLEN, so we are consistently protected from buffer overflow in all error calls.

(We already had a varargs debug_file_printf() call, so this doesn't hurt our compiler portability.)

In doing this, I was able to get rid of error_numbered() and warning_numbered(), so we're not gaining too many lines of code. I also got rid of no_such_label() which was entirely unused.

Also renamed memory_out_error() to fatalerror_memory_out() for consistency's sake.

