### PR TITLE
Uniform linebreak counting

### DIFF
--- a/chars.c
+++ b/chars.c
@@ -322,8 +322,9 @@ static void read_source_to_iso_file(uchar *uccg)
 /*                                                                           */
 /*      00         remains 0 (meaning "end of file")                         */
 /*      TAB        becomes SPACE                                             */
+/*      0a         remains '\n'                                              */
 /*      0c         ("form feed") becomes '\n'                                */
-/*      0d         becomes '\n'                                              */
+/*      0d         remains '\r'                                              */
 /*      other control characters become '?'                                  */
 /*      7f         becomes '?'                                               */
 /*      80 to 9f   become '?'                                                */
@@ -346,7 +347,7 @@ static void make_source_to_iso_grid(void)
         for (n=1; n<32; n++) source_to_iso_grid[n] = '?';
         source_to_iso_grid[10] = '\n';
         source_to_iso_grid[12] = '\n';
-        source_to_iso_grid[13] = '\n';
+        source_to_iso_grid[13] = '\r';
         source_to_iso_grid[127] = '?';
         source_to_iso_grid[TAB_CHARACTER] = ' ';
 

--- a/files.c
+++ b/files.c
@@ -102,7 +102,7 @@ extern void load_sourcefile(char *filename_given, int same_directory_flag)
     do
     {   x = translate_in_filename(x, name, filename_given, same_directory_flag,
                 (total_files==0)?1:0);
-        handle = fopen(name,"r");
+        handle = fopen(name,"rb");
     } while ((handle == NULL) && (x != 0));
 
     InputFiles[total_files].filename = my_malloc(strlen(name)+1, "filename storage");

--- a/inform.c
+++ b/inform.c
@@ -1530,6 +1530,16 @@ static int strcpyupper(char *to, char *from, int max)
 static void execute_icl_command(char *p);
 static int execute_dashdash_command(char *p, char *p2);
 
+/* Open a file and see whether the initial lines match the "!% ..." format
+   used for ICL commands. Stop when we reach a line that doesn't.
+   
+   This does not do line break conversion. It just reads to the next
+   \n (and ignores \r as whitespace). Therefore it will work on Unix and
+   DOS source files, but fail to cope with Mac-Classic (\r) source files.
+   I am not going to worry about this, because files from the Mac-Classic
+   era shouldn't have "!%" lines; that convention was invented well after
+   Mac switched over to \n format.
+ */
 static int execute_icl_header(char *argname)
 {
   FILE *command_file;
@@ -1542,7 +1552,7 @@ static int execute_icl_header(char *argname)
 
   do
     {   x = translate_in_filename(x, filename, argname, 0, 1);
-        command_file = fopen(filename,"r");
+        command_file = fopen(filename,"rb");
     } while ((command_file == NULL) && (x != 0));
   if (!command_file) {
     /* Fail silently. The regular compiler will try to open the file

--- a/lexer.c
+++ b/lexer.c
@@ -1582,7 +1582,12 @@ static int get_next_char_from_string(void)
     CurrentLB->chars_read++;
     if (forerrors_pointer < FORERRORS_SIZE-1)
         forerrors_buff[forerrors_pointer++] = current;
+
+    /* We shouldn't have \r when compiling from string (veneer function).
+       If we do, just shove it under the carpet. */
+    if (current == '\r') current = '\n';
     if (current == '\n') reached_new_line();
+    
     return(current);
 }
 


### PR DESCRIPTION
We now open source files with `fopen(name, "rb")` and handle the linebreak conversion ourselves.

This avoids inconsistencies when compiling the same file on Mac and Windows. See discussion: https://github.com/DavidKinder/Inform6/issues/224 . This PR addresses that issue.

The fix turned out to be small. Change `source_to_iso_grid[]` to pass `\r` through unchanged. Then, in get_next_char_from_pipeline(), convert `\r` to `\n` after being careful about incrementing the line count.

`tokeniser_grid[]` has to recognize `\r` as whitespace (because we sometimes look ahead at `lookahead` without going through get_next_char()). The only other tweak I needed was when checking for the end of a comment line.

One corner case remains: ICL header comments won't work in an old-Mac source file (`\r` linebreaks). I don't feel fussed about this because source files from that era won't have `!%` comments.

Test cases, as usual, are at https://github.com/erkyrath/Inform6-Testing/tree/uniform-linebreak . 
