### PR TITLE
put_token_back() reverts symbols

### DIFF
--- a/bpatch.c
+++ b/bpatch.c
@@ -137,7 +137,7 @@ static int32 backpatch_value_z(int32 value)
                 break;
             }
             if (symbols[value].type != ROUTINE_T) {
-                ebf_error("routine named 'Main'", symbols[value].name);
+                ebf_symbol_error("'Main' routine", symbols[value].name, typename(symbols[value].type), symbols[value].line);
                 value = 0;
                 break;
             }

--- a/bpatch.c
+++ b/bpatch.c
@@ -130,9 +130,17 @@ static int32 backpatch_value_z(int32 value)
             value += individuals_offset;
             break;
         case MAIN_MV:
-            value = symbol_index("Main", -1);
-            if (symbols[value].type != ROUTINE_T)
+            value = get_symbol_index("Main");
+            if (value < 0 || (symbols[value].flags & UNKNOWN_SFLAG)) {
                 error("No 'Main' routine has been defined");
+                value = 0;
+                break;
+            }
+            if (symbols[value].type != ROUTINE_T) {
+                ebf_error("routine named 'Main'", symbols[value].name);
+                value = 0;
+                break;
+            }
             symbols[value].flags |= USED_SFLAG;
             value = symbols[value].value;
             if (OMIT_UNUSED_ROUTINES)

--- a/bpatch.c
+++ b/bpatch.c
@@ -285,9 +285,17 @@ static int32 backpatch_value_g(int32 value)
             value += individuals_offset;
             break;
         case MAIN_MV:
-            value = symbol_index("Main", -1);
-            if (symbols[value].type != ROUTINE_T)
+            value = get_symbol_index("Main");
+            if (value < 0 || (symbols[value].flags & UNKNOWN_SFLAG)) {
                 error("No 'Main' routine has been defined");
+                value = 0;
+                break;
+            }
+            if (symbols[value].type != ROUTINE_T) {
+                ebf_symbol_error("'Main' routine", symbols[value].name, typename(symbols[value].type), symbols[value].line);
+                value = 0;
+                break;
+            }
             symbols[value].flags |= USED_SFLAG;
             value = symbols[value].value;
             if (OMIT_UNUSED_ROUTINES)

--- a/directs.c
+++ b/directs.c
@@ -1097,7 +1097,10 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
         if (debugfile_switch)
         {   write_debug_undef(token_value);
         }
-        end_symbol_scope(token_value);
+        /* We remove it from the symbol table. But previous uses of the symbol
+           were valid, so we don't set neverused true. We also mark it
+           USED so that it can't trigger "symbol not used" warnings. */
+        end_symbol_scope(token_value, FALSE);
         symbols[token_value].flags |= USED_SFLAG;
         break;
 

--- a/directs.c
+++ b/directs.c
@@ -1155,8 +1155,8 @@ Fake_Action directives to a point after the inclusion of \"Parser\".)");
                    version.
                    The calculation here is repeated from select_target(). */
                 DICT_ENTRY_BYTE_LENGTH = ((version_number==3)?7:9) - (ZCODE_LESS_DICT_DATA?1:0);
