### PR TITLE
Assembly format for inline bytes (and words)

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -618,6 +618,7 @@ extern void make_array()
                 put_token_back();
 
                 AO = parse_expression(ARRAY_CONTEXT);
+                /* TODO: detect expr error, exit loop */
 
                 if (i == 0)
                 {   get_next_token();
@@ -710,6 +711,7 @@ advance as part of 'Zcharacter table':", unicode);
                 }
                 put_token_back();
                 array_entry(i, is_static, parse_expression(ARRAY_CONTEXT));
+                /* TODO: detect expr error, exit loop */
                 i++;
             }
     }

--- a/asm.c
+++ b/asm.c
@@ -3136,6 +3136,7 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
     }
     else if ((token_type == SEP_TT) && (token_value == ARROW_SEP))
     {
+        int32 start_pc = zcode_ha_size;
         if (asm_trace_level > 0) {
             printf("%5d  +%05lx %3s %-12s", ErrorReport.line_number,
                    ((long int) zmachine_pc), "   ", "<bytes>");
@@ -3156,6 +3157,16 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
         }
         if (asm_trace_level > 0) {
             printf("\n");
+        }
+        if (asm_trace_level>=2)
+        {
+            int j;
+            for (j=0;start_pc<zcode_ha_size;
+                 j++, start_pc++)
+            {   if (j%16==0) printf("                               ");
+                printf("%02x ", zcode_holding_area[start_pc]);
+            }
+            if (j) printf("\n");
         }
         return;
     }

--- a/asm.c
+++ b/asm.c
@@ -3164,8 +3164,7 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
                 byteout(((AO.value >> 8) & 0xFF), AO.marker);
                 byteout((AO.value & 0xFF), 0);
                 if (asm_trace_level > 0) {
-                    printf(" %02x", ((AO.value >> 8) & 0xFF));
-                    printf(" %02x", (AO.value & 0xFF));
+                    printf(" %04x", (AO.value & 0xFFFF));
                 }
             }
         }

--- a/asm.c
+++ b/asm.c
@@ -3137,10 +3137,15 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
     else if ((token_type == SEP_TT) && (token_value == ARROW_SEP))
     {
         while (1) {
+            assembly_operand AO;
             get_next_token();
             if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) break;
+            put_token_back();
+            AO = parse_expression(ARRAY_CONTEXT);
+            if (AO.marker != 0)
+                error("Entries in code byte arrays must be known constants");
+            printf("### val -> $%x\n", (AO.value & 0xFF));
         }
-        printf("### got @-->\n"); //###
         return;
     }
     else

--- a/asm.c
+++ b/asm.c
@@ -1238,7 +1238,7 @@ extern void assemblez_instruction(const assembly_instruction *AI)
                  j++, start_pc++)
             {   if (j%16==0) printf("\n                               ");
                 if (zcode_markers[start_pc] & 0x7f)
-                    printf("[%s]", describe_mv_short(zcode_markers[start_pc] & 0x7f));
+                    printf("{%s}", describe_mv_short(zcode_markers[start_pc] & 0x7f));
                 printf("%02x ", zcode_holding_area[start_pc]);
             }
         }
@@ -1636,9 +1636,9 @@ extern void assembleg_instruction(const assembly_instruction *AI)
                 printf("%02x ", zcode_holding_area[start_pc]);
             }
             else {
-                printf("%02x", zcode_holding_area[start_pc]);
                 if (zcode_markers[start_pc])
-                    printf("{%02x}", zcode_markers[start_pc]);
+                    printf("{%s}", describe_mv_short(zcode_markers[start_pc]));
+                printf("%02x", zcode_holding_area[start_pc]);
                 printf(" ");
             }
         }
@@ -3187,7 +3187,7 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
                  j++, start_pc++)
             {   if (j%16==0) printf("                               ");
                 if (zcode_markers[start_pc] & 0x7f)
-                    printf("[%s]", describe_mv_short(zcode_markers[start_pc] & 0x7f));
+                    printf("{%s}", describe_mv_short(zcode_markers[start_pc] & 0x7f));
                 printf("%02x ", zcode_holding_area[start_pc]);
             }
             if (j) printf("\n");

