### PR TITLE
Add compile target to gametext.txt

### DIFF
--- a/files.c
+++ b/files.c
@@ -661,7 +661,6 @@ static void output_file_g(void)
         final_glulx_version = requested_glulx_version;
       }
     }
-    printf("### final glulx version = %x\n", final_glulx_version);
 
     /*  (1)  Output the header. We use sf_put here, instead of fputc,
         because the header is included in the checksum. */

--- a/files.c
+++ b/files.c
@@ -1229,13 +1229,13 @@ extern void close_transcript_file(void)
     write_to_transcript_file("",  STRCTX_INFO);
 
     if (!glulx_mode) {
-        snprintf(botline_buffer, 256, "[Z-machine version %d]", version_number);
+        snprintf(botline_buffer, 256, "[Compiled Z-machine version %d]", version_number);
     }
     else {
         int32 major = (final_glulx_version >> 16) & 0xFFFF;
         int32 minor = (final_glulx_version >> 8) & 0xFF;
         int32 patch = final_glulx_version & 0xFF;
-        snprintf(botline_buffer, 256, "[Glulx version %d.%d.%d]", major, minor, patch);
+        snprintf(botline_buffer, 256, "[Compiled Glulx version %d.%d.%d]", major, minor, patch);
     }
     write_to_transcript_file(botline_buffer, STRCTX_INFO);
     

--- a/files.c
+++ b/files.c
@@ -1232,7 +1232,10 @@ extern void close_transcript_file(void)
         snprintf(botline_buffer, 256, "[Z-machine version %d]", version_number);
     }
     else {
-        snprintf(botline_buffer, 256, "[Glulx version %x]", final_glulx_version);
+        int32 major = (final_glulx_version >> 16) & 0xFFFF;
+        int32 minor = (final_glulx_version >> 8) & 0xFF;
+        int32 patch = final_glulx_version & 0xFF;
+        snprintf(botline_buffer, 256, "[Glulx version %d.%d.%d]", major, minor, patch);
     }
     write_to_transcript_file(botline_buffer, STRCTX_INFO);
     

--- a/header.h
+++ b/header.h
@@ -2475,7 +2475,7 @@ extern int
 extern int oddeven_packing_switch;
 
 extern int glulx_mode, compression_switch;
-extern int32 requested_glulx_version;
+extern int32 requested_glulx_version, final_glulx_version;
 
 extern int error_format,    store_the_text,       asm_trace_setting,
     expr_trace_setting,     tokens_trace_setting,

--- a/inform.c
+++ b/inform.c
@@ -34,7 +34,9 @@ int version_number,      /* 3 to 8 (Z-code)                                  */
 int32 scale_factor,      /* packed address multiplier                        */
     length_scale_factor; /* length-in-header multiplier                      */
 
-int32 requested_glulx_version;
+int32 requested_glulx_version; /* version requested via -v switch            */
+int32 final_glulx_version;     /* requested version combined with game
+                                  feature requirements                       */
 
 extern void select_version(int vn)
 {   version_number = vn;
@@ -334,6 +336,7 @@ static void reset_switch_settings(void)
     compression_switch = TRUE;
     glulx_mode = FALSE;
     requested_glulx_version = 0;
+    final_glulx_version = 0;
 
     /* These aren't switches, but for clarity we reset them too. */
     asm_trace_level = 0;
@@ -1109,13 +1112,13 @@ disabling -X switch\n");
 
     run_pass();
 
+    if (no_errors==0) { output_file(); output_has_occurred = TRUE; }
+    else { output_has_occurred = FALSE; }
+
     if (transcript_switch)
     {   write_dictionary_to_transcript();
         close_transcript_file();
     }
-
-    if (no_errors==0) { output_file(); output_has_occurred = TRUE; }
-    else { output_has_occurred = FALSE; }
 
     if (debugfile_switch)
     {   end_debug_file();


### PR DESCRIPTION
Handles https://github.com/DavidKinder/Inform6/issues/240

In `-r` mode, the gametext.txt file now contains a line like

> [Compiled Z-machine version 8]

> [Compiled Glulx version 3.0.0]

With `$TRANSCRIPT_FORMAT=1`, this is instead

> I: [Compiled Z-machine version 8]

> I: [Compiled Glulx version 3.0.0]

Note that this line is at the end of gametext.txt, not the beginning. (Because the Glulx version number isn't finalized until compilation is complete.)

---

The change is a bit messy, but only superficially. The Glulx version number is computed in output_file_g(). That used to be done in the local variable `VersionNum`, but now we want that to persist after the output_file stage, so I renamed it to `final_glulx_version` and made it a global.

The close_transcript_file() function now generates the version line at the end of gametext.txt.

For this to work, I had to move the close_transcript_file() call after output_file(). This shouldn't affect anything. It's actually a bit tidier. The sequence in compile() is now

```
begin_debug_file();
open_transcript_file();
output_file();
close_transcript_file();
end_debug_file();
```

...which I think is a more harmonious ordering.