-                debtok = symbol_index("DICT_ENTRY_BYTES", -1);
-                if (!(symbols[debtok].flags & UNKNOWN_SFLAG))
+                debtok = get_symbol_index("DICT_ENTRY_BYTES");
+                if (debtok >= 0 && !(symbols[debtok].flags & UNKNOWN_SFLAG))
                 {
                     if (!(symbols[debtok].flags & REDEFINABLE_SFLAG))
                     {

--- a/expressc.c
+++ b/expressc.c
@@ -1071,10 +1071,16 @@ static assembly_operand check_nonzero_at_runtime_g(assembly_operand AO1,
     /* Test if inside the "Class" object... */
     INITAOTV(&AO3, BYTECONSTANT_OT, GOBJFIELD_PARENT());
     assembleg_3(aload_gc, AO, AO3, stack_pointer);
-    ln = symbol_index("Class", -1);
-    AO3.value = symbols[ln].value;
-    AO3.marker = OBJECT_MV;
-    AO3.type = CONSTANT_OT;
+    ln = get_symbol_index("Class");
+    if (ln < 0) {
+        error("No 'Class' object found");
+        AO3 = zero_operand;
+    }
+    else {
+        AO3.value = symbols[ln].value;
+        AO3.marker = OBJECT_MV;
+        AO3.type = CONSTANT_OT;
+    }
     assembleg_2_branch(jne_gc, stack_pointer, AO3, passed_label);
   }
   
@@ -1092,10 +1098,16 @@ static assembly_operand check_nonzero_at_runtime_g(assembly_operand AO1,
   }
   else {
     /* Build the symbol for "Object" */
-    ln = symbol_index("Object", -1);
-    AO2.value = symbols[ln].value;
-    AO2.marker = OBJECT_MV;
-    AO2.type = CONSTANT_OT;
+    ln = get_symbol_index("Object");
+    if (ln < 0) {
+        error("No 'Object' object found");
+        AO2 = zero_operand;
+    }
+    else {
+        AO2.value = symbols[ln].value;
+        AO2.marker = OBJECT_MV;
+        AO2.type = CONSTANT_OT;
+    }
     if (check_sp) {
       /* Push "Object" */
       assembleg_store(AO1, AO2);

--- a/expressp.c
+++ b/expressp.c
@@ -311,8 +311,8 @@ but not used as a value:", unicode);
 
                     current_token.text += 3;
                     current_token.type = SYMBOL_TT;
-                    symbol = symbol_index(current_token.text, -1);
-                    if (symbols[symbol].type != GLOBAL_VARIABLE_T) {
+                    symbol = get_symbol_index(current_token.text);
+                    if (symbol < 0 || symbols[symbol].type != GLOBAL_VARIABLE_T) {
                         ebf_error(
                         "global variable name after '#g$'",
                         current_token.text);

--- a/expressp.c
+++ b/expressp.c
@@ -363,7 +363,7 @@ but not used as a value:", unicode);
                         "'#r$Routine' can now be written just 'Routine'");
                     current_token.text += 3;
                     current_token.type = SYMBOL_TT;
-                    current_token.value = symbol_index(current_token.text, -1);
+                    current_token.value = symbol_index(current_token.text, -1, NULL);
                     goto ReceiveSymbol;
 
                 case HASHWDOLLAR_SEP:

--- a/header.h
+++ b/header.h
@@ -814,7 +814,7 @@ typedef struct lexeme_data_s {
     char *text;  /* points at lextexts array */
     int32 value;
     int type;    /* a *_TT value */
-    int newsymbol; /* (for SYMBOL_TT) this symbol was first encountered here */
+    int newsymbol; /* (for SYMBOL_TT) this token created the symbol */
     debug_location location;
     int lextext; /* index of text string in lextexts */
     int context; /* lexical context used to interpret this token */

--- a/header.h
+++ b/header.h
@@ -1288,7 +1288,7 @@ typedef struct operator_s
 #define DEFCON_SFLAG   8     /* defined by Default */
 #define STUB_SFLAG     16    /* defined by Stub */
 #define UNHASHED_SFLAG 32    /* removed from hash chain */
-/*                     64       flag no longer used */
+#define DISCARDED_SFLAG 64   /* removed and should never have been used */
 #define ALIASED_SFLAG  128   /* defined as property/attribute alias name */
 
 #define CHANGE_SFLAG   256   /* defined by Default with a value,
@@ -2661,7 +2661,7 @@ extern int hash_code_from_string(char *p);
 extern int strcmpcis(char *p, char *q);
 extern int get_symbol_index(char *p);
 extern int symbol_index(char *lexeme_text, int hashcode, int *created);
-extern void end_symbol_scope(int k);
+extern void end_symbol_scope(int k, int neveruse);
 extern void describe_symbol(int k);
 extern void list_symbols(int level);
 extern void assign_marked_symbol(int index, int marker, int32 value, int type);

--- a/header.h
+++ b/header.h
@@ -1286,8 +1286,8 @@ typedef struct operator_s
 #define USED_SFLAG     4     /* referred to in code */
 #define DEFCON_SFLAG   8     /* defined by Default */
 #define STUB_SFLAG     16    /* defined by Stub */
-#define IMPORT_SFLAG   32    /* no longer used */
-#define EXPORT_SFLAG   64    /* no longer used */
+#define UNHASHED_SFLAG 32    /* removed from hash chain */
+#define EXPORT_SFLAG   64    /* flag no longer used */
 #define ALIASED_SFLAG  128   /* defined as property/attribute alias name */
 
 #define CHANGE_SFLAG   256   /* defined by Default with a value,

--- a/header.h
+++ b/header.h
@@ -1287,7 +1287,7 @@ typedef struct operator_s
 #define DEFCON_SFLAG   8     /* defined by Default */
 #define STUB_SFLAG     16    /* defined by Stub */
 #define UNHASHED_SFLAG 32    /* removed from hash chain */
-#define EXPORT_SFLAG   64    /* flag no longer used */
+/*                     64       flag no longer used */
 #define ALIASED_SFLAG  128   /* defined as property/attribute alias name */
 
 #define CHANGE_SFLAG   256   /* defined by Default with a value,

--- a/header.h
+++ b/header.h
@@ -1281,22 +1281,25 @@ typedef struct operator_s
 /*   Symbol flag definitions (in no significant order)                       */
 /* ------------------------------------------------------------------------- */
 
-#define UNKNOWN_SFLAG  1
-#define REPLACE_SFLAG  2
-#define USED_SFLAG     4
-#define DEFCON_SFLAG   8
-#define STUB_SFLAG     16
-#define IMPORT_SFLAG   32
-#define EXPORT_SFLAG   64
-#define ALIASED_SFLAG  128
+#define UNKNOWN_SFLAG  1     /* no definition known */
+#define REPLACE_SFLAG  2     /* routine marked for Replace */
+#define USED_SFLAG     4     /* referred to in code */
+#define DEFCON_SFLAG   8     /* defined by Default */
+#define STUB_SFLAG     16    /* defined by Stub */
+#define IMPORT_SFLAG   32    /* no longer used */
+#define EXPORT_SFLAG   64    /* no longer used */
+#define ALIASED_SFLAG  128   /* defined as property/attribute alias name */
 
-#define CHANGE_SFLAG   256
-#define SYSTEM_SFLAG   512
-#define INSF_SFLAG     1024
-#define UERROR_SFLAG   2048
-#define ACTION_SFLAG   4096
-#define REDEFINABLE_SFLAG  8192
-#define STAR_SFLAG    16384
+#define CHANGE_SFLAG   256   /* defined by Default with a value,
+                                or symbol has a backpatchable value */
+#define SYSTEM_SFLAG   512   /* created by compiler */
+#define INSF_SFLAG     1024  /* created in System_File */
+#define UERROR_SFLAG   2048  /* "No such constant" error issued */
+#define ACTION_SFLAG   4096  /* action name constant (Foo_A) */
+#define REDEFINABLE_SFLAG  8192  /* built-in symbol that can be redefined
+                                    by the user */
+#define STAR_SFLAG    16384  /* function defined with "*" or property named
+                                "foo_to" */
 
 /* ------------------------------------------------------------------------- */
 /*   Symbol type definitions                                                 */

--- a/header.h
+++ b/header.h
@@ -2659,7 +2659,7 @@ extern char *typename(int type);
 extern int hash_code_from_string(char *p);
 extern int strcmpcis(char *p, char *q);
 extern int get_symbol_index(char *p);
-extern int symbol_index(char *lexeme_text, int hashcode);
+extern int symbol_index(char *lexeme_text, int hashcode, int *created);
 extern void end_symbol_scope(int k);
 extern void describe_symbol(int k);
 extern void list_symbols(int level);

--- a/header.h
+++ b/header.h
@@ -814,6 +814,7 @@ typedef struct lexeme_data_s {
     char *text;  /* points at lextexts array */
     int32 value;
     int type;    /* a *_TT value */
+    int newsymbol; /* (for SYMBOL_TT) this symbol was first encountered here */
     debug_location location;
     int lextext; /* index of text string in lextexts */
     int context; /* lexical context used to interpret this token */

--- a/lexer.c
+++ b/lexer.c
@@ -795,6 +795,7 @@ extern void construct_local_variable_tables(void)
 
 static void interpret_identifier(char *p, int pos, int dirs_only_flag)
 {   int index, hashcode;
+    int created;
 
     /*  An identifier is either a keyword or a "symbol", a name which the
         lexical analyser leaves to higher levels of Inform to understand.    */
@@ -865,7 +866,7 @@ static void interpret_identifier(char *p, int pos, int dirs_only_flag)
 
     /*  Search for the name; create it if necessary.                         */
 
-    circle[pos].value = symbol_index(p, hashcode);
+    circle[pos].value = symbol_index(p, hashcode, &created);
     circle[pos].type = SYMBOL_TT;
 }
 

--- a/lexer.c
+++ b/lexer.c
@@ -624,7 +624,7 @@ static int lexical_context(void)
 static void print_context(int c)
 {
     if (c < 0) {
-        printf("???");
+        printf("??? ");
         return;
     }
     if ((c & 1) != 0) printf("OPC ");

--- a/lexer.c
+++ b/lexer.c
@@ -599,6 +599,7 @@ static int lexical_context(void)
         always translate to the same output tokens whenever the context
         is the same.
 
+        ####
         In fact, for efficiency reasons this number omits the bit of
         information held in the variable "dont_enter_into_symbol_table".
         Inform never needs to backtrack through tokens parsed in that
@@ -619,11 +620,17 @@ static int lexical_context(void)
     if (local_variables.enabled)      c |= 1024;
 
     if (return_sp_as_variable)        c |= 2048;
+    if (dont_enter_into_symbol_table) c |= 4096;
+    
     return(c);
 }
 
 static void print_context(int c)
 {
+    if (c < 0) {
+        printf("???");
+        return;
+    }
     if ((c & 1) != 0) printf("OPC ");
     if ((c & 2) != 0) printf("DIR ");
     if ((c & 4) != 0) printf("TK ");
@@ -795,11 +802,12 @@ extern void construct_local_variable_tables(void)
 
 static void interpret_identifier(char *p, int pos, int dirs_only_flag)
 {   int index, hashcode;
-    int created;
 
     /*  An identifier is either a keyword or a "symbol", a name which the
         lexical analyser leaves to higher levels of Inform to understand.    */
 
+    circle[pos].newsymbol = FALSE;
+    
     hashcode = hash_code_from_string(p);
 
     /* dir_only_flag means we should only recognize directive keywords.      */
@@ -867,7 +875,12 @@ static void interpret_identifier(char *p, int pos, int dirs_only_flag)
 
     /*  Search for the name; create it if necessary.                         */
 
-    circle[pos].value = symbol_index(p, hashcode, &created);
+    circle[pos].value = symbol_index(p, hashcode, &circle[pos].newsymbol);
+    if (FALSE && circle[pos].newsymbol) { //###
+        printf("### new symbol: ");
+        describe_token(&circle[pos]);
+        printf("\n");
+    } //###
     circle[pos].type = SYMBOL_TT;
 }
 
@@ -1699,11 +1712,27 @@ extern void release_token_texts(void)
 extern void put_token_back(void)
 {   tokens_put_back++;
 
+    int pos = circle_position - tokens_put_back + 1;
+    if (pos<0) pos += CIRCLE_SIZE;
+
     if (tokens_trace_level > 0)
-    {   if (tokens_trace_level == 1) printf("<- ");
-        else printf("<-\n");
+    {
+        printf("<- ");
+        if (tokens_trace_level > 1) {
+            describe_token(&circle[pos]);
+            printf("\n");
+        }
     }
 
+    if (circle[pos].type == SYMBOL_TT && circle[pos].newsymbol) {
+        //printf("### putting back a new symbol '%s'!\n", symbols[circle[pos].value].name);
+        end_symbol_scope(circle[pos].value); //### flag?
+        /* Remove new-symbol flag, and force reinterpretation next time
+           we see the symbol. */
+        circle[pos].newsymbol = FALSE;
+        circle[pos].context = -1;
+    }
+    
     /*  The following error, of course, should never happen!                 */
 
     if (tokens_put_back == CIRCLE_SIZE)
@@ -1802,6 +1831,7 @@ extern void get_next_token(void)
     circle[circle_position].text = NULL; /* will fill in later */
     circle[circle_position].value = 0;
     circle[circle_position].type = 0;
+    circle[circle_position].newsymbol = FALSE;
     circle[circle_position].context = context;
 
     StartTokenAgain:
@@ -2107,7 +2137,10 @@ extern void get_next_token(void)
         else
         {   printf("-> "); describe_token(&circle[i]);
             printf(" ");
-            if (tokens_trace_level > 2) print_context(circle[i].context);
+            if (tokens_trace_level > 2) {
+                if (circle[i].newsymbol) printf("newsym ");
+                print_context(circle[i].context);
+            }
             printf("\n");
         }
     }
@@ -2121,6 +2154,7 @@ extern void restart_lexer(char *lexical_source, char *name)
     for (i=0; i<CIRCLE_SIZE; i++)
     {   circle[i].type = 0;
         circle[i].value = 0;
+        circle[i].newsymbol = FALSE;
         circle[i].text = "(if this is ever visible, there is a bug)";
         circle[i].lextext = -1;
         circle[i].context = 0;

--- a/lexer.c
+++ b/lexer.c
@@ -639,6 +639,7 @@ static void print_context(int c)
     if ((c & 512) != 0) printf("SCON ");
     if ((c & 1024) != 0) printf("LV ");
     if ((c & 2048) != 0) printf("sp ");
+    if ((c & 4096) != 0) printf("dontent ");
 }
 
 static int *keywords_hash_table;

--- a/lexer.c
+++ b/lexer.c
@@ -1725,8 +1725,9 @@ extern void put_token_back(void)
     }
 
     if (circle[pos].type == SYMBOL_TT && circle[pos].newsymbol) {
-        //printf("### putting back a new symbol '%s'!\n", symbols[circle[pos].value].name);
-        end_symbol_scope(circle[pos].value); //### flag?
+        /* Remove the symbol from the symbol table. (Or mark it as unreachable
+           anyhow.) */
+        end_symbol_scope(circle[pos].value, TRUE);
         /* Remove new-symbol flag, and force reinterpretation next time
            we see the symbol. */
         circle[pos].newsymbol = FALSE;

--- a/lexer.c
+++ b/lexer.c
@@ -599,12 +599,8 @@ static int lexical_context(void)
         always translate to the same output tokens whenever the context
         is the same.
 
-        ####
-        In fact, for efficiency reasons this number omits the bit of
-        information held in the variable "dont_enter_into_symbol_table".
-        Inform never needs to backtrack through tokens parsed in that
-        way (thankfully, as it would be expensive indeed to check
-        the tokens).                                                         */
+        (For many years, the "dont_enter_into_symbol_table" variable
+        was omitted from this number. But now we can include it.)            */
 
     int c = 0;
     if (opcode_names.enabled)         c |= 1;
@@ -876,11 +872,6 @@ static void interpret_identifier(char *p, int pos, int dirs_only_flag)
     /*  Search for the name; create it if necessary.                         */
 
     circle[pos].value = symbol_index(p, hashcode, &circle[pos].newsymbol);
-    if (FALSE && circle[pos].newsymbol) { //###
-        printf("### new symbol: ");
-        describe_token(&circle[pos]);
-        printf("\n");
-    } //###
     circle[pos].type = SYMBOL_TT;
 }
 

--- a/lexer.c
+++ b/lexer.c
@@ -802,6 +802,7 @@ static void interpret_identifier(char *p, int pos, int dirs_only_flag)
 
     hashcode = hash_code_from_string(p);
 
+    /* dir_only_flag means we should only recognize directive keywords.      */
     if (dirs_only_flag) goto KeywordSearch;
 
     /*  If this is assembly language, perhaps it is "sp"?                    */

--- a/lexer.c
+++ b/lexer.c
@@ -808,9 +808,9 @@ static void interpret_identifier(char *p, int pos)
     hashcode = hash_code_from_string(p);
 
     /*  If dont_enter_into_symbol_table is true, we skip all keywords
-        and just mark it as an unquoted string. Except that if
-        dont_enter_into_symbol_table is -2, we recognize directive keywords
-        (only).
+        (and variables) and just mark the name as an unquoted string.
+        Except that if dont_enter_into_symbol_table is -2, we recognize
+        directive keywords (only).
     */
 
     if (dont_enter_into_symbol_table) {

--- a/objects.c
+++ b/objects.c
@@ -1878,7 +1878,7 @@ inconvenience, please contact the maintainers.");
 
     if (metaclass_flag)
     {   token_text = metaclass_name;
-        token_value = symbol_index(token_text, -1);
+        token_value = symbol_index(token_text, -1, NULL);
         token_type = SYMBOL_TT;
     }
     else

--- a/states.c
+++ b/states.c
@@ -86,11 +86,7 @@ static void parse_action(void)
     }
     else
     {
-        /* The token might be a symbol, or not. I think which you get is a
-           matter of lookahead, which is part of the general problem with
-           lookahead and dont_enter_into_symbol_table. But we can work
-           around it here by checking both possibilities. */
-        if (token_type != UQ_TT && token_type != SYMBOL_TT) {
+        if (token_type != UQ_TT) {
             ebf_curtoken_error("name of action");
         }
         codegen_action = FALSE;

--- a/states.c
+++ b/states.c
@@ -2468,10 +2468,16 @@ static void parse_statement_g(int break_label, int continue_label)
                  }
 
                  sequence_point_follows = TRUE;
-                 ln = symbol_index("Class", -1);
-                 INITAOT(&AO2, CONSTANT_OT);
-                 AO2.value = symbols[ln].value;
-                 AO2.marker = OBJECT_MV;
+                 ln = get_symbol_index("Class");
+                 if (ln < 0) {
+                     error("No 'Class' object found");
+                     AO2 = zero_operand;
+                 }
+                 else {
+                     INITAOT(&AO2, CONSTANT_OT);
+                     AO2.value = symbols[ln].value;
+                     AO2.marker = OBJECT_MV;
+                 }
                  assembleg_store(AO, AO2);
 
                  assemble_label_no(ln = next_label++);

--- a/symbols.c
+++ b/symbols.c
@@ -831,7 +831,7 @@ static void stockup_symbols(void)
         create_rsymbol("Grammar__Version", 1, CONSTANT_T);
     else
         create_rsymbol("Grammar__Version", 2, CONSTANT_T);
-    grammar_version_symbol = symbol_index("Grammar__Version", -1);
+    grammar_version_symbol = get_symbol_index("Grammar__Version");
 
     if (runtime_error_checking_switch)
         create_rsymbol("STRICT_MODE",0, CONSTANT_T);

--- a/symbols.c
+++ b/symbols.c
@@ -230,12 +230,13 @@ extern int get_symbol_index(char *p)
 extern int symbol_index(char *p, int hashcode, int *created)
 {
     /*  Return the index in the symbols array of symbol "p", creating a
-        new symbol with that name if it isn't already there.
+        new symbol with that name if it isn't already there. This
+        always returns a valid symbol index.
 
         The optional created argument receives TRUE if the symbol
         was newly created.
 
-        Provide the hashcode of p if you know it, or -1 if you don't.
+        Pass in the hashcode of p if you know it, or -1 if you don't.
 
         New symbols are created with flag UNKNOWN_SFLAG, value 0x100
         (a 2-byte quantity in Z-machine terms) and type CONSTANT_T.
@@ -398,6 +399,7 @@ static void describe_flags(int flags)
     if (flags & DEFCON_SFLAG)   printf("(Defaulted) ");
     if (flags & STUB_SFLAG)     printf("(Stubbed) ");
     if (flags & UNHASHED_SFLAG) printf("(not in hash chain) ");
+    if (flags & DISCARDED_SFLAG)  printf("(removed, do not use) ");
     if (flags & ALIASED_SFLAG)  printf("(aliased) ");
     if (flags & CHANGE_SFLAG)   printf("(value will change) ");
     if (flags & SYSTEM_SFLAG)   printf("(System) ");

--- a/symbols.c
+++ b/symbols.c
@@ -227,10 +227,13 @@ extern int get_symbol_index(char *p)
     return -1;
 }
 
-extern int symbol_index(char *p, int hashcode)
+extern int symbol_index(char *p, int hashcode, int *created)
 {
     /*  Return the index in the symbols array of symbol "p", creating a
         new symbol with that name if it isn't already there.
+
+        The optional created argument receives TRUE if the symbol
+        was newly created.
 
         Provide the hashcode of p if you know it, or -1 if you don't.
 
@@ -256,6 +259,7 @@ extern int symbol_index(char *p, int hashcode)
         {
             if (track_unused_routines)
                 df_note_function_symbol(this);
+            if (created) *created = FALSE;
             return this;
         }
         if (new_entry > 0) break;
@@ -315,6 +319,7 @@ extern int symbol_index(char *p, int hashcode)
 
     if (track_unused_routines)
         df_note_function_symbol(no_symbols);
+    if (created) *created = TRUE;
     return(no_symbols++);
 }
 
@@ -784,7 +789,7 @@ static void emit_debug_information_for_predefined_symbol
 }
 
 static void create_symbol(char *p, int32 value, int type)
-{   int i = symbol_index(p, -1);
+{   int i = symbol_index(p, -1, NULL);
     if (!(symbols[i].flags & (UNKNOWN_SFLAG + REDEFINABLE_SFLAG))) {
         /* Symbol already defined! */
         if (symbols[i].value == value && symbols[i].type == type) {
@@ -804,7 +809,7 @@ static void create_symbol(char *p, int32 value, int type)
 }
 
 static void create_rsymbol(char *p, int value, int type)
-{   int i = symbol_index(p, -1);
+{   int i = symbol_index(p, -1, NULL);
     /* This is only called for a few symbols with known names.
        They will not collide. */
     symbols[i].value = value; symbols[i].type = type; symbols[i].line = blank_brief_location;

--- a/symbols.c
+++ b/symbols.c
@@ -1252,15 +1252,15 @@ extern void locate_dead_functions(void)
        issue_unused_warnings(). But for the sake of thoroughness,
        we'll mark them specially. */
 
-    ix = symbol_index("Main__", -1);
-    if (symbols[ix].type == ROUTINE_T) {
+    ix = get_symbol_index("Main__");
+    if (ix >= 0 && symbols[ix].type == ROUTINE_T) {
         uint32 addr = symbols[ix].value * (glulx_mode ? 1 : scale_factor);
         tofunc = df_function_for_address(addr);
         if (tofunc)
             tofunc->usage |= DF_USAGE_MAIN;
     }
-    ix = symbol_index("Main", -1);
-    if (symbols[ix].type == ROUTINE_T) {
+    ix = get_symbol_index("Main");
+    if (ix >= 0 && symbols[ix].type == ROUTINE_T) {
         uint32 addr = symbols[ix].value * (glulx_mode ? 1 : scale_factor);
         tofunc = df_function_for_address(addr);
         if (tofunc)

--- a/symbols.c
+++ b/symbols.c
@@ -523,7 +523,7 @@ extern void issue_unused_warnings(void)
 
     for (i=0;i<no_symbols;i++)
     {   if (((symbols[i].flags
-             & (SYSTEM_SFLAG + UNKNOWN_SFLAG + EXPORT_SFLAG
+             & (SYSTEM_SFLAG + UNKNOWN_SFLAG
                 + INSF_SFLAG + USED_SFLAG + REPLACE_SFLAG)) == 0)
              && (symbols[i].type != OBJECT_T))
             dbnu_warning(typename(symbols[i].type), symbols[i].name, symbols[i].line);

--- a/symbols.c
+++ b/symbols.c
@@ -521,15 +521,18 @@ extern void issue_unused_warnings(void)
     }
     /*  Now back to mark anything necessary as used  */
 
-    i = symbol_index("Main", -1);
-    if (!(symbols[i].flags & UNKNOWN_SFLAG)) symbols[i].flags |= USED_SFLAG;
+    i = get_symbol_index("Main");
+    if (i >= 0 && !(symbols[i].flags & UNKNOWN_SFLAG)) {
+        symbols[i].flags |= USED_SFLAG;
+    }
 
     for (i=0;i<no_symbols;i++)
     {   if (((symbols[i].flags
              & (SYSTEM_SFLAG + UNKNOWN_SFLAG
                 + INSF_SFLAG + USED_SFLAG + REPLACE_SFLAG)) == 0)
-             && (symbols[i].type != OBJECT_T))
+             && (symbols[i].type != OBJECT_T)) {
             dbnu_warning(typename(symbols[i].type), symbols[i].name, symbols[i].line);
+        }
     }
 }
 

--- a/symbols.c
+++ b/symbols.c
@@ -324,6 +324,7 @@ extern void end_symbol_scope(int k)
     */
 
     int j;
+    symbols[k].flags |= UNHASHED_SFLAG;
     j = hash_code_from_string(symbols[k].name);
     if (start_of_list[j] == k)
     {   start_of_list[j] = symbols[k].next_entry;
@@ -379,7 +380,7 @@ static void describe_flags(int flags)
     if (flags & USED_SFLAG)     printf("(used) ");
     if (flags & DEFCON_SFLAG)   printf("(Defaulted) ");
     if (flags & STUB_SFLAG)     printf("(Stubbed) ");
-    if (flags & IMPORT_SFLAG)   printf("(Imported) ");
+    if (flags & UNHASHED_SFLAG) printf("(not in hash chain) ");
     if (flags & EXPORT_SFLAG)   printf("(Exported) ");
     if (flags & ALIASED_SFLAG)  printf("(aliased) ");
     if (flags & CHANGE_SFLAG)   printf("(value will change) ");

--- a/symbols.c
+++ b/symbols.c
@@ -232,6 +232,8 @@ extern int symbol_index(char *p, int hashcode)
     /*  Return the index in the symbols array of symbol "p", creating a
         new symbol with that name if it isn't already there.
 
+        Provide the hashcode of p if you know it, or -1 if you don't.
+
         New symbols are created with flag UNKNOWN_SFLAG, value 0x100
         (a 2-byte quantity in Z-machine terms) and type CONSTANT_T.
 

--- a/symbols.c
+++ b/symbols.c
@@ -383,7 +383,6 @@ static void describe_flags(int flags)
     if (flags & DEFCON_SFLAG)   printf("(Defaulted) ");
     if (flags & STUB_SFLAG)     printf("(Stubbed) ");
     if (flags & UNHASHED_SFLAG) printf("(not in hash chain) ");
-    if (flags & EXPORT_SFLAG)   printf("(Exported) ");
     if (flags & ALIASED_SFLAG)  printf("(aliased) ");
     if (flags & CHANGE_SFLAG)   printf("(value will change) ");
     if (flags & SYSTEM_SFLAG)   printf("(System) ");

--- a/symbols.c
+++ b/symbols.c
@@ -330,7 +330,7 @@ extern void end_symbol_scope(int k, int neveruse)
        and put_token_back().
 
        If you know the symbol has never been used, set neveruse and
-       it will be flagged as a compiler error if it *is* used.
+       it will be flagged as an error if it *is* used.
        
        If the symbol is not found in the hash table, this silently does
        nothing.

--- a/symbols.c
+++ b/symbols.c
@@ -327,7 +327,8 @@ extern void end_symbol_scope(int k)
 {
     /* Remove the given symbol from the hash table, making it
        invisible to symbol_index. This is used by the Undef directive.
-       If the symbol is not found, this silently does nothing.
+       If the symbol is not found in the hash table, this silently does
+       nothing.
     */
 
     int j;

--- a/text.c
+++ b/text.c
@@ -678,8 +678,8 @@ advance as part of 'Zcharacter table':", unicode);
                     j = atoi(temp_symbol);
                 }
                 else {
-                    int sym = symbol_index(temp_symbol, -1);
-                    if ((symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
+                    int sym = get_symbol_index(temp_symbol);
+                    if (sym < 0 || (symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
                         error_named("'@(...)' abbreviation expected a known constant value, but contained", temp_symbol);
                     }
                     else {
@@ -878,8 +878,8 @@ string.");
                 j = atoi(temp_symbol);
             }
             else {
-                int sym = symbol_index(temp_symbol, -1);
-                if ((symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
+                int sym = get_symbol_index(temp_symbol);
+                if (sym < 0 || (symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
                     error_named("'@(...)' abbreviation expected a known constant value, but contained", temp_symbol);
                 }
                 else {

--- a/veneer.c
+++ b/veneer.c
@@ -33,7 +33,7 @@ extern void compile_initial_routine(void)
   int32 j;
     assembly_operand AO;
 
-    j = symbol_index("Main__", -1);
+    j = symbol_index("Main__", -1, NULL);
     clear_local_variables();
     assign_symbol(j,
         assemble_routine_header(FALSE, "Main__", FALSE, j),
@@ -2231,7 +2231,7 @@ static void compile_symbol_table_routine(void)
     add_local_variable("dummy1");
     add_local_variable("dummy2");
 
-    veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1);
+    veneer_mode = TRUE; j = symbol_index("Symb__Tab", -1, NULL);
     assign_symbol(j,
         assemble_routine_header(FALSE, "Symb__Tab", FALSE, j),
         ROUTINE_T);
@@ -2385,7 +2385,7 @@ extern void compile_veneer(void)
     {   try_veneer_again = FALSE;
         for (i=0; i<VENEER_ROUTINES; i++)
         {   if (veneer_routine_needs_compilation[i] == VR_CALLED)
-            {   j = symbol_index(VRs[i].name, -1);
+            {   j = symbol_index(VRs[i].name, -1, NULL);
                 if (symbols[j].flags & UNKNOWN_SFLAG)
                 {   veneer_mode = TRUE;
                     strcpy(veneer_source_area, VRs[i].source1);

--- a/verbs.c
+++ b/verbs.c
@@ -329,7 +329,7 @@ extern void make_fake_action(void)
     
     /* Action symbols (including fake_actions) may collide with other kinds of symbols. So we don't check that. */
 
-    i = symbol_index(action_sub, -1);
+    i = symbol_index(action_sub, -1, NULL);
 
     if (!(symbols[i].flags & UNKNOWN_SFLAG))
     {   discard_token_location(beginning_debug_location);
@@ -372,7 +372,7 @@ extern assembly_operand action_of_name(char *name)
     strcpy(action_sub, name);
     strcat(action_sub, "__A");
     
-    j = symbol_index(action_sub, -1);
+    j = symbol_index(action_sub, -1, NULL);
 
     if (symbols[j].type == FAKE_ACTION_T)
     {   INITAO(&AO);
@@ -426,7 +426,7 @@ extern void find_the_actions(void)
         action_name[namelen - 3] = '\0'; /* remove "__A" */
         strcpy(action_sub, action_name);
         strcat(action_sub, "Sub");
-        j = symbol_index(action_sub, -1);
+        j = symbol_index(action_sub, -1, NULL);
         if (symbols[j].flags & UNKNOWN_SFLAG)
         {
             error_named_at("No ...Sub action routine found for action:", action_name, symbols[actions[i].symbol].line);

--- a/verbs.c
+++ b/verbs.c
@@ -426,13 +426,12 @@ extern void find_the_actions(void)
         action_name[namelen - 3] = '\0'; /* remove "__A" */
         strcpy(action_sub, action_name);
         strcat(action_sub, "Sub");
-        j = symbol_index(action_sub, -1);
-        if (symbols[j].flags & UNKNOWN_SFLAG)
+        j = get_symbol_index(action_sub);
+        if (j < 0 || symbols[j].flags & UNKNOWN_SFLAG)
         {
             error_named_at("No ...Sub action routine found for action:", action_name, symbols[actions[i].symbol].line);
         }
-        else
-        if (symbols[j].type != ROUTINE_T)
+        else if (symbols[j].type != ROUTINE_T)
         {
             error_named_at("No ...Sub action routine found for action:", action_name, symbols[actions[i].symbol].line);
             error_named_at("-- ...Sub symbol found, but not a routine:", action_sub, symbols[j].line);

--- a/verbs.c
+++ b/verbs.c
@@ -433,8 +433,7 @@ extern void find_the_actions(void)
         }
         else if (symbols[j].type != ROUTINE_T)
         {
-            error_named_at("No ...Sub action routine found for action:", action_name, symbols[actions[i].symbol].line);
-            error_named_at("-- ...Sub symbol found, but not a routine:", action_sub, symbols[j].line);
+            ebf_symbol_error("action's ...Sub routine", action_sub, typename(symbols[j].type), symbols[j].line);
         }
         else
         {   actions[i].byte_offset = symbols[j].value;

--- a/verbs.c
+++ b/verbs.c
@@ -426,8 +426,8 @@ extern void find_the_actions(void)
         action_name[namelen - 3] = '\0'; /* remove "__A" */
         strcpy(action_sub, action_name);
         strcat(action_sub, "Sub");
-        j = get_symbol_index(action_sub);
-        if (j < 0 || symbols[j].flags & UNKNOWN_SFLAG)
+        j = symbol_index(action_sub, -1);
+        if (symbols[j].flags & UNKNOWN_SFLAG)
         {
             error_named_at("No ...Sub action routine found for action:", action_name, symbols[actions[i].symbol].line);
         }


### PR DESCRIPTION
If we call get_next_token() and it creates a symbol, but then you call put_token_back(), it uncreates the symbol.

(Really it just unlinks the symbol from the symbol-hash-table, so it can never be recognized in the future.)

This fixes https://github.com/DavidKinder/Inform6/issues/163 , https://github.com/DavidKinder/Inform6/issues/201 , and https://github.com/DavidKinder/Inform6/issues/231 (without the hack I used to fix 231 before). And https://github.com/DavidKinder/Inform6/issues/233 of course.

----

Under the hood:

symbol_index() now has an extra out-argument `*created` which returns whether the symbol already existed (false), or had to be created (true). If you don't care about this, pass NULL.

The only caller that cares about this is interpret_identifier() in the lexer. This now stashes the flag in the lexeme ring as `newsymbol`. (Only for tokens that are symbols, of course.)

In put_token_back(), if we're putting back a symbol with `newsymbol` set, we call end_symbol_scope() to nuke it. We'll be seeing it again very soon (get_next_token() calls interpret_identifier()), but maybe `dont_enter_into_symbol_table` will be true next time.

As part of this work, I moved the check for `dont_enter_into_symbol_table` inside interpret_identifier(). This is the case where we want to return `UQ_TT` (unquoted string) instead of `SYMBOL_TT`. This makes interpret_identifier() quite a bit simpler; I was able to get rid of the confusing `dirs_only_flag` argument entirely. And a `goto`!

On the other hand, I had to repeat the keyword search loop for the extra-special case `dont_enter_into_symbol_table == -2` (recognize directive keywords only).

Several places that called symbol_index(), but required the symbol to exist, now call get_symbol_index() instead. (This is an alternative that just searches for a symbol, without trying to create it.) I also check the return value of that, which means a bit more error-checking code.

I commented all the `_SFLAG` definitions in header.h.


