### PR TITLE
Fix internal compiler errors on certain invalid expressions

### DIFF
--- a/expressp.c
+++ b/expressp.c
@@ -502,23 +502,24 @@ static int find_prec(const token_data *a, const token_data *b)
             a GREATER_P a   if a left-associative
     */
 
-    int i, j, l1, l2;
+    int ai, bi, j, l1, l2;
 
     switch(a->type)
-    {   case SUBOPEN_TT:  i=0; break;
-        case SUBCLOSE_TT: i=1; break;
-        case ENDEXP_TT:   i=2; break;
-        case OP_TT:       i=3; break;
-        default:          i=4; break;
+    {   case SUBOPEN_TT:  ai=0; break;
+        case SUBCLOSE_TT: ai=1; break;
+        case ENDEXP_TT:   ai=2; break;
+        case OP_TT:       ai=3; break;
+        default:          ai=4; break;
     }
     switch(b->type)
-    {   case SUBOPEN_TT:  i+=0; break;
-        case SUBCLOSE_TT: i+=5; break;
-        case ENDEXP_TT:   i+=10; break;
-        case OP_TT:       i+=15; break;
-        default:          i+=20; break;
+    {   case SUBOPEN_TT:  bi=0; break;
+        case SUBCLOSE_TT: bi=1; break;
+        case ENDEXP_TT:   bi=2; break;
+        case OP_TT:       bi=3; break;
+        default:          bi=4; break;
     }
 
+#if 0 //###
     if ((i == 16 || i == 19) && operators[b->value].usage == PRE_U) {
         /* (a=")"/default, b=OP) case where OP is a unary prefix operator.
            This looks like "(a ~b)" or "((a) ~b)", which are errors. */
@@ -535,8 +536,9 @@ static int find_prec(const token_data *a, const token_data *b)
            together. */
         return NOOP_E;
     }
-
-    j = prec_table[i];
+#endif //###
+    
+    j = prec_table[ai+5*bi];
     if (j != -1) return j;
 
     /* -1 is the (a=OP, b=OP) case. We must compare the precedence of the

--- a/expressp.c
+++ b/expressp.c
@@ -468,6 +468,8 @@ but not used as a value:", unicode);
 #define EQUAL_P   102
 #define GREATER_P 103
 
+#define BYPREC     -1       /* Compare the precedence of two operators */
+
 #define NOVAL_E     1       /* Missing operand error                */
 #define CLOSEB_E    2       /* Unexpected close bracket             */
 #define NOOP_E      3       /* Missing operator error               */
@@ -476,14 +478,14 @@ but not used as a value:", unicode);
 
 const int prec_table[49] = {
 
-/* a ..........   (         )           end       op:pre      op:bin      op:post     term      */
+/*   a .......   (         )           end       op:pre      op:bin      op:post     term      */
 
 /* b  (    */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    LOWER_P,    NOOP_E,
 /* .  )    */    EQUAL_P,  GREATER_P,  CLOSEB_E, GREATER_P,  GREATER_P,  GREATER_P,  GREATER_P,
 /* .  end  */    OPENB_E,  GREATER_P,  NOVAL_E,  GREATER_P,  GREATER_P,  GREATER_P,  GREATER_P,
-/* .  op:pre  */ LOWER_P,  GREATER_P,  LOWER_P,  -1,         -1,         -1,         GREATER_P,
-/* .  op:bin  */ LOWER_P,  GREATER_P,  LOWER_P,  -1,         -1,         -1,         GREATER_P,
-/* .  op:post */ LOWER_P,  GREATER_P,  LOWER_P,  -1,         -1,         -1,         GREATER_P,
+/* .  op:pre  */ LOWER_P,  GREATER_P,  LOWER_P,  BYPREC,     BYPREC,     BYPREC,     GREATER_P,
+/* .  op:bin  */ LOWER_P,  GREATER_P,  LOWER_P,  BYPREC,     BYPREC,     BYPREC,     GREATER_P,
+/* .  op:post */ LOWER_P,  GREATER_P,  LOWER_P,  BYPREC,     BYPREC,     BYPREC,     GREATER_P,
 /* .  term */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    LOWER_P,    NOOP_E
 
 };
@@ -541,10 +543,10 @@ static int find_prec(const token_data *a, const token_data *b)
 #endif //###
     
     j = prec_table[ai+7*bi];
-    if (j != -1) return j;
+    if (j != BYPREC) return j;
 
-    /* -1 is the (a=OP, b=OP) case. We must compare the precedence of the
-       two operators. */
+    /* BYPREC is the (a=OP, b=OP) cases. We must compare the precedence of the
+       two operators. (We've already eliminated invalid cases like (a++ --b).) */
     l1 = operators[a->value].precedence;
     l2 = operators[b->value].precedence;
     if (operators[b->value].usage == PRE_U) return LOWER_P;

--- a/expressp.c
+++ b/expressp.c
@@ -528,6 +528,8 @@ static int find_prec(const token_data *a, const token_data *b)
     j = prec_table[i];
     if (j != -1) return j;
 
+    /* -1 is the (a=OP, b=OP) case. We must compare the precedence of the
+       two operators. */
     l1 = operators[a->value].precedence;
     l2 = operators[b->value].precedence;
     if (operators[b->value].usage == PRE_U) return LOWER_P;

--- a/expressp.c
+++ b/expressp.c
@@ -520,13 +520,19 @@ static int find_prec(const token_data *a, const token_data *b)
     }
 
     if ((i == 16 || i == 19) && operators[b->value].usage == PRE_U) {
-        /* (a=")" or "default", b=OP) case where OP is a unary operator.
+        /* (a=")"/default, b=OP) case where OP is a unary prefix operator.
            This looks like "(a ~b)" or "((a) ~b)", which are errors. */
         return NOOP_E;
     }
     if ((i == 3 || i == 23) && operators[a->value].usage == POST_U) {
-        /* (a=OP, b="(" or "default") case where OP is a unary operator.
+        /* (a=OP, b="("/default) case where OP is a unary postfix operator.
            This looks like "(a++ b)" or "(a++ (b))", which are errors. */
+        return NOOP_E;
+    }
+    if (i == 18 && operators[a->value].usage == POST_U && operators[b->value].usage == PRE_U) {
+        /* (a=OP, b=OP) where a prefix op follows a postfix op.
+           This looks like "(a++ --b)". It's like both the above errors put
+           together. */
         return NOOP_E;
     }
 

--- a/expressp.c
+++ b/expressp.c
@@ -512,14 +512,28 @@ static int find_prec(const token_data *a, const token_data *b)
     {   case SUBOPEN_TT:  ai=0; break;
         case SUBCLOSE_TT: ai=1; break;
         case ENDEXP_TT:   ai=2; break;
-        case OP_TT:       ai=3; break;
+        case OP_TT:
+            if (operators[a->value].usage == PRE_U)
+                ai=3;
+            else if (operators[a->value].usage == POST_U)
+                ai=5;
+            else
+                ai=4;
+            break;
         default:          ai=6; break;
     }
     switch(b->type)
     {   case SUBOPEN_TT:  bi=0; break;
         case SUBCLOSE_TT: bi=1; break;
         case ENDEXP_TT:   bi=2; break;
-        case OP_TT:       bi=3; break;
+        case OP_TT:
+            if (operators[b->value].usage == PRE_U)
+                bi=3;
+            else if (operators[b->value].usage == POST_U)
+                bi=5;
+            else
+                bi=4;
+            break;
         default:          bi=6; break;
     }
 

--- a/expressp.c
+++ b/expressp.c
@@ -519,8 +519,8 @@ static int find_prec(const token_data *a, const token_data *b)
         default:          i+=20; break;
     }
 