--- a/asm.c
+++ b/asm.c
@@ -3150,13 +3150,23 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             put_token_back();
             AO = parse_expression(ARRAY_CONTEXT);
             /* TODO: detect expr error, exit loop */
-            if (AO.marker != 0)
-                error("Entries in code byte arrays must be known constants");
-            if (AO.value >= 256)
-                warning("Entry in code byte array not in range 0 to 255");
-            byteout((AO.value & 0xFF), 0);
-            if (asm_trace_level > 0) {
-                printf(" %02x", (AO.value & 0xFF));
+            if (!isword) {
+                if (AO.marker != 0)
+                    error("Entries in code byte arrays must be known constants");
+                if (AO.value >= 256)
+                    warning("Entry in code byte array not in range 0 to 255");
+                byteout((AO.value & 0xFF), 0);
+                if (asm_trace_level > 0) {
+                    printf(" %02x", (AO.value & 0xFF));
+                }
+            }
+            else {
+                byteout(((AO.value >> 8) & 0xFF), AO.marker);
+                byteout((AO.value & 0xFF), 0);
+                if (asm_trace_level > 0) {
+                    printf(" %02x", ((AO.value >> 8) & 0xFF));
+                    printf(" %02x", (AO.value & 0xFF));
+                }
             }
         }
         if (asm_trace_level > 0) {

--- a/asm.c
+++ b/asm.c
@@ -3142,6 +3142,7 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) break;
             put_token_back();
             AO = parse_expression(ARRAY_CONTEXT);
+            /* TODO: detect expr error, exit loop */
             if (AO.marker != 0)
                 error("Entries in code byte arrays must be known constants");
             byteout((AO.value & 0xFF), 0);

--- a/asm.c
+++ b/asm.c
@@ -1237,6 +1237,8 @@ extern void assemblez_instruction(const assembly_instruction *AI)
         {   for (j=0;start_pc<zcode_ha_size;
                  j++, start_pc++)
             {   if (j%16==0) printf("\n                               ");
+                if (zcode_markers[start_pc])
+                    printf("[%s]", describe_mv_short(zcode_markers[start_pc]));
                 printf("%02x ", zcode_holding_area[start_pc]);
             }
         }
@@ -3184,6 +3186,8 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             for (j=0;start_pc<zcode_ha_size;
                  j++, start_pc++)
             {   if (j%16==0) printf("                               ");
+                if (zcode_markers[start_pc])
+                    printf("[%s]", describe_mv_short(zcode_markers[start_pc]));
                 printf("%02x ", zcode_holding_area[start_pc]);
             }
             if (j) printf("\n");

--- a/asm.c
+++ b/asm.c
@@ -3146,6 +3146,9 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
         int isword = (token_value == DARROW_SEP);
         while (1) {
             assembly_operand AO;
+            /* This isn't the start of a statement, but it's safe to
+               release token texts anyway. */
+            release_token_texts();
             get_next_token();
             if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) break;
             put_token_back();
@@ -3488,6 +3491,9 @@ S (store), SS (two stores), R (execution never continues)");
         int isword = (token_value == DARROW_SEP);
         while (1) {
             assembly_operand AO;
+            /* This isn't the start of a statement, but it's safe to
+               release token texts anyway. */
+            release_token_texts();
             get_next_token();
             if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) break;
             put_token_back();

--- a/asm.c
+++ b/asm.c
@@ -3148,6 +3148,12 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             put_token_back();
             AO = parse_expression(ARRAY_CONTEXT);
             /* TODO: detect expr error, exit loop */
+            if (!isword) {
+                if (AO.marker != 0)
+                    error("Entries in code byte arrays must be known constants");
+                if (AO.value >= 256)
+                    warning("Entry in code byte array not in range 0 to 255");
+            }
             if (execution_never_reaches_here) {
                 continue;
             }
