### PR TITLE
Fix end-of-file check in get_next_char()

### DIFF
--- a/header.h
+++ b/header.h
@@ -602,7 +602,7 @@
 #define  MAX_IDENTIFIER_LENGTH  32
 #define  MAX_ABBREV_LENGTH      64
 #define  MAX_DICT_WORD_SIZE     40
-#define  MAX_DICT_WORD_BYTES    (40*4)
+#define  MAX_DICT_WORD_BYTES    (MAX_DICT_WORD_SIZE*4)
 #define  MAX_NUM_ATTR_BYTES     39
 #define  MAX_VERB_WORD_SIZE    120
 

--- a/header.h
+++ b/header.h
@@ -601,7 +601,7 @@
 #define  MAX_ERRORS            100
 #define  MAX_IDENTIFIER_LENGTH  32
 #define  MAX_ABBREV_LENGTH      64
-#define  MAX_DICT_WORD_SIZE     40
+#define  MAX_DICT_WORD_SIZE     64
 #define  MAX_DICT_WORD_BYTES    (MAX_DICT_WORD_SIZE*4)
 #define  MAX_NUM_ATTR_BYTES     39
 #define  MAX_VERB_WORD_SIZE    120

--- a/lexer.c
+++ b/lexer.c
@@ -1867,7 +1867,7 @@ extern void get_next_token(void)
             quoted_size=0;
             do
             {   e = d; d = (*get_next_char)(); lexaddc(d);
-                if (quoted_size++==64)
+                if (quoted_size++==MAX_DICT_WORD_SIZE)
                 {   error(
                     "Too much text for one pair of quotations '...' to hold");
                     lexaddc('\''); break;

--- a/lexer.c
+++ b/lexer.c
@@ -272,6 +272,12 @@ static int lex_pos;         /* Current write position in that lextext        */
 /* ------------------------------------------------------------------------- */
 /*   The lexer itself needs up to 3 characters of lookahead (it uses an      */
 /*   LR(3) grammar to translate characters into tokens).                     */
+/*                                                                           */
+/*   Past the end of the stream, we fill in zero bytes. This has the         */
+/*   awkward side effect that a zero byte in a source file will silently     */
+/*   terminate it, rather than producing an "illegal source character"       */
+/*   error. On the up side, we can compile veneer routines (which are null-  */
+/*   terminated strings) with no extra work.                                 */
 /* ------------------------------------------------------------------------- */
 
 #define LOOKAHEAD_SIZE 3

--- a/lexer.c
+++ b/lexer.c
@@ -1534,7 +1534,7 @@ static int get_next_char_from_pipeline(void)
 }
 
 /* ------------------------------------------------------------------------- */
-/*   Source 2: from a string                                                 */
+/*   Source 2: from a (null-terminated) string                               */
 /* ------------------------------------------------------------------------- */
 
 static int source_to_analyse_pointer;            /*  Current read position   */
@@ -1574,7 +1574,8 @@ static int get_next_char_from_string(void)
 /*                                                                           */
 /*       restart_lexer(source, name) if source is NULL, initialise the lexer */
 /*                                       to read from source files;          */
-/*                                   otherwise, to read from this string.    */
+/*                                       otherwise, to read from this null-  */
+/*                                       terminated string.                  */
 /* ------------------------------------------------------------------------- */
 
 extern void release_token_texts(void)

--- a/lexer.c
+++ b/lexer.c
@@ -1366,7 +1366,7 @@ static int32 construct_double(int wanthigh, int signbit, double intv, double fra
 /*                                                                           */
 /*   Note that file_load_chars(p, size) loads "size" bytes into buffer "p"   */
 /*   from the current input file.  If the file runs out, then if it was      */
-/*   the last source file 4 EOF characters are placed in the buffer: if it   */
+/*   the last source file 4 null characters are placed in the buffer: if it  */
 /*   was only an Include file ending, then a '\n' character is placed there  */
 /*   (essentially to force termination of any comment line) followed by      */
 /*   three harmless spaces.                                                  */
@@ -1873,8 +1873,8 @@ extern void get_next_token(void)
                     }
                     break;
                 }
-            } while (d != EOF);
-            if (d==EOF) ebf_error("'\''", "end of file");
+            } while (d != 0);
+            if (d==0) ebf_error("'\''", "end of file");
             lexdelc();
             circle[circle_position].type = SQ_TT;
             break;
@@ -1887,14 +1887,14 @@ extern void get_next_token(void)
                 {   lex_pos--;
                     while (lexlastc() == ' ') lex_pos--;
                     if (lexlastc() != '^') lexaddc(' ');
-                    while ((lookahead != EOF) &&
+                    while ((lookahead != 0) &&
                           (tokeniser_grid[lookahead] == WHITESPACE_CODE))
                     (*get_next_char)();
                 }
                 else if (d == '\\')
                 {   int newline_passed = FALSE;
                     lex_pos--;
-                    while ((lookahead != EOF) &&
+                    while ((lookahead != 0) &&
                           (tokeniser_grid[lookahead] == WHITESPACE_CODE))
                         if ((d = (*get_next_char)()) == '\n')
                             newline_passed = TRUE;
@@ -1906,8 +1906,8 @@ extern void get_next_token(void)
                             chb);
                     }
                 }
-            }   while ((d != EOF) && (d!='\"'));
-            if (d==EOF) ebf_error("'\"'", "end of file");
+            }   while ((d != 0) && (d!='\"'));
+            if (d==0) ebf_error("'\"'", "end of file");
             lexdelc();
             circle[circle_position].type = DQ_TT;
             break;

--- a/lexer.c
+++ b/lexer.c
@@ -278,6 +278,7 @@ static int lex_pos;         /* Current write position in that lextext        */
 
 static int current, lookahead,          /* The latest character read, and    */
     lookahead2, lookahead3;             /* the three characters following it */