-    if (i == 19 && operators[b->value].usage == PRE_U) {
-        /* (a=default, b=OP) case where OP is a unary operator.
+    if ((i == 16 || i == 19) && operators[b->value].usage == PRE_U) {
+        /* (a=")" or default, b=OP) case where OP is a unary operator.
            This looks like "(a ~b)" which is an error. */
         return NOOP_E;
     }

--- a/expressp.c
+++ b/expressp.c
@@ -536,25 +536,6 @@ static int find_prec(const token_data *a, const token_data *b)
             break;
         default:          bi=6; break;
     }
-
-#if 0 //###
-    if ((i == 16 || i == 19) && operators[b->value].usage == PRE_U) {
-        /* (a=")"/default, b=OP) case where OP is a unary prefix operator.
-           This looks like "(a ~b)" or "((a) ~b)", which are errors. */
-        return NOOP_E;
-    }
-    if ((i == 3 || i == 23) && operators[a->value].usage == POST_U) {
-        /* (a=OP, b="("/default) case where OP is a unary postfix operator.
-           This looks like "(a++ b)" or "(a++ (b))", which are errors. */
-        return NOOP_E;
-    }
-    if (i == 18 && operators[a->value].usage == POST_U && operators[b->value].usage == PRE_U) {
-        /* (a=OP, b=OP) where a prefix op follows a postfix op.
-           This looks like "(a++ --b)". It's like both the above errors put
-           together. */
-        return NOOP_E;
-    }
-#endif //###
     
     j = prec_table[ai+7*bi];
     if (j != BYPREC) return j;