@@ -3157,10 +3163,6 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
                     isword?"<words>":"<bytes>");
             }
             if (!isword) {
-                if (AO.marker != 0)
-                    error("Entries in code byte arrays must be known constants");
-                if (AO.value >= 256)
-                    warning("Entry in code byte array not in range 0 to 255");
                 byteout((AO.value & 0xFF), 0);
                 bytecount++;
                 if (asm_trace_level > 0) {

--- a/asm.c
+++ b/asm.c
@@ -3136,6 +3136,10 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
     }
     else if ((token_type == SEP_TT) && (token_value == ARROW_SEP))
     {
+        if (asm_trace_level > 0) {
+            printf("%5d  +%05lx %3s %-12s", ErrorReport.line_number,
+                   ((long int) zmachine_pc), "   ", "<bytes>");
+        }
         while (1) {
             assembly_operand AO;
             get_next_token();
@@ -3146,7 +3150,12 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             if (AO.marker != 0)
                 error("Entries in code byte arrays must be known constants");
             byteout((AO.value & 0xFF), 0);
-            printf("### val -> $%x\n", (AO.value & 0xFF));
+            if (asm_trace_level > 0) {
+                printf(" %02x", (AO.value & 0xFF));
+            }
+        }
+        if (asm_trace_level > 0) {
+            printf("\n");
         }
         return;
     }

--- a/asm.c
+++ b/asm.c
@@ -3150,7 +3150,9 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) break;
             put_token_back();
             AO = parse_expression(ARRAY_CONTEXT);
-            /* TODO: detect expr error, exit loop */
+            if (AO.marker == ERROR_MV) {
+                break;
+            }
             if (!isword) {
                 if (AO.marker != 0)
                     error("Entries in code byte arrays must be known constants");
@@ -3490,7 +3492,9 @@ S (store), SS (two stores), R (execution never continues)");
             if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) break;
             put_token_back();
             AO = parse_expression(ARRAY_CONTEXT);
-            /* TODO: detect expr error, exit loop */
+            if (AO.marker == ERROR_MV) {
+                break;
+            }
             if (!isword) {
                 if (AO.marker != 0)
                     error("Entries in code byte arrays must be known constants");

--- a/asm.c
+++ b/asm.c
@@ -3134,6 +3134,15 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
         }
         O = custom_opcode_z;
     }
