### PR TITLE
parse_expression() now reports errors

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -618,6 +618,7 @@ extern void make_array()
                 put_token_back();
 
                 AO = parse_expression(ARRAY_CONTEXT);
+                //###
 
                 if (i == 0)
                 {   get_next_token();
@@ -691,6 +692,7 @@ advance as part of 'Zcharacter table':", unicode);
             i = 0;
             while (TRUE)
             {
+                assembly_operand AO;
                 /* This isn't the start of a statement, but it's safe to
                    release token texts anyway. Expressions in an array
                    list are independent of each other. */
@@ -709,7 +711,9 @@ advance as part of 'Zcharacter table':", unicode);
                     put_token_back(); break;
                 }
                 put_token_back();
-                array_entry(i, is_static, parse_expression(ARRAY_CONTEXT));
+                AO = parse_expression(ARRAY_CONTEXT);
+                //###
+                array_entry(i, is_static, AO);
                 i++;
             }
     }

--- a/arrays.c
+++ b/arrays.c
@@ -618,7 +618,8 @@ extern void make_array()
                 put_token_back();
 
                 AO = parse_expression(ARRAY_CONTEXT);
-                //###
+                if (AO.marker == ERROR_MV)
+                    break;
 
                 if (i == 0)
                 {   get_next_token();
@@ -712,7 +713,8 @@ advance as part of 'Zcharacter table':", unicode);
                 }
                 put_token_back();
                 AO = parse_expression(ARRAY_CONTEXT);
-                //###
+                if (AO.marker == ERROR_MV)
+                    break;
                 array_entry(i, is_static, AO);
                 i++;
             }

--- a/asm.c
+++ b/asm.c
@@ -2248,6 +2248,7 @@ static void transfer_routine_z(void)
           default:
             switch(zcode_markers[i] & 0x7f)
             {   case NULL_MV: break;
+                case ERROR_MV: break;
                 case VARIABLE_MV:
                 case OBJECT_MV:
                 case ACTION_MV:
@@ -2472,6 +2473,8 @@ static void transfer_routine_g(void)
       else {
         switch(zcode_markers[i] & 0x7f) {
         case NULL_MV: 
+            break;
+        case ERROR_MV:
             break;
         case ACTION_MV:
         case IDENT_MV:

--- a/bpatch.c
+++ b/bpatch.c
@@ -49,6 +49,9 @@ extern char *describe_mv(int mval)
         case ACTION_MV:     return("action");
         case OBJECT_MV:     return("internal object");
 
+        /* Only occurs secondary to another reported error */
+        case ERROR_MV:      return("error");
+
     }
     return("** No such MV **");
 }

--- a/header.h
+++ b/header.h
@@ -1927,7 +1927,9 @@ typedef struct operator_s
 #define OBJECT_MV             16     /* Ref to internal object number */
 #define STATIC_ARRAY_MV       17     /* Ref to internal static array address */
 
-#define LARGEST_BPATCH_MV     17     /* Larger marker values are never written
+#define ERROR_MV              18     /* An error was reported while
+                                        generating this value */
+#define LARGEST_BPATCH_MV     18     /* Larger marker values are never written
                                         to backpatch tables */
 
 /* Values 32-35 were used only for module import/export. */


### PR DESCRIPTION
Fixes https://github.com/DavidKinder/Inform6/issues/246 .

The problem is that parse_expression() can generate an error, but the caller (the array statement) can't detect that fact to exit its loop. 

Now parse_expression() returns a zero value with ERROR_MV set to indicate a blatant error. (Not every single error, but the ones which can lead to an infinite loop of errors. "Expected expression but found EOF" is the big offender here.)

ERROR_MV is ignored in most situations; the error has been reported, so we can just treat it as a regular zero and move on. But in two places in arrays.c, we check for it and break out of a loop. I may find other good places for this check in the future.