--- a/expressp.c
+++ b/expressp.c
@@ -2092,6 +2092,8 @@ extern assembly_operand parse_expression(int context)
 
             case NOOP_E:             /* Missing operator error               */
                 error_named("Missing operator after", a.text);
+                /* We insert a "+" token so that the rest of the expression
+                   can be compiled. */
                 put_token_back();
                 current_token.type = OP_TT;
                 current_token.value = PLUS_OP;

--- a/expressp.c
+++ b/expressp.c
@@ -474,15 +474,17 @@ but not used as a value:", unicode);
 #define OPENB_E     4       /* Expression ends with an open bracket */
 #define ASSOC_E     5       /* Associativity illegal error          */
 
-const int prec_table[25] = {
+const int prec_table[49] = {
 
-/* a .......... (         )           end       op          term             */
+/* a ..........   (         )           end       op:pre      op:bin      op:post     term      */
 
-/* b  (    */   LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    NOOP_E,
-/* .  )    */   EQUAL_P,  GREATER_P,  CLOSEB_E, GREATER_P,  GREATER_P,
-/* .  end  */   OPENB_E,  GREATER_P,  NOVAL_E,  GREATER_P,  GREATER_P,
-/* .  op   */   LOWER_P,  GREATER_P,  LOWER_P,  -1,         GREATER_P,
-/* .  term */   LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    NOOP_E
+/* b  (    */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    LOWER_P,    NOOP_E,
+/* .  )    */    EQUAL_P,  GREATER_P,  CLOSEB_E, GREATER_P,  GREATER_P,  GREATER_P,  GREATER_P,
+/* .  end  */    OPENB_E,  GREATER_P,  NOVAL_E,  GREATER_P,  GREATER_P,  GREATER_P,  GREATER_P,
+/* .  op:pre  */ LOWER_P,  GREATER_P,  LOWER_P,  -1,         -1,         -1,         GREATER_P,
+/* .  op:bin  */ LOWER_P,  GREATER_P,  LOWER_P,  -1,         -1,         -1,         GREATER_P,
+/* .  op:post */ LOWER_P,  GREATER_P,  LOWER_P,  -1,         -1,         -1,         GREATER_P,
+/* .  term */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    LOWER_P,    NOOP_E
 
 };
 
@@ -509,14 +511,14 @@ static int find_prec(const token_data *a, const token_data *b)
         case SUBCLOSE_TT: ai=1; break;
         case ENDEXP_TT:   ai=2; break;
         case OP_TT:       ai=3; break;
-        default:          ai=4; break;
+        default:          ai=6; break;
     }
     switch(b->type)
     {   case SUBOPEN_TT:  bi=0; break;
         case SUBCLOSE_TT: bi=1; break;
         case ENDEXP_TT:   bi=2; break;
         case OP_TT:       bi=3; break;
-        default:          bi=4; break;
+        default:          bi=6; break;
     }
 
 #if 0 //###
