### PR TITLE
Update some veneer routines for v3

### DIFF
--- a/veneer.c
+++ b/veneer.c
@@ -679,6 +679,16 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
 
         "CP__Tab",
         "x id n l;\
+         #IFV3;\
+         while (1)\
+         {   n = x->0;\
+             if (n == 0) break;\
+             x++;\
+             if (id == (n & 31)) return x;\
+             l = (n/32)+1;\
+             x = x + l;\
+         }\
+         #IFNOT;\
          while ((n=0->x) ~= 0)\
          {   if (n & $80) { x++; l = (0->x) & $3f; }\
              else { if (n & $40) l=2; else l=1; }\
@@ -686,6 +696,7 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
              if ((n & $3f) == id) return x;\
              x = x + l;\
          }\
+         #ENDIF;\
          if (id<0) return x+1; rfalse; ]", "", "", "", "", ""
     },
     {   /*  Cl__Ms:   the five message-receiving properties of Classes       */

--- a/veneer.c
+++ b/veneer.c
@@ -684,8 +684,8 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
          {   n = x->0;\
              if (n == 0) break;\
              x++;\
-             if (id == (n & 31)) return x;\
-             l = (n/32)+1;\
+             if (id == (n & $1f)) return x;\
+             l = (n/$20)+1;\
              x = x + l;\
          }\
          #IFNOT;\

--- a/veneer.c
+++ b/veneer.c
@@ -405,7 +405,11 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
              identifier = (identifier & $3f00) / $100;\
              if (~~(obj ofclass cla)) rfalse; i=0-->5;\
              if (cla == 2) return i+2*identifier-2;\
+             #IFV3;\
+             i = (i+60+cla*9)-->0;\
+             #IFNOT;\
              i = 0-->((i+124+cla*14)/2);\
+             #ENDIF;\
              i = CP__Tab(i + 2*(0->i) + 1, -1)+6;\
              return CP__Tab(i, identifier);\
          }\

--- a/veneer.c
+++ b/veneer.c
@@ -254,6 +254,10 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
 
         "CA__Pr",
         "obj id a b c d e f x y z s s2 n m;\
+         #IFV3;\
+         #Message error \"Object message calls are not supported in v3.\";\
+         obj = id = a = b = c = d = e = f = x = y = z = s = s2 = n = m = 0;\
+         #IFNOT;\
          if (obj < 1 || obj > #largest_object-255)\
          {   switch(Z__Region(obj))\
              { 2: if (id == call)\
@@ -315,6 +319,7 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
         default: return x-->m;\
             }\
          }\
+         #ENDIF;\
          rfalse;\
          ]"
     },
@@ -703,6 +708,10 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
 
         "Cl__Ms",
         "obj id y a b c d x;\
+         #IFV3;\
+         #Message error \"Class messages are not supported in v3.\";\
+         obj = id = y = a = b = c = d = x = 0;\
+         #IFNOT;\
          switch(id)\
          {   create:\
                  if (children(obj)<=1) rfalse; x=child(obj);\
@@ -733,6 +742,7 @@ static VeneerRoutine VRs_z[VENEER_ROUTINES] =
                  { RT__Err(\"copy\", b, -obj); rfalse; }\
                  Copy__Primitive(a, b); rfalse;\
          }\
+         #ENDIF;\
          ]", "", "", ""
     },
     {   /*  RT__ChT:  check at run-time that a proposed object move is legal


### PR DESCRIPTION
Fix the v3 object-table math in RA__Pr(), and also CP__Tab(), which is only called from RA__Pr().

This fixes the behavior of `Obj.BaseClass::prop` in v3.

---

Mark CA__Pr() and Cl__Ms() as compile-time errors in v3.

This only affects v3 games which try to do `obj.prop()`. Such a call already generated messy compile-time errors:

> Error:  Opcode unavailable in this Z-machine version: "check_arg_count"

Now it produces a more meaningful error:

> Error:  Object message calls are not supported in v3.

If the game or library replaces CA__Pr() and Cl__Ms() with working code, the veneer functions will be omitted and there will be no error.