+    else if ((token_type == SEP_TT) && (token_value == ARROW_SEP))
+    {
+        while (1) {
+            get_next_token();
+            if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) break;
+        }
+        printf("### got @-->\n"); //###
+        return;
+    }
     else
     {   if (token_type != OPCODE_NAME_TT)
         {   ebf_curtoken_error("an opcode name");

--- a/asm.c
+++ b/asm.c
@@ -3150,6 +3150,9 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             put_token_back();
             AO = parse_expression(ARRAY_CONTEXT);
             /* TODO: detect expr error, exit loop */
+            if (execution_never_reaches_here) {
+                continue;
+            }
             if (!isword) {
                 if (AO.marker != 0)
                     error("Entries in code byte arrays must be known constants");

--- a/asm.c
+++ b/asm.c
@@ -3144,6 +3144,7 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             AO = parse_expression(ARRAY_CONTEXT);
             if (AO.marker != 0)
                 error("Entries in code byte arrays must be known constants");
+            byteout((AO.value & 0xFF), 0);
             printf("### val -> $%x\n", (AO.value & 0xFF));
         }
         return;

--- a/asm.c
+++ b/asm.c
@@ -1237,8 +1237,8 @@ extern void assemblez_instruction(const assembly_instruction *AI)
         {   for (j=0;start_pc<zcode_ha_size;
                  j++, start_pc++)
             {   if (j%16==0) printf("\n                               ");
-                if (zcode_markers[start_pc])
-                    printf("[%s]", describe_mv_short(zcode_markers[start_pc]));
+                if (zcode_markers[start_pc] & 0x7f)
+                    printf("[%s]", describe_mv_short(zcode_markers[start_pc] & 0x7f));
                 printf("%02x ", zcode_holding_area[start_pc]);
             }
         }
@@ -3186,8 +3186,8 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             for (j=0;start_pc<zcode_ha_size;
                  j++, start_pc++)
             {   if (j%16==0) printf("                               ");
-                if (zcode_markers[start_pc])
-                    printf("[%s]", describe_mv_short(zcode_markers[start_pc]));
+                if (zcode_markers[start_pc] & 0x7f)
+                    printf("[%s]", describe_mv_short(zcode_markers[start_pc] & 0x7f));
                 printf("%02x ", zcode_holding_area[start_pc]);
             }
             if (j) printf("\n");

--- a/asm.c
+++ b/asm.c
@@ -3397,151 +3397,151 @@ static assembly_operand parse_operand_g(void)
 
 static void parse_assembly_g(void)
 {
-  opcodeg O;
-  assembly_operand AO;
-  int error_flag = FALSE, is_macro = FALSE;
+    opcodeg O;
+    assembly_operand AO;
+    int error_flag = FALSE, is_macro = FALSE;
 
-  AI.operand_count = 0;
-  AI.text = NULL;
+    AI.operand_count = 0;
+    AI.text = NULL;
 
-  opcode_names.enabled = TRUE;
-  opcode_macros.enabled = TRUE;
-  get_next_token();
-  opcode_names.enabled = FALSE;
-  opcode_macros.enabled = FALSE;
-
-  if (token_type == DQ_TT) {
-    char *cx;
-    int badflags;
-
-    AI.internal_number = -1;
-
-    /* The format is @"FlagsCount:Code". Flags (which are optional)
-       can include "S" for store, "SS" for two stores, "B" for branch
-       format, "R" if execution never continues after the opcode. The
-       Count is the number of arguments (currently limited to 0-9),
-       and the Code is a decimal integer representing the opcode
-       number.
-
-       So: @"S3:123" for a three-argument opcode (load, load, store)
-       whose opcode number is (decimal) 123. Or: @"2:234" for a
-       two-argument opcode (load, load) whose number is 234. */
-
-    custom_opcode_g.name = (uchar *) token_text;
-    custom_opcode_g.flags = 0;
-    custom_opcode_g.op_rules = 0;
-    custom_opcode_g.no = 0;
-
-    badflags = FALSE;
-
-    for (cx = token_text; *cx && *cx != ':'; cx++) {
-      if (badflags)
-      continue;
-
-      switch (*cx) {
-      case 'S':
-      if (custom_opcode_g.flags & St)
-        custom_opcode_g.flags |= St2;
-      else
-        custom_opcode_g.flags |= St;
-      break;
-      case 'B':
-      custom_opcode_g.flags |= Br;
-      break;
-      case 'R':
-      custom_opcode_g.flags |= Rf;
-      break;
-      default:
-      if (isdigit(*cx)) {
-        custom_opcode_g.no = (*cx) - '0';
-        break;
-      }
-      badflags = TRUE;
-      error("Unknown custom opcode flag: options are B (branch), \
-S (store), SS (two stores), R (execution never continues)");
-      break;
-      }
-    }
-
-    if (*cx != ':') {
-      error("Custom opcode must have colon");
-    }
-    else {
-      cx++;
-      if (!(*cx))
-      error("Custom opcode must have colon followed by opcode number");
-      else
-      custom_opcode_g.code = atoi(cx);
-    }
-
-    O = custom_opcode_g;
-  }
-  else {
-    if (token_type != OPCODE_NAME_TT && token_type != OPCODE_MACRO_TT) {
-      ebf_curtoken_error("an opcode name");
-      panic_mode_error_recovery();
-      return;
-    }
-    AI.internal_number = token_value;
-    if (token_type == OPCODE_MACRO_TT) {
-      O = internal_number_to_opmacro_g(AI.internal_number);
-      is_macro = TRUE;
-    }
-    else
-      O = internal_number_to_opcode_g(AI.internal_number);
-  }
-  
-  return_sp_as_variable = TRUE;
-
-  while (1) {
+    opcode_names.enabled = TRUE;
+    opcode_macros.enabled = TRUE;
     get_next_token();
-    
-    if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) 
-      break;
+    opcode_names.enabled = FALSE;
+    opcode_macros.enabled = FALSE;
 
-    if (AI.operand_count == 8) {
-      error("No assembly instruction may have more than 8 operands");
-      panic_mode_error_recovery(); 
-      break;
-    }
+    if (token_type == DQ_TT) {
+        char *cx;
+        int badflags;
 
-    if ((O.flags & Br) && (AI.operand_count == O.no-1)) {
-      if (!((token_type == SEP_TT) && (token_value == BRANCH_SEP))) {
-        error_flag = TRUE;
-        error("Branch opcode must have '?' label");
-        put_token_back();
-      }
-      AO.type = CONSTANT_OT;
-      AO.value = parse_label();
-      AO.marker = BRANCH_MV;
+        AI.internal_number = -1;
+
+        /* The format is @"FlagsCount:Code". Flags (which are optional)
+           can include "S" for store, "SS" for two stores, "B" for branch
+           format, "R" if execution never continues after the opcode. The
+           Count is the number of arguments (currently limited to 0-9),
+           and the Code is a decimal integer representing the opcode
+           number.
+
+           So: @"S3:123" for a three-argument opcode (load, load, store)
+           whose opcode number is (decimal) 123. Or: @"2:234" for a
+           two-argument opcode (load, load) whose number is 234. */
+
+        custom_opcode_g.name = (uchar *) token_text;
+        custom_opcode_g.flags = 0;
+        custom_opcode_g.op_rules = 0;
+        custom_opcode_g.no = 0;
+
+        badflags = FALSE;
+
+        for (cx = token_text; *cx && *cx != ':'; cx++) {
+            if (badflags)
+                continue;
+
+            switch (*cx) {
+            case 'S':
+                if (custom_opcode_g.flags & St)
+                    custom_opcode_g.flags |= St2;
+                else
+                    custom_opcode_g.flags |= St;
+                break;
+            case 'B':
+                custom_opcode_g.flags |= Br;
+                break;
+            case 'R':
+                custom_opcode_g.flags |= Rf;
+                break;
+            default:
+                if (isdigit(*cx)) {
+                    custom_opcode_g.no = (*cx) - '0';
+                    break;
+                }
+                badflags = TRUE;
+                error("Unknown custom opcode flag: options are B (branch), \
+S (store), SS (two stores), R (execution never continues)");
+                break;
+            }
+        }
+
+        if (*cx != ':') {
+            error("Custom opcode must have colon");
+        }
+        else {
+            cx++;
+            if (!(*cx))
+                error("Custom opcode must have colon followed by opcode number");
+            else
+                custom_opcode_g.code = atoi(cx);
+        }
+
+        O = custom_opcode_g;
     }
     else {
-      put_token_back();
-      AO = parse_operand_g();
+        if (token_type != OPCODE_NAME_TT && token_type != OPCODE_MACRO_TT) {
+            ebf_curtoken_error("an opcode name");
+            panic_mode_error_recovery();
+            return;
+        }
+        AI.internal_number = token_value;
+        if (token_type == OPCODE_MACRO_TT) {
+            O = internal_number_to_opmacro_g(AI.internal_number);
+            is_macro = TRUE;
+        }
+        else
+            O = internal_number_to_opcode_g(AI.internal_number);
+    }
+  
+    return_sp_as_variable = TRUE;
+
+    while (1) {
+        get_next_token();
+    
+        if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) 
+            break;
+
+        if (AI.operand_count == 8) {
+            error("No assembly instruction may have more than 8 operands");
+            panic_mode_error_recovery(); 
+            break;
+        }
+
+        if ((O.flags & Br) && (AI.operand_count == O.no-1)) {
+            if (!((token_type == SEP_TT) && (token_value == BRANCH_SEP))) {
+                error_flag = TRUE;
+                error("Branch opcode must have '?' label");
+                put_token_back();
+            }
+            AO.type = CONSTANT_OT;
+            AO.value = parse_label();
+            AO.marker = BRANCH_MV;
+        }
+        else {
+            put_token_back();
+            AO = parse_operand_g();
+        }
+
+        AI.operand[AI.operand_count] = AO;
+        AI.operand_count++;
     }
 
-    AI.operand[AI.operand_count] = AO;
-    AI.operand_count++;
-  }
+    return_sp_as_variable = FALSE;
 
-  return_sp_as_variable = FALSE;
+    if (O.no != AI.operand_count) {
+        error_flag = TRUE;
+    }
 
-  if (O.no != AI.operand_count) {
-    error_flag = TRUE;
-  }
+    if (!error_flag) {
+        if (is_macro)
+            assembleg_macro(&AI);
+        else
+            assembleg_instruction(&AI);
+    }
 
-  if (!error_flag) {
-    if (is_macro)
-      assembleg_macro(&AI);
-    else
-      assembleg_instruction(&AI);
-  }
-
-  if (error_flag) {
-    make_opcode_syntax_g(O);
-    error_named("Assembly mistake: syntax is",
-      opcode_syntax_string);
-  }
+    if (error_flag) {
+        make_opcode_syntax_g(O);
+        error_named("Assembly mistake: syntax is",
+            opcode_syntax_string);
+    }
 }
 
 extern void parse_assembly(void)

--- a/asm.c
+++ b/asm.c
@@ -3170,7 +3170,8 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
                 byteout((AO.value & 0xFF), 0);
                 bytecount += 2;
                 if (asm_trace_level > 0) {
-                    printf(" %04x", (AO.value & 0xFFFF));
+                    printf(" ");
+                    print_operand(&AO, TRUE);
                 }
             }
         }

