### PR TITLE
Replace quoted_size++

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -1987,6 +1987,7 @@ extern void get_next_token(void)
             quoted_size=0;
             do
             {   e = d; d = (*get_next_char)(); lexaddc(d);
+                quoted_size++;
                 if ((d == '\'') && (e != '@'))
                 {   if (quoted_size == 1)
                     {   d = (*get_next_char)(); lexaddc(d);
@@ -2002,7 +2003,6 @@ extern void get_next_token(void)
             break;
 
         case DQUOTE_CODE:    /* Double-quotes: scan a literal string */
-            quoted_size=0;
             do
             {   d = (*get_next_char)(); lexaddc(d);
                 if (d == '\n')


### PR DESCRIPTION
I also removed a stray `quoted_size=0` which was not being used for anything.

This fixes https://github.com/DavidKinder/Inform6/issues/234 , which turns out to be a real regression after all. (Introduced https://github.com/DavidKinder/Inform6/commit/f1d8d622abe3d0b46eaa07fc944ca50d9beacb66 .)

