### PR TITLE
Glulx random() built-in function now follows the DM4 spec

### DIFF
--- a/expressc.c
+++ b/expressc.c
@@ -2645,23 +2645,17 @@ static void generate_code_from(int n, int void_flag)
                          else {
                              //### one operand, check constancy
                            int ln, ln2;
-                           if (ET[ET[below].right].value.type == LOCALVAR_OT && ET[ET[below].right].value.value == 0) {
-                               /* already on stack */
-                           }
-                           else {
-                               assembleg_store(stack_pointer, ET[ET[below].right].value);
-                           }
+                           assembleg_store(temp_var1, ET[ET[below].right].value);
                            ln = next_label++;
                            ln2 = next_label++;
-                           assembleg_2(stkpeek_gc, zero_operand, stack_pointer);
-                           assembleg_2_branch(jle_gc, stack_pointer, zero_operand, ln);
+                           assembleg_2_branch(jle_gc, temp_var1, zero_operand, ln);
                            assembleg_2(random_gc,
-                             stack_pointer, stack_pointer);
+                             temp_var1, stack_pointer);
                            assembleg_3(add_gc, stack_pointer, one_operand,
                              Result);
                            assembleg_0_branch(jump_gc, ln2);
                            assemble_label_no(ln);
-                           assembleg_2(neg_gc, stack_pointer, stack_pointer);
+                           assembleg_2(neg_gc, temp_var1, stack_pointer);
                            assembleg_1(setrandom_gc,
                              stack_pointer);
                            assembleg_store(Result, zero_operand);

--- a/expressc.c
+++ b/expressc.c
@@ -2642,8 +2642,36 @@ static void generate_code_from(int n, int void_flag)
                             assembleg_2(random_gc, AO, stack_pointer);
                             assembleg_3(aload_gc, AO2, stack_pointer, Result);
                          }
+                         else if (is_constant_ot(ET[ET[below].right].value.type) && ET[ET[below].right].value.marker == 0) {
+                           /* One argument, value known at compile time */
+                           int32 arg = ET[ET[below].right].value.value; /* signed */
+                           if (arg > 0) {
+                             assembly_operand AO;
+                             INITAO(&AO);
+                             AO.value = arg;
+                             set_constant_ot(&AO);
+                             assembleg_2(random_gc,
+                               AO, stack_pointer);
+                             assembleg_3(add_gc, stack_pointer, one_operand,
+                               Result);
+                           }
+                           else if (arg == 0) {
+                             assembleg_1(setrandom_gc,
+                               zero_operand);
+                             assembleg_store(Result, zero_operand);
+                           }
+                           else {
+                             assembly_operand AO;
+                             INITAO(&AO);
+                             AO.value = -arg;
+                             set_constant_ot(&AO);
+                             assembleg_1(setrandom_gc,
+                               AO);
+                             assembleg_store(Result, zero_operand);
+                           }
+                         }
                          else {
-                             //### one operand, check constancy
+                           /* One argument, not known at compile time */
                            int ln, ln2;
                            assembleg_store(temp_var1, ET[ET[below].right].value);
                            ln = next_label++;

--- a/expressc.c
+++ b/expressc.c
@@ -2655,12 +2655,8 @@ static void generate_code_from(int n, int void_flag)
                              assembleg_3(add_gc, stack_pointer, one_operand,
                                Result);
                            }
-                           else if (arg == 0) {
-                             assembleg_1(setrandom_gc,
-                               zero_operand);
-                             assembleg_store(Result, zero_operand);
-                           }
                            else {
+                             /* This handles zero or negative */
                              assembly_operand AO;
                              INITAO(&AO);
                              AO.value = -arg;

--- a/expressc.c
+++ b/expressc.c
@@ -2643,10 +2643,29 @@ static void generate_code_from(int n, int void_flag)
                             assembleg_3(aload_gc, AO2, stack_pointer, Result);
                          }
                          else {
+                             //### one operand, check constancy
+                           int ln, ln2;
+                           if (ET[ET[below].right].value.type == LOCALVAR_OT && ET[ET[below].right].value.value == 0) {
+                               /* already on stack */
+                           }
+                           else {
+                               assembleg_store(stack_pointer, ET[ET[below].right].value);
+                           }
+                           ln = next_label++;
+                           ln2 = next_label++;
+                           assembleg_2(stkpeek_gc, zero_operand, stack_pointer);
+                           assembleg_2_branch(jle_gc, stack_pointer, zero_operand, ln);
                            assembleg_2(random_gc,
-                             ET[ET[below].right].value, stack_pointer);
+                             stack_pointer, stack_pointer);
                            assembleg_3(add_gc, stack_pointer, one_operand,
                              Result);
+                           assembleg_0_branch(jump_gc, ln2);
+                           assemble_label_no(ln);
+                           assembleg_2(neg_gc, stack_pointer, stack_pointer);
+                           assembleg_1(setrandom_gc,
+                             stack_pointer);
+                           assembleg_store(Result, zero_operand);
+                           assemble_label_no(ln2);
                          }
                          break;
 


### PR DESCRIPTION
See https://github.com/DavidKinder/Inform6/issues/255 .

The implementation of `y = random(x)` now looks roughly like:

```
    temp_global = x;
    if (temp_global > 0) {
        y = (@random temp_global) + 1;
    }
    else {
        @setrandom (-temp_global);
        y = 0;
    }
```

(This isn't legal I6 assembly but it gets the idea across.)

The minus sign in the `@setrandom` case means that `random(-1)` does `@setrandom 1`. I think this is slightly cleaner for testing.

If `x` is a compile-time constant, we can skip the branch and simply compile one of `(@random CONST) + 1` or `@setrandom CONST`. As a result, this change does not affect the compiled output of `random(CONST)` for positive CONST.

The multi-argument `random(C1, C2, C3...)` case is not affected by this change either.

This change _does_ affect the compiled output of Glulx games that use the standard library (I6 or I7). They will now be slightly larger: about 50 bytes for a minimal I6 game, about 200 for an I7 game. Glulx users are not likely to worry about this.