--- a/asm.c
+++ b/asm.c
@@ -3134,12 +3134,14 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
         }
         O = custom_opcode_z;
     }
-    else if ((token_type == SEP_TT) && (token_value == ARROW_SEP))
+    else if ((token_type == SEP_TT) && (token_value == ARROW_SEP || token_value == DARROW_SEP))
     {
         int32 start_pc = zcode_ha_size;
+        int isword = (token_value == DARROW_SEP);
         if (asm_trace_level > 0) {
             printf("%5d  +%05lx %3s %-12s", ErrorReport.line_number,
-                   ((long int) zmachine_pc), "   ", "<bytes>");
+                ((long int) zmachine_pc), "   ",
+                isword?"<words>":"<bytes>");
         }
         while (1) {
             assembly_operand AO;
@@ -3150,6 +3152,8 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             /* TODO: detect expr error, exit loop */
             if (AO.marker != 0)
                 error("Entries in code byte arrays must be known constants");
+            if (AO.value >= 256)
+                warning("Entry in code byte array not in range 0 to 255");
             byteout((AO.value & 0xFF), 0);
             if (asm_trace_level > 0) {
                 printf(" %02x", (AO.value & 0xFF));

--- a/bpatch.c
+++ b/bpatch.c
@@ -88,6 +88,9 @@ extern char *describe_mv_short(int mval)
         case LABEL_MV:      return("lbl");
         case DELETED_MV:    return("del");
 
+        /* Only occurs secondary to another reported error */
+        case ERROR_MV:      return("err");
+
     }
     if (mval >= BRANCH_MV && mval < BRANCHMAX_MV) return "br";
     

--- a/bpatch.c
+++ b/bpatch.c
@@ -53,6 +53,37 @@ extern char *describe_mv(int mval)
     return("** No such MV **");
 }
 