@@ -538,7 +540,7 @@ static int find_prec(const token_data *a, const token_data *b)
     }
 #endif //###
     
-    j = prec_table[ai+5*bi];
+    j = prec_table[ai+7*bi];
     if (j != -1) return j;
 
     /* -1 is the (a=OP, b=OP) case. We must compare the precedence of the

--- a/expressp.c
+++ b/expressp.c
@@ -520,8 +520,13 @@ static int find_prec(const token_data *a, const token_data *b)
     }
 
     if ((i == 16 || i == 19) && operators[b->value].usage == PRE_U) {
-        /* (a=")" or default, b=OP) case where OP is a unary operator.
+        /* (a=")" or "default", b=OP) case where OP is a unary operator.
            This looks like "(a ~b)" or "((a) ~b)", which are errors. */
+        return NOOP_E;
+    }
+    if ((i == 3 || i == 23) && operators[a->value].usage == POST_U) {
+        /* (a=OP, b="(" or "default") case where OP is a unary operator.
+           This looks like "(a++ b)" or "(a++ (b))", which are errors. */
         return NOOP_E;
     }
 

--- a/expressp.c
+++ b/expressp.c
@@ -2091,7 +2091,7 @@ extern assembly_operand parse_expression(int context)
                 break;
 
             case NOOP_E:             /* Missing operator error               */
-                error("Missing operator: inserting '+'");
+                error_named("Missing operator after", a.text);
                 put_token_back();
                 current_token.type = OP_TT;
                 current_token.value = PLUS_OP;

--- a/expressp.c
+++ b/expressp.c
@@ -2078,6 +2078,8 @@ extern assembly_operand parse_expression(int context)
 
             case NOVAL_E:            /* Missing operand error                */
                 error_named("Missing operand after", a.text);
+                /* We insert a "0" token so that the rest of the expression
+                   can be compiled. */
                 put_token_back();
                 current_token.type = NUMBER_TT;
                 current_token.value = 0;

--- a/expressp.c
+++ b/expressp.c
@@ -480,13 +480,13 @@ const int prec_table[49] = {
 
 /*   a .......   (         )           end       op:pre      op:bin      op:post     term      */
 
-/* b  (    */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    LOWER_P,    NOOP_E,
+/* b  (    */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    NOOP_E,     NOOP_E,
 /* .  )    */    EQUAL_P,  GREATER_P,  CLOSEB_E, GREATER_P,  GREATER_P,  GREATER_P,  GREATER_P,
 /* .  end  */    OPENB_E,  GREATER_P,  NOVAL_E,  GREATER_P,  GREATER_P,  GREATER_P,  GREATER_P,
-/* .  op:pre  */ LOWER_P,  GREATER_P,  LOWER_P,  BYPREC,     BYPREC,     BYPREC,     GREATER_P,
+/* .  op:pre  */ LOWER_P,  NOOP_E,     LOWER_P,  BYPREC,     BYPREC,     NOOP_E,     NOOP_E,
 /* .  op:bin  */ LOWER_P,  GREATER_P,  LOWER_P,  BYPREC,     BYPREC,     BYPREC,     GREATER_P,
 /* .  op:post */ LOWER_P,  GREATER_P,  LOWER_P,  BYPREC,     BYPREC,     BYPREC,     GREATER_P,
-/* .  term */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    LOWER_P,    NOOP_E
+/* .  term */    LOWER_P,  NOOP_E,     LOWER_P,  LOWER_P,    LOWER_P,    NOOP_E,     NOOP_E
 
 };
 

--- a/expressp.c
+++ b/expressp.c
@@ -474,7 +474,7 @@ but not used as a value:", unicode);
 #define OPENB_E     4       /* Expression ends with an open bracket */
 #define ASSOC_E     5       /* Associativity illegal error          */
 
