### PR TITLE
Yet more warnings

### DIFF
--- a/objects.c
+++ b/objects.c
@@ -852,7 +852,13 @@ static int write_properties_between(int mark, int from, int to)
                 }
 
                 for (k=0; k<full_object.pp[j].l; k++)
-                {   if (full_object.pp[j].ao[k].marker != 0)
+                {
+                    if (k >= 32) {
+                        /* We catch this earlier, but we'll check again to avoid overflowing ao[] */
+                        error("Too many values for Z-machine property");
+                        break;
+                    }
+                    if (full_object.pp[j].ao[k].marker != 0)
                         backpatch_zmachine(full_object.pp[j].ao[k].marker,
                             PROP_ZA, mark);
                     properties_table[mark++] = full_object.pp[j].ao[k].value/256;

--- a/syntax.c
+++ b/syntax.c
@@ -713,6 +713,8 @@ extern void parse_code_block(int break_label, int continue_label,
                         if (!constcount)
                         {
                             ebf_error("constant", "<expression>");
+                            panic_mode_error_recovery();
+                            continue;
                         }
 
                         if (constcount > MAX_SPEC_STACK)


### PR DESCRIPTION
While checking that negation case, I turned up a couple more array bounds errors. Both of these occur while recovering from an I6 syntax error.