+extern char *describe_mv_short(int mval)
+{   switch(mval)
+    {   case NULL_MV:       return("");
+
+        /*  Marker values used in ordinary story file backpatching  */
+
+        case DWORD_MV:      return("dictwd");
+        case STRING_MV:     return("str");
+        case INCON_MV:      return("syscon");
+        case IROUTINE_MV:   return("rtn");
+        case VROUTINE_MV:   return("vrtn");
+        case ARRAY_MV:      return("arr");
+        case NO_OBJS_MV:    return("obj-count");
+        case INHERIT_MV:    return("inh-com");
+        case INDIVPT_MV:    return("indiv-ptab");
+        case INHERIT_INDIV_MV: return("inh-indiv");
+        case MAIN_MV:       return("main");
+        case SYMBOL_MV:     return("sym");
+
+        /*  Additional marker values used in Glulx backpatching
+            (IDENT_MV is not really used at all any more) */
+
+        case VARIABLE_MV:   return("glob");
+        case IDENT_MV:      return("prop");
+        case ACTION_MV:     return("action");
+        case OBJECT_MV:     return("obj");
+
+    }
+    return("???");
+}
+
 /* ------------------------------------------------------------------------- */
 /*   The mending operation                                                   */
 /* ------------------------------------------------------------------------- */

