### PR TITLE
Link to 6.3x release notes

### DIFF
--- a/ReleaseNotes.html
+++ b/ReleaseNotes.html
@@ -15,7 +15,8 @@ to implement has been governed by two factors:
 <li><p>Avoidance of changes which might cause existing games to misbehave; and
 <li><p>Minimisation of features which would require updates to the <i>Inform Designer&rsquo;s Manual</i>.
 </ul>
-Since the first release of the Inform 6.3 compiler, the Inform 6 library has been split into a separate project,
+Older release notes (Inform 6.30 through 6.36) are <a href="https://inform-fiction.org/manual/ReleaseNotes-6.3x.html">archived here</a>.
+<p>Since the first release of the Inform 6.3 compiler, the Inform 6 library has been split into a separate project,
 maintained at <a href="https://gitlab.com/DavidGriffith/inform6lib">https://gitlab.com/DavidGriffith/inform6lib</a>.
 
 <h2>Acknowledgements</h2>


### PR DESCRIPTION
I didn't want the old release notes to be lost, so I stashed them on the I6 web site and added a link in the current release notes.
