### PR TITLE
Remove lexer length limitations on identifiers and dict words

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -850,7 +850,7 @@ extern void arrays_allocate_arrays(void)
         "global variable values");
 
     initialise_memory_list(&current_array_name,
-        sizeof(char), MAX_IDENTIFIER_LENGTH+1, NULL,
+        sizeof(char), 32, NULL,
         "array name currently being defined");
 }
 

--- a/asm.c
+++ b/asm.c
@@ -307,7 +307,7 @@ extern int is_variable_ot(int otval)
 extern char *variable_name(int32 i)
 {
     if (i==0) return("sp");
-    if (i<MAX_LOCAL_VARIABLES) return local_variable_names[i-1].text;
+    if (i<MAX_LOCAL_VARIABLES) return get_local_variable_name(i-1);
 
     if (!glulx_mode) {
       if (i==255) return("TEMP1");
@@ -1721,8 +1721,8 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
     for (i=0; i<MAX_LOCAL_VARIABLES; i++) variables[i].usage = FALSE;
 
     if (no_locals >= 1
-      && strcmpcis(local_variable_names[0].text, "_vararg_count")==0) {
-      stackargs = TRUE;
+        && strcmpcis(get_local_variable_name(0), "_vararg_count")==0) {
+        stackargs = TRUE;
     }
 
     if (veneer_mode) routine_starts_line = blank_brief_location;

--- a/asm.c
+++ b/asm.c
@@ -857,6 +857,7 @@ static opcodez internal_number_to_opcode_z(int32 i)
 
 static void make_opcode_syntax_z(opcodez opco)
 {   char *p = "", *q = opcode_syntax_string;
+    /* TODO: opcode_syntax_string[128] is unsafe */
     sprintf(q, "%s", opco.name);
     switch(opco.no)
     {   case ONE: p=" <operand>"; break;
@@ -904,6 +905,7 @@ static void make_opcode_syntax_g(opcodeg opco)
     int ix;
     char *cx;
     char *q = opcode_syntax_string;
+    /* TODO: opcode_syntax_string[128] is unsafe */
 
     sprintf(q, "%s", opco.name);
     sprintf(q+strlen(q), " <%d operand%s", opco.no,
@@ -1785,7 +1787,8 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
 
       if ((routine_asterisked) || (define_INFIX_switch))
       {   char fnt[256]; assembly_operand PV, RFA, CON, STP, SLF; int ln, ln2;
-
+          /* TODO: fnt[256] is unsafe */
+          
           ln = next_label++;
           ln2 = next_label++;
 

--- a/asm.c
+++ b/asm.c
@@ -79,9 +79,9 @@ static char opcode_syntax_string[128];  /*  Text buffer holding the correct
 static int routine_symbol;         /* The symbol index of the routine currently
                                       being compiled */
 static memory_list current_routine_name; /* The name of the routine currently
-                                      being compiled. (This may be longer
-                                      than MAX_IDENTIFIER_LENGTH, e.g. for
-                                      an "obj.prop" property routine.)       */
+                                      being compiled. (This may not be a
+                                      simple symbol, e.g. for an "obj.prop"
+                                      property routine.)                     */
 static int routine_locals;         /* The number of local variables used by
                                       the routine currently being compiled   */
 
@@ -3556,7 +3556,7 @@ extern void asm_allocate_arrays(void)
         "code area");
 
     initialise_memory_list(&current_routine_name,
-        sizeof(char), 3*MAX_IDENTIFIER_LENGTH, NULL,
+        sizeof(char), 64, NULL,
         "routine name currently being defined");
 }
 

--- a/asm.c
+++ b/asm.c
@@ -1707,8 +1707,8 @@ extern void define_symbol_label(int symbol)
     labels[label].symbol = symbol;
 }
 
-/* The local variables must already be set up; the no_locals variable
-   indicates how many exist. */
+/* The local variables must already be set up; no_locals indicates
+   how many exist. */
 extern int32 assemble_routine_header(int routine_asterisked, char *name,
     int embedded_flag, int the_symbol)
 {   int i, rv;

--- a/directs.c
+++ b/directs.c
@@ -10,7 +10,6 @@
 
 int no_routines,                   /* Number of routines compiled so far     */
     no_named_routines,             /* Number not embedded in objects         */
-    no_locals,                     /* Number of locals in current routine    */
     no_termcs;                     /* Number of terminating characters       */
 int terminating_characters[32];
 
@@ -886,11 +885,11 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
                 (We don't set local_variable.keywords because we're not
                 going to be parsing any code.)                               */
 
-            no_locals = k;
-            strcpy(local_variable_names[0].text, "dummy1");
-            strcpy(local_variable_names[1].text, "dummy2");
-            strcpy(local_variable_names[2].text, "dummy3");
-            strcpy(local_variable_names[3].text, "dummy4");
+            clear_local_variables();
+            if (k >= 1) add_local_variable("dummy1");
+            if (k >= 2) add_local_variable("dummy2");
+            if (k >= 3) add_local_variable("dummy3");
+            if (k >= 4) add_local_variable("dummy4");
 
             assign_symbol(i,
                 assemble_routine_header(FALSE, symbols[i].name, FALSE, i),
@@ -1294,7 +1293,6 @@ extern void init_directs_vars(void)
 extern void directs_begin_pass(void)
 {   no_routines = 0;
     no_named_routines = 0;
-    no_locals = 0;
     no_termcs = 0;
     constant_made_yet = FALSE;
     ifdef_sp = 0;

--- a/directs.c
+++ b/directs.c
@@ -886,13 +886,14 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
                 (We don't set local_variable.keywords because we're not
                 going to be parsing any code.)                               */
 
+            no_locals = k;
             strcpy(local_variable_names[0].text, "dummy1");
             strcpy(local_variable_names[1].text, "dummy2");
             strcpy(local_variable_names[2].text, "dummy3");
             strcpy(local_variable_names[3].text, "dummy4");
 
             assign_symbol(i,
-                assemble_routine_header(k, FALSE, symbols[i].name, FALSE, i),
+                assemble_routine_header(FALSE, symbols[i].name, FALSE, i),
                 ROUTINE_T);
 
             /*  Ensure the return value of a stubbed routine is false,

--- a/files.c
+++ b/files.c
@@ -1205,9 +1205,9 @@ extern void open_transcript_file(char *what_of)
 
     transcript_open = TRUE;
 
-    sprintf(topline_buffer, "Transcript of the text of \"%s\"", what_of);
+    snprintf(topline_buffer, 256, "Transcript of the text of \"%s\"", what_of);
     write_to_transcript_file(topline_buffer, STRCTX_INFO);
-    sprintf(topline_buffer, "[From %s]", banner_line);
+    snprintf(topline_buffer, 256, "[From %s]", banner_line);
     write_to_transcript_file(topline_buffer, STRCTX_INFO);
     if (TRANSCRIPT_FORMAT == 1) {
         write_to_transcript_file("[I:info, G:game text, V:veneer text, L:lowmem string, A:abbreviation, D:dict word, O:object name, S:symbol, X:infix]", STRCTX_INFO);
@@ -1228,7 +1228,7 @@ extern void close_transcript_file(void)
     char sn_buffer[7];
 
     write_serial_number(sn_buffer);
-    sprintf(botline_buffer, "[End of transcript: release %d, serial %s]",
+    snprintf(botline_buffer, 256, "[End of transcript: release %d, serial %s]",
         release_number, sn_buffer);
     write_to_transcript_file("",  STRCTX_INFO);
     write_to_transcript_file(botline_buffer, STRCTX_INFO);

--- a/header.h
+++ b/header.h
@@ -2518,7 +2518,7 @@ extern int  dont_enter_into_symbol_table;
 extern int  return_sp_as_variable;
 extern int  next_token_begins_syntax_line;
 extern int  no_locals;
-extern identstruct *local_variable_names;
+extern int *local_variable_name_offsets;
 
 extern int32 token_value;
 extern int   token_type;
@@ -2538,6 +2538,7 @@ extern void describe_token_triple(const char *text, int32 value, int type);
 extern void construct_local_variable_tables(void);
 extern void clear_local_variables(void);
 extern void add_local_variable(char *name);
+extern char *get_local_variable_name(int index);
 
 extern void declare_systemfile(void);
 extern int  is_systemfile(void);

--- a/header.h
+++ b/header.h
@@ -599,7 +599,6 @@
 /* ------------------------------------------------------------------------- */
 
 #define  MAX_ERRORS            100
-#define  MAX_IDENTIFIER_LENGTH  32
 #define  MAX_ABBREV_LENGTH      64
 #define  MAX_NUM_ATTR_BYTES     39
 #define  MAX_VERB_WORD_SIZE    120

--- a/header.h
+++ b/header.h
@@ -652,11 +652,6 @@ typedef struct brief_location_s
     int32 orig_line_number;
 } brief_location;
 
-typedef struct identstruct_s
-{
-    char text[MAX_IDENTIFIER_LENGTH+1];
-} identstruct;
-
 typedef struct assembly_operand_t
 {   int   type;     /* ?_OT value */
     int32 value;

--- a/header.h
+++ b/header.h
@@ -2151,7 +2151,7 @@ extern void assemble_label_no(int n);
 extern int assemble_forward_label_no(int n);
 extern void assemble_jump(int n);
 extern void define_symbol_label(int symbol);
-extern int32 assemble_routine_header(int no_locals, int debug_flag,
+extern int32 assemble_routine_header(int debug_flag,
     char *name, int embedded_flag, int the_symbol);
 extern void assemble_routine_end(int embedded_flag, debug_locations locations);
 

--- a/header.h
+++ b/header.h
@@ -601,8 +601,6 @@
 #define  MAX_ERRORS            100
 #define  MAX_IDENTIFIER_LENGTH  32
 #define  MAX_ABBREV_LENGTH      64
-#define  MAX_DICT_WORD_SIZE     64
-#define  MAX_DICT_WORD_BYTES    (MAX_DICT_WORD_SIZE*4)
 #define  MAX_NUM_ATTR_BYTES     39
 #define  MAX_VERB_WORD_SIZE    120
 

--- a/header.h
+++ b/header.h
@@ -2299,7 +2299,7 @@ extern void  make_upper_case(char *str);
 
 extern brief_location routine_starts_line;
 
-extern int  no_routines, no_named_routines, no_locals, no_termcs;
+extern int  no_routines, no_named_routines, no_termcs;
 extern int  terminating_characters[];
 
 extern int  parse_given_directive(int internal_flag);
@@ -2517,6 +2517,7 @@ extern int  total_source_line_count;
 extern int  dont_enter_into_symbol_table;
 extern int  return_sp_as_variable;
 extern int  next_token_begins_syntax_line;
+extern int  no_locals;
 extern identstruct *local_variable_names;
 
 extern int32 token_value;
@@ -2535,6 +2536,9 @@ extern void describe_token_triple(const char *text, int32 value, int type);
 #define describe_token(t) describe_token_triple((t)->text, (t)->value, (t)->type)
 
 extern void construct_local_variable_tables(void);
+extern void clear_local_variables(void);
+extern void add_local_variable(char *name);
+
 extern void declare_systemfile(void);
 extern int  is_systemfile(void);
 extern void report_errors_at_current_line(void);

--- a/inform.c
+++ b/inform.c
@@ -160,13 +160,6 @@ static void select_target(int targ)
     MAX_LOCAL_VARIABLES = MAX_KEYWORD_GROUP_SIZE;
   }
 
-  if (DICT_WORD_SIZE > MAX_DICT_WORD_SIZE) {
-    DICT_WORD_SIZE = MAX_DICT_WORD_SIZE;
-    warning_fmt(
-      "DICT_WORD_SIZE cannot exceed MAX_DICT_WORD_SIZE; resetting to %d", 
-      MAX_DICT_WORD_SIZE);
-    /* MAX_DICT_WORD_SIZE can be increased in header.h without fear. */
-  }
   if (NUM_ATTR_BYTES > MAX_NUM_ATTR_BYTES) {
     NUM_ATTR_BYTES = MAX_NUM_ATTR_BYTES;
     warning_fmt(

--- a/lexer.c
+++ b/lexer.c
@@ -1867,11 +1867,6 @@ extern void get_next_token(void)
             quoted_size=0;
             do
             {   e = d; d = (*get_next_char)(); lexaddc(d);
-                if (quoted_size++==MAX_DICT_WORD_SIZE)
-                {   error(
-                    "Too much text for one pair of quotations '...' to hold");
-                    lexaddc('\''); break;
-                }
                 if ((d == '\'') && (e != '@'))
                 {   if (quoted_size == 1)
                     {   d = (*get_next_char)(); lexaddc(d);

--- a/lexer.c
+++ b/lexer.c
@@ -255,8 +255,7 @@ static lexeme_data circle[CIRCLE_SIZE];
 
 typedef struct lextext_s {
     char *text;
-    size_t size; /* Allocated size (including terminal null)
-                    This is always at least MAX_IDENTIFIER_LENGTH+1         */
+    size_t size; /* Allocated size (including terminal null)                 */
 } lextext;
 
 static lextext *lextexts; /* Allocated to no_lextexts */
@@ -1764,7 +1763,7 @@ extern void get_next_token(void)
         /* fresh lextext block; must init it */
         no_lextexts = lex_index+1;
         ensure_memory_list_available(&lextexts_memlist, no_lextexts);
-        lextexts[lex_index].size = MAX_IDENTIFIER_LENGTH + 1;
+        lextexts[lex_index].size = 64;   /* this can grow */
         lextexts[lex_index].text = my_malloc(lextexts[lex_index].size, "one lexeme text");
     }
     lex_pos = 0;
@@ -1960,26 +1959,11 @@ extern void get_next_token(void)
         case IDENTIFIER_CODE:    /* Letter or underscore: an identifier */
 
             lexaddc(d); n=1;
-            while ((n<=MAX_IDENTIFIER_LENGTH)
-                   && ((tokeniser_grid[lookahead] == IDENTIFIER_CODE)
+            while (((tokeniser_grid[lookahead] == IDENTIFIER_CODE)
                    || (tokeniser_grid[lookahead] == DIGIT_CODE)))
                 n++, lexaddc((*get_next_char)());
 
             lexaddc(0);
-
-            if (n > MAX_IDENTIFIER_LENGTH)
-            {
-                error_fmt(
-                    "Name exceeds the maximum length of %d characters: \"%s\"",
-                    MAX_IDENTIFIER_LENGTH, lextexts[lex_index].text);
-                /* Eat any further extra characters in the identifier */
-                while (((tokeniser_grid[lookahead] == IDENTIFIER_CODE)
-                        || (tokeniser_grid[lookahead] == DIGIT_CODE)))
-                    (*get_next_char)();
-                /* Trim token so that it doesn't violate
-                   MAX_IDENTIFIER_LENGTH during error recovery */
-                lextexts[lex_index].text[MAX_IDENTIFIER_LENGTH] = 0;
-            }
 
             if (dont_enter_into_symbol_table)
             {   circle[circle_position].type = UQ_TT;

--- a/lexer.c
+++ b/lexer.c
@@ -741,7 +741,7 @@ extern void add_local_variable(char *name)
 {
     int len;
 
-    if (no_locals+1 > MAX_LOCAL_VARIABLES-1) {
+    if (no_locals >= MAX_LOCAL_VARIABLES-1) {
         /* This should have been caught before we got here */
         error("too many local variables");
         return;

--- a/lexer.c
+++ b/lexer.c
@@ -652,6 +652,9 @@ static int *local_variable_hash_codes;
    119 for Glulx.
 */
 
+/* The number of local variables in the current routine. */
+int no_locals;
+
 /* Names of local variables in the current routine.
    This is allocated to MAX_LOCAL_VARIABLES-1. (The stack pointer "local"
    is not included in this array.)
@@ -726,7 +729,9 @@ static void make_keywords_tables(void)
 
 /* Look at the strings stored in local_variable_names (from 0 to no_locals).
    Set local_variables.keywords to point to these, and also prepare the
-   hash tables. */
+   hash tables.
+   This must be called after add_local_variable(), but before we start
+   compiling function code. */
 extern void construct_local_variable_tables(void)
 {   int i, h;
     for (i=0; i<HASH_TAB_SIZE; i++) local_variable_hash_table[i] = -1;
@@ -2135,6 +2140,8 @@ extern void lexer_begin_pass(void)
     hash_printed_since_newline = FALSE;
 
     pipeline_made = FALSE;
+
+    no_locals = 0;
 
     restart_lexer(NULL, NULL);
 }

--- a/objects.c
+++ b/objects.c
@@ -888,6 +888,7 @@ static int write_property_block_z(char *shortname)
 
     if (shortname != NULL)
     {
+        /* The limit of 510 bytes, or 765 Z-characters, is a Z-spec limit. */
         i = translate_text(510,shortname,STRCTX_OBJNAME);
         if (i < 0) {
             error ("Short name of object exceeded 765 Z-characters");

--- a/symbols.c
+++ b/symbols.c
@@ -665,6 +665,7 @@ extern void write_the_identifier_names(void)
 
     for (j=0; j<no_arrays; j++)
     {
+        i = arrays[j].symbol;
         array_name_strings[j]
             = compile_string(symbols[i].name, STRCTX_SYMBOL);
     }

--- a/symbols.c
+++ b/symbols.c
@@ -670,32 +670,33 @@ extern void write_the_identifier_names(void)
             = compile_string(symbols[i].name, STRCTX_SYMBOL);
     }
     
-  if (define_INFIX_switch)
-  { for (i=0; i<no_symbols; i++)
-    {   if (symbols[i].type == GLOBAL_VARIABLE_T)
-        {
-            array_name_strings[no_arrays + symbols[i].value -16]
-                = compile_string(symbols[i].name, STRCTX_SYMBOL);
-        }
-    }
-
-    for (i=0; i<no_named_routines; i++)
+    if (define_INFIX_switch)
     {
-        array_name_strings[no_arrays + no_globals + i]
-            = compile_string(symbols[named_routine_symbols[i]].name, STRCTX_SYMBOL);
-    }
-
-    for (i=0, no_named_constants=0; i<no_symbols; i++)
-    {   if (((symbols[i].type == OBJECT_T) || (symbols[i].type == CLASS_T)
-            || (symbols[i].type == CONSTANT_T))
-            && ((symbols[i].flags & (UNKNOWN_SFLAG+ACTION_SFLAG))==0))
+        for (i=0; i<no_symbols; i++)
+        {   if (symbols[i].type == GLOBAL_VARIABLE_T)
+            {
+                array_name_strings[no_arrays + symbols[i].value -16]
+                    = compile_string(symbols[i].name, STRCTX_SYMBOL);
+            }
+        }
+        
+        for (i=0; i<no_named_routines; i++)
         {
-            array_name_strings[no_arrays + no_globals + no_named_routines
-                + no_named_constants++]
-                = compile_string(symbols[i].name, STRCTX_SYMBOL);
+            array_name_strings[no_arrays + no_globals + i]
+                = compile_string(symbols[named_routine_symbols[i]].name, STRCTX_SYMBOL);
+        }
+        
+        for (i=0, no_named_constants=0; i<no_symbols; i++)
+        {   if (((symbols[i].type == OBJECT_T) || (symbols[i].type == CLASS_T)
+                 || (symbols[i].type == CONSTANT_T))
+                && ((symbols[i].flags & (UNKNOWN_SFLAG+ACTION_SFLAG))==0))
+            {
+                array_name_strings[no_arrays + no_globals + no_named_routines
+                                   + no_named_constants++]
+                    = compile_string(symbols[i].name, STRCTX_SYMBOL);
+            }
         }
     }
-  }
 
     veneer_mode = FALSE;
 }

--- a/syntax.c
+++ b/syntax.c
@@ -455,10 +455,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         restart_lexer(lexical_source, name);
     }
 
-    no_locals = 0;
-
-    for (i=0;i<MAX_LOCAL_VARIABLES-1;i++)
-        local_variable_names[i].text[0] = 0;
+    clear_local_variables();
 
     do
     {   statements.enabled = TRUE;
@@ -495,7 +492,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
             if (strcmpcis(token_text, local_variable_names[i].text)==0)
                 error_named("Local variable defined twice:", token_text);
         }
-        strcpy(local_variable_names[no_locals++].text, token_text);
+        add_local_variable(token_text);
     } while(TRUE);
 
     /* Set up the local variable hash and the local_variables.keywords

--- a/syntax.c
+++ b/syntax.c
@@ -489,7 +489,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
         }
 
         for (i=0;i<no_locals;i++) {
-            if (strcmpcis(token_text, local_variable_names[i].text)==0)
+            if (strcmpcis(token_text, get_local_variable_name(i))==0)
                 error_named("Local variable defined twice:", token_text);
         }
         add_local_variable(token_text);

--- a/syntax.c
+++ b/syntax.c
@@ -509,7 +509,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
     if ((embedded_flag == FALSE) && (veneer_mode == FALSE) && debug_flag)
         symbols[r_symbol].flags |= STAR_SFLAG;
 
-    packed_address = assemble_routine_header(no_locals, debug_flag,
+    packed_address = assemble_routine_header(debug_flag,
         name, embedded_flag, r_symbol);
 
     do

--- a/syntax.c
+++ b/syntax.c
@@ -475,12 +475,6 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
             break;
         }
 
-        if (strlen(token_text) > MAX_IDENTIFIER_LENGTH)
-        {   error_named("Local variable identifier too long:", token_text);
-            panic_mode_error_recovery();
-            break;
-        }
-
         if (no_locals == MAX_LOCAL_VARIABLES-1)
         {   error_fmt("Too many local variables for a routine; max is %d",
                 MAX_LOCAL_VARIABLES-1);

--- a/tables.c
+++ b/tables.c
@@ -99,14 +99,20 @@ extern void write_serial_number(char *buffer)
         the ability to work out today's date                                 */
 
     time_t tt;  tt=time(0);
-    if (serial_code_given_in_program)
+    if (serial_code_given_in_program) {
         strcpy(buffer, serial_code_buffer);
-    else
+    }
+    else {
 #ifdef TIME_UNAVAILABLE
         sprintf(buffer,"970000");
 #else
-        strftime(buffer,10,"%y%m%d",localtime(&tt));
+        /* Write a six-digit date, null-terminated. Fall back to "970000"
+           if that fails. */
+        int len = strftime(buffer,7,"%y%m%d",localtime(&tt));
+        if (len != 6)
+            sprintf(buffer,"970000");
 #endif
+    }
 }
 
 static char percentage_buffer[64];

--- a/text.c
+++ b/text.c
@@ -659,7 +659,7 @@ advance as part of 'Zcharacter table':", unicode);
                 i += 2;
                 /* This accepts "12xyz" as a symbol, which it really isn't,
                    but that just means it won't be found. */
-                while ((text_in[i] == '_' || isalnum(text_in[i])) && len < MAX_IDENTIFIER_LENGTH) {
+                while ((text_in[i] == '_' || isalnum(text_in[i]))) {
                     char ch = text_in[i++];
                     if (isdigit(ch)) digits++;
                     ensure_memory_list_available(&temp_symbol_memlist, len+1);
@@ -859,7 +859,7 @@ string.");
             i += 2;
             /* This accepts "12xyz" as a symbol, which it really isn't,
                but that just means it won't be found. */
-            while ((text_in[i] == '_' || isalnum(text_in[i])) && len < MAX_IDENTIFIER_LENGTH) {
+            while ((text_in[i] == '_' || isalnum(text_in[i]))) {
                 char ch = text_in[i++];
                 if (isdigit(ch)) digits++;
                 ensure_memory_list_available(&temp_symbol_memlist, len+1);

--- a/veneer.c
+++ b/veneer.c
@@ -34,7 +34,7 @@ extern void compile_initial_routine(void)
     assembly_operand AO;
 
     j = symbol_index("Main__", -1);
-    no_locals = 0;
+    clear_local_variables();
     assign_symbol(j,
         assemble_routine_header(FALSE, "Main__", FALSE, j),
         ROUTINE_T);
@@ -2224,12 +2224,12 @@ static void compile_symbol_table_routine(void)
 {   int32 j, nl, arrays_l, routines_l, constants_l;
     assembly_operand AO, AO2, AO3;
 
+    clear_local_variables();
     /* Assign local var names for the benefit of the debugging information 
        file. (We don't set local_variable.keywords because we're not
        going to be parsing any code.) */
-    no_locals = 2;
-    strcpy(local_variable_names[0].text, "dummy1");
-    strcpy(local_variable_names[1].text, "dummy2");
+    add_local_variable("dummy1");
+    add_local_variable("dummy2");
 
     veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1);
     assign_symbol(j,

--- a/veneer.c
+++ b/veneer.c
@@ -34,8 +34,9 @@ extern void compile_initial_routine(void)
     assembly_operand AO;
 
     j = symbol_index("Main__", -1);
+    no_locals = 0;
     assign_symbol(j,
-        assemble_routine_header(0, FALSE, "Main__", FALSE, j),
+        assemble_routine_header(FALSE, "Main__", FALSE, j),
         ROUTINE_T);
     symbols[j].flags |= SYSTEM_SFLAG + USED_SFLAG;
     if (trace_fns_setting==3) symbols[j].flags |= STAR_SFLAG;
@@ -2226,12 +2227,13 @@ static void compile_symbol_table_routine(void)
     /* Assign local var names for the benefit of the debugging information 
        file. (We don't set local_variable.keywords because we're not
        going to be parsing any code.) */
+    no_locals = 2;
     strcpy(local_variable_names[0].text, "dummy1");
     strcpy(local_variable_names[1].text, "dummy2");
 
     veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1);
     assign_symbol(j,
-        assemble_routine_header(2, FALSE, "Symb__Tab", FALSE, j),
+        assemble_routine_header(FALSE, "Symb__Tab", FALSE, j),
         ROUTINE_T);
     symbols[j].flags |= SYSTEM_SFLAG + USED_SFLAG;
     if (trace_fns_setting==3) symbols[j].flags |= STAR_SFLAG;

--- a/verbs.c
+++ b/verbs.c
@@ -97,7 +97,7 @@ static memory_list English_verbs_given_memlist;
   int32   *adjectives; /* Allocated to no_adjectives */
   static memory_list adjectives_memlist;
 
-  static uchar *adjective_sort_code; /* Allocated to no_adjectives*DICT_WORD_BYTES */
+  static uchar *adjective_sort_code; /* Allocated to no_adjectives*DICT_WORD_BYTES, except it's sometimes no_adjectives+1 because we can bump it tentatively */
   static memory_list adjective_sort_code_memlist;
 
 /* ------------------------------------------------------------------------- */
@@ -440,7 +440,6 @@ static int make_adjective(char *English_word)
         table is left empty in GV2.                                          */
 
     int i; 
-    uchar new_sort_code[MAX_DICT_WORD_BYTES];
 
     if (no_adjectives >= 255) {
         error("Grammar version 1 cannot support more than 255 prepositions");
@@ -451,9 +450,13 @@ static int make_adjective(char *English_word)
         error("Grammar version 1 cannot be used with ZCODE_LESS_DICT_DATA");
         return 0;
     }
+
+    /* Allocate the extra space even though we might not need it. We'll use
+       the prospective new adjective_sort_code slot as a workspace. */
     ensure_memory_list_available(&adjectives_memlist, no_adjectives+1);
     ensure_memory_list_available(&adjective_sort_code_memlist, (no_adjectives+1) * DICT_WORD_BYTES);
 
+    uchar *new_sort_code = adjective_sort_code+no_adjectives*DICT_WORD_BYTES;
     dictionary_prepare(English_word, new_sort_code);
     for (i=0; i<no_adjectives; i++)
         if (compare_sorts(new_sort_code,
@@ -461,8 +464,6 @@ static int make_adjective(char *English_word)
             return(0xff-i);
     adjectives[no_adjectives]
         = dictionary_add(English_word,8,0,0xff-no_adjectives);
-    copy_sorts(adjective_sort_code+no_adjectives*DICT_WORD_BYTES,
-        new_sort_code);
     return(0xff-no_adjectives++);
 }
 
@@ -548,8 +549,7 @@ static void register_verb(char *English_verb, int number)
 
     /* We set a hard limit of MAX_VERB_WORD_SIZE=120 because the
        English_verb_list table stores length in a leading byte. (We could
-       raise that to 250, really, but there's little point when
-       MAX_DICT_WORD_SIZE is 64.) */
+       raise that to 250, really.) */
     entrysize = strlen(English_verb)+4;
     if (entrysize > MAX_VERB_WORD_SIZE+4)
         error_fmt("Verb word is too long -- max length is %d", MAX_VERB_WORD_SIZE);


### PR DESCRIPTION
I6 symbols (identifiers) can now be any length. The entire symbol is significant. This addresses https://github.com/DavidKinder/Inform6/issues/176 .

Dict words can also be any length. The DICT_WORD_SIZE limit still applies, but the lexer no longer gets upset at extremely long dict words. They are just silently trimmed to DICT_WORD_SIZE. On Glulx, DICT_WORD_SIZE can now be increased without limit.

(There's still a hardcoded MAX_VERB_WORD_SIZE limit, due to the way the English_verb_list table is stored. I'll clean that up someday.)

(The lexer limit on strings has already been removed.)

---

The most unpleasant part of this task turned out to be local variables. We were storing them in a fixed-size array of fixed-size chunks. That all had to be redone.

As part of that, I realized that passing a `no_locals` argument to assemble_routine_header() was scar tissue. There was already a `no_locals` global, so passing it as an argument was redundant. Furthermore, all assemble_routine_header() did with it was store it in a static global `routine_locals` for later use! Three variables to store a single value, sigh.

I got rid of `routine_locals` and the argument. Everybody now relies on the `no_locals` global. To set this up, we call clear_local_variables() / add_local_variable() as appropriate before calling assemble_routine_header(). 

Local variables aside, storing very long symbols required only small changes to symbols.c. We might have to allocate a symbol_name_space_chunk which is larger than SYMBOLS_CHUNK_SIZE. 

I also had to replace a few fixed-length string buffers with memlists. These were mostly small changes, although write_the_identifier_names() got reworked quite a bit.


 