+                                        /* (zero means end-of-stream)        */
 
 static int pipeline_made;               /* Whether or not the pipeline of
                                            characters has been constructed

--- a/lexer.c
+++ b/lexer.c
@@ -273,10 +273,10 @@ static int lex_pos;         /* Current write position in that lextext        */
 /*   The lexer itself needs up to 3 characters of lookahead (it uses an      */
 /*   LR(3) grammar to translate characters into tokens).                     */
 /*                                                                           */
-/*   Past the end of the stream, we fill in zero bytes. This has the         */
-/*   awkward side effect that a zero byte in a source file will silently     */
-/*   terminate it, rather than producing an "illegal source character"       */
-/*   error. On the up side, we can compile veneer routines (which are null-  */
+/*   Past the end of the stream, we fill in zeros. This has the awkward      */
+/*   side effect that a zero byte in a source file will silently terminate   */
+/*   it, rather than producing an "illegal source character" error.          */
+/*   On the up side, we can compile veneer routines (which are null-         */
 /*   terminated strings) with no extra work.                                 */
 /* ------------------------------------------------------------------------- */
 

--- a/text.c
+++ b/text.c
@@ -1801,13 +1801,13 @@ int dict_entries;                     /* Total number of records entered     */
 /*   typedef, and operate directly on uchar arrays of length DICT_WORD_SIZE. */
 /*   In Z-code, DICT_WORD_SIZE will be 6, so the Z-code compiler will work   */
 /*   as before. In Glulx, it can be any value up to MAX_DICT_WORD_SIZE.      */
-/*   (That limit is defined as 40 in the header; it exists only for a few    */
-/*   static buffers, and can be increased without using significant memory.) */
+/*   (That limit is defined as 64 in the header. It exists only for a few    */
+/*   static buffers, plus an overflow bound for dict word lexing. It can     */
+/*   be increased without using significant memory.) */
 /*                                                                           */
-/*   ...Well, that certainly bit me on the butt, didn't it. In further       */
-/*   modifying the compiler to generate a Unicode dictionary, I have to      */
-/*   store four-byte values in the uchar array. This is handled by making    */
-/*   the array size DICT_WORD_BYTES (which is DICT_WORD_SIZE*DICT_CHAR_SIZE).*/
+/*   In further modifying the compiler to generate a Unicode dictionary,     */
+/*   I have to store four-byte values in the uchar array. We make the array  */
+/*   size DICT_WORD_BYTES (which is DICT_WORD_SIZE*DICT_CHAR_SIZE).          */
 /*   Then we store the 32-bit character value big-endian. This lets us       */
 /*   continue to compare arrays bytewise, which is a nice simplification.    */
 /* ------------------------------------------------------------------------- */

--- a/text.c
+++ b/text.c
@@ -1803,7 +1803,7 @@ int dict_entries;                     /* Total number of records entered     */
 /*   as before. In Glulx, it can be any value up to MAX_DICT_WORD_SIZE.      */
 /*   (That limit is defined as 64 in the header. It exists only for a few    */
 /*   static buffers, plus an overflow bound for dict word lexing. It can     */
-/*   be increased without using significant memory.) */
+/*   be increased without using significant memory.)                         */
 /*                                                                           */
 /*   In further modifying the compiler to generate a Unicode dictionary,     */
 /*   I have to store four-byte values in the uchar array. We make the array  */

--- a/verbs.c
+++ b/verbs.c
@@ -549,7 +549,7 @@ static void register_verb(char *English_verb, int number)
     /* We set a hard limit of MAX_VERB_WORD_SIZE=120 because the
        English_verb_list table stores length in a leading byte. (We could
        raise that to 250, really, but there's little point when
-       MAX_DICT_WORD_SIZE is 40.) */
+       MAX_DICT_WORD_SIZE is 64.) */
     entrysize = strlen(English_verb)+4;
     if (entrysize > MAX_VERB_WORD_SIZE+4)
         error_fmt("Verb word is too long -- max length is %d", MAX_VERB_WORD_SIZE);


### PR DESCRIPTION
The get_next_char() functions (get_next_char_from_pipeline(), get_next_char_from_string()) were defined as returning zero on end-of-file. But all the places where the return value was checked were looking for EOF (-1). 

This led to an unhappy situation where an unclosed quotation mark at the end of a source file would hang the compiler! It would loop forever, adding zeroes to the token buffer and waiting for an EOF that never came.

I went back and forth over whether to settle on EOF or zero. I wound up picking zero, because there was more code in that went that way. In particular, all input goes through the `uchar source_to_iso_grid[]` map, which is explicit about mapping zero to zero so that end-of-file is signalled correctly. It would be messy to get that array to handle -1.

String input (which is used to compile veneer functions) uses null-terminated strings, so end-of-file is naturally zero there too.

The side-effect here is that a null byte in the source will silently terminate it. (Or noisily terminate it, if the null is in the middle of a statement.) This is inconsistent with other control characters, which throw a poorly-phrased error:

> Expected directive, '[' or class name but found ?

I am okay with this outcome.

----

While I was doing that, I noticed that lexer.c capped dict words at 64 characters. I changed that to the header constant `MAX_DICT_WORD_SIZE`, which was previously 40, but I've bumped it up to 64 to avoid changing behavior.

(Note that this is not the same as the memory setting `DICT_WORD_SIZE`, which is 6 in Z-code, 9 in Glulx. In Glulx you can increase it *up to* `MAX_DICT_WORD_SIZE`. 40 was already generous for this limit but 64 doesn't hurt.)

Fixes: https://github.com/DavidKinder/Inform6/issues/218
Test: https://github.com/erkyrath/Inform6-Testing/tree/badquote