### PR TITLE
Action symbol bug

### DIFF
--- a/states.c
+++ b/states.c
@@ -86,7 +86,11 @@ static void parse_action(void)
     }
     else
     {
-        if (token_type != UQ_TT) {
+        /* The token might be a symbol, or not. I think this is a matter of
+           lookahead, which is part of the general problem with lookahead
+           and dont_enter_into_symbol_table. But we can work around it
+           here. */
+        if (token_type != UQ_TT && token_type != SYMBOL_TT) {
             ebf_curtoken_error("name of action");
         }
         codegen_action = FALSE;

--- a/states.c
+++ b/states.c
@@ -86,10 +86,10 @@ static void parse_action(void)
     }
     else
     {
-        /* The token might be a symbol, or not. I think this is a matter of
-           lookahead, which is part of the general problem with lookahead
-           and dont_enter_into_symbol_table. But we can work around it
-           here. */
+        /* The token might be a symbol, or not. I think which you get is a
+           matter of lookahead, which is part of the general problem with
+           lookahead and dont_enter_into_symbol_table. But we can work
+           around it here by checking both possibilities. */
         if (token_type != UQ_TT && token_type != SYMBOL_TT) {
             ebf_curtoken_error("name of action");
         }


### PR DESCRIPTION
Fix for https://github.com/DavidKinder/Inform6/issues/231 .

Weirdly, this *wasn't* a result of https://github.com/DavidKinder/Inform6/pull/214 as I thought. It was actually caused by https://github.com/DavidKinder/Inform6/pull/212 (change https://github.com/DavidKinder/Inform6/commit/160b34e81071d3de040cce3ac29ef720454c04ad ). The problem only appears in `switch` cases because of how we set `dont_enter_into_symbol_table` in different statement contexts.

Long story: we sometimes set the `dont_enter_into_symbol_table` flag before reading a token, if we don't expect it to be a symbol. (E.g. in the statement `<Look>`, there is no symbol `Look` -- the language only recognizes `##Look` and `LookSub`.) 

But there's that damnable comment in lexer.c:

```
        In fact, for efficiency reasons this number omits the bit of
        information held in the variable "dont_enter_into_symbol_table".
        Inform never needs to backtrack through tokens parsed in that
        way (thankfully, as it would be expensive indeed to check
        the tokens).
```

Turns out Inform *does* need to backtrack through tokens parsed that way, and several problems are now dangling off that. I'll file a separate bug.

In the meantime, we can cope with *this* bug simply by accepting both cases for `<Look>`. The token might be an unquoted-string literal or a symbol by the time we see it.