--- a/bpatch.c
+++ b/bpatch.c
@@ -34,6 +34,7 @@ extern char *describe_mv(int mval)
         case IROUTINE_MV:   return("routine");
         case VROUTINE_MV:   return("veneer routine");
         case ARRAY_MV:      return("internal array");
+        case STATIC_ARRAY_MV:  return("internal static array");
         case NO_OBJS_MV:    return("the number of objects");
         case INHERIT_MV:    return("inherited common p value");
         case INDIVPT_MV:    return("indiv prop table address");
@@ -65,6 +66,7 @@ extern char *describe_mv_short(int mval)
         case IROUTINE_MV:   return("rtn");
         case VROUTINE_MV:   return("vrtn");
         case ARRAY_MV:      return("arr");
+        case STATIC_ARRAY_MV:  return("stat-arr");
         case NO_OBJS_MV:    return("obj-count");
         case INHERIT_MV:    return("inh-com");
         case INDIVPT_MV:    return("indiv-ptab");
@@ -80,7 +82,12 @@ extern char *describe_mv_short(int mval)
         case ACTION_MV:     return("action");
         case OBJECT_MV:     return("obj");
 
+        case LABEL_MV:      return("lbl");
+        case DELETED_MV:    return("del");
+
     }
+    if (mval >= BRANCH_MV && mval < BRANCHMAX_MV) return "br";
+    
     return("???");
 }
 

--- a/bpatch.c
+++ b/bpatch.c
@@ -60,7 +60,7 @@ extern char *describe_mv_short(int mval)
 
         /*  Marker values used in ordinary story file backpatching  */
 
-        case DWORD_MV:      return("dictwd");
+        case DWORD_MV:      return("dict");
         case STRING_MV:     return("str");
         case INCON_MV:      return("syscon");
         case IROUTINE_MV:   return("rtn");

--- a/header.h
+++ b/header.h
@@ -2255,6 +2255,7 @@ extern int32 zcode_backpatch_size, staticarray_backpatch_size,
 extern int   backpatch_marker, backpatch_error_flag;
 
 extern char *describe_mv(int mval);
+extern char *describe_mv_short(int mval);
 
 extern int32 backpatch_value(int32 value);
 extern void  backpatch_zmachine_image_z(void);


### PR DESCRIPTION
As described in this thread: https://intfiction.org/t/i6-assembly-bytes-extension/64439
Covers https://github.com/DavidKinder/Inform6/issues/245

Two new statement types, handled as new assembly syntax:

```
@ -> BYTE BYTE BYTE ...;
@ --> WORD WORD WORD ...;
```

The given bytes or words are directly copied out into the function. (Words are two-byte chunks in Z-code, four-byte chunks in Glulx.) The compiler assumes the data forms valid opcodes, but verifying this is your problem. 

---

Additional changes:

The `--trace asm=2` output used to show the bytecode like this:

```
    8  +00011 <*> aload        long_16 (internal array: foo) zero_ local_0 (val) 
                               48 03 09 00{06} 00 00 10 00 
```

The `{06}` is the backpatch marker (referring to that byte and the following three). This wasn't very legible and it was only implemented for Glulx. I have now made it more readable, and it works in both G and Z:

```
[Glulx]
    8  +00011 <*> aload        long_16 (internal array: foo) zero_ local_0 (val) 
                               48 03 09 {arr}00 00 00 10 00

[Z-code]
    8  +00009 <*> loadw        long_488 (internal array: foo) short_0 -> val 
                               cf 1f {arr}01 e8 00 01 
```

The marker is now a short text label which appears *before* the two-byte/four-byte sequence. (As opposed to appearing after the first byte.) To support this, I've added a describe_mv_short() function to bpatch.c -- this is just like describe_mv() but prints an abbreviation.

I reindented the parse_assembly_g() function, so there's a lot of diff lines that are whitespace-only.

---

Future work:

My original post mentioned the idea of letting game code get a pointer to function code, perhaps through a label. This would let you compile *data* into a function. (Of course in Zcode this would only work for functions whose real address was under $FFFF.)

I still like this idea, but I haven't implemented it yet. It would require both new syntax and new backpatching logic. For now, if you want static data for a function, use the `Array static` declaration.