-const int prec_table[] = {
+const int prec_table[25] = {
 
 /* a .......... (         )           end       op          term             */
 

--- a/expressp.c
+++ b/expressp.c
@@ -519,7 +519,14 @@ static int find_prec(const token_data *a, const token_data *b)
         default:          i+=20; break;
     }
 
-    j = prec_table[i]; if (j != -1) return j;
+    if (i == 19 && operators[b->value].usage == PRE_U) {
+        /* (a=default, b=OP) case where OP is a unary operator.
+           This looks like "(a ~b)" which is an error. */
+        return NOOP_E;
+    }
+
+    j = prec_table[i];
+    if (j != -1) return j;
 
     l1 = operators[a->value].precedence;
     l2 = operators[b->value].precedence;

--- a/expressp.c
+++ b/expressp.c
@@ -508,6 +508,12 @@ static int find_prec(const token_data *a, const token_data *b)
 
     int ai, bi, j, l1, l2;
 
+    /*   Select a column and row in prec_table, based on the type of
+         a and b. If a/b is an operator, we have to distinguish three
+         columns/rows depending on whether the operator is prefix,
+         postfix, or neither.
+    */
+    
     switch(a->type)
     {   case SUBOPEN_TT:  ai=0; break;
         case SUBCLOSE_TT: ai=1; break;
@@ -541,7 +547,9 @@ static int find_prec(const token_data *a, const token_data *b)
     if (j != BYPREC) return j;
 
     /* BYPREC is the (a=OP, b=OP) cases. We must compare the precedence of the
-       two operators. (We've already eliminated invalid cases like (a++ --b).) */
+       two operators.
+       (We've already eliminated invalid cases like (a++ --b).)
+    */
     l1 = operators[a->value].precedence;
     l2 = operators[b->value].precedence;
     if (operators[b->value].usage == PRE_U) return LOWER_P;

--- a/expressp.c
+++ b/expressp.c
@@ -521,7 +521,7 @@ static int find_prec(const token_data *a, const token_data *b)
 
     if ((i == 16 || i == 19) && operators[b->value].usage == PRE_U) {
         /* (a=")" or default, b=OP) case where OP is a unary operator.
-           This looks like "(a ~b)" which is an error. */
+           This looks like "(a ~b)" or "((a) ~b)", which are errors. */
         return NOOP_E;
     }
 


### PR DESCRIPTION
Fixes https://github.com/DavidKinder/Inform6/issues/248 .

Expressions like `(a++ b)`, `(a ~b)`, `(a++ ~b)`, `(a++ --b)` were accepted by the expression parser but caused errors in the code generator. These manifested as compiler errors, such as:

> *** Compiler error:  SR error: emitter stack overfull

> *** Compiler error: SR error: Attempt to remove a nonexistent bracket layer from the emitter stack

All these expressions are invalid. (With the possible exception of `(a++ -b)`, which could be valid if the `-` were a binary operator, but Inform treats it as unary.)

To handle this, I expanded the prec_table[] in expressp.c to have separate rows and columns for prefix, binary, and postfix operators. (Previously it had just one row and column for all operators.) The bad cases now have the entry NOOP_E, which indicates an expression parsing error.

(NOOP_E is glossed as "missing operator" because the most likely cause is a missing binary operator. That is, you could make the above examples valid by adding a `+` sign: `(a++ + b)`, `(a + ~b)`, `(a++ + ~b)`, `(a++ + --b)`.)

---

Test cases: https://github.com/erkyrath/Inform6-Testing/blob/unaryop-err/src/unaryop_err_test.inf

---

Incidental changes:

I renamed the error constants `e1`, `e2`, etc to have more meaningful names. Same goes for the `-1` table entry.

The prec_table[] is now 7x7, which makes it a bit too wide for the source's normal 80-character formatting. Sorry!

The compiler error "Missing operator: inserting '+'" now reads "Missing operator after ..."

The trace message "Adding bracket layer" now shows the `depth` argument.
