### PR TITLE
Remove limit on Abbreviate directive

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -110,12 +110,6 @@ extern int parse_given_directive(int internal_flag)
            if (token_type != DQ_TT)
            {   return ebf_error_recover("abbreviation string");
            }
-           /* Abbreviation string with null must fit in a MAX_ABBREV_LENGTH
-              array. */
-           if (strlen(token_text)>=MAX_ABBREV_LENGTH)
-           {   error_named("Abbreviation too long", token_text);
-               continue;
-           }
            make_abbreviation(token_text);
         } while (TRUE);
 

--- a/files.c
+++ b/files.c
@@ -344,7 +344,7 @@ static void output_compression(int entnum, int32 *size, int *count)
     (*size) += 1;
     break;
   case 3:
-    cx = (char *)abbreviations_at + ent->u.val*MAX_ABBREV_LENGTH;
+    cx = abbreviation_text(ent->u.val);
     while (*cx) {
       sf_put(*cx);
       cx++;

--- a/header.h
+++ b/header.h
@@ -764,6 +764,8 @@ typedef struct abbreviation_s {
     int value;
     int quality;
     int freq;
+    int textpos; /* in abbreviations_text */
+    int textlen;
 } abbreviation;
 
 typedef struct maybe_file_position_S
@@ -2754,7 +2756,6 @@ extern int32 low_strings_top;
 
 extern int   no_abbreviations;
 extern int   abbrevs_lookup_table_made, is_abbreviation;
-extern uchar *abbreviations_at;
 extern abbreviation *abbreviations;
 
 extern int32 total_chars_trans, total_bytes_trans,

--- a/header.h
+++ b/header.h
@@ -2822,6 +2822,7 @@ extern int32 compile_string(char *b, int strctx);
 extern int32 translate_text(int32 p_limit, char *s_text, int strctx);
 extern void  optimise_abbreviations(void);
 extern void  make_abbreviation(char *text);
+extern char *abbreviation_text(int num);
 extern void  show_dictionary(int level);
 extern void  word_to_ascii(uchar *p, char *result);
 extern void  print_dict_word(int node);

--- a/tables.c
+++ b/tables.c
@@ -1636,7 +1636,7 @@ static void display_frequencies()
             saving = (abbreviations[i].freq-1)*abbreviations[i].quality;
         
         strcpy(abbrev_string,
-               (char *)abbreviations_at+i*MAX_ABBREV_LENGTH);
+               abbreviation_text(i));
         for (j=0; abbrev_string[j]!=0; j++)
             if (abbrev_string[j]==' ') abbrev_string[j]='_';
         

--- a/tables.c
+++ b/tables.c
@@ -1636,6 +1636,8 @@ static void display_frequencies()
             saving = (abbreviations[i].freq-1)*abbreviations[i].quality;
 
         astr = abbreviation_text(i);
+        /* Print the abbreviation text, left-padded to ten spaces, with
+           spaces replaced by underscores. */
         for (j=strlen(astr); j<10; j++) {
             putchar(' ');
         }

--- a/tables.c
+++ b/tables.c
@@ -1629,18 +1629,21 @@ static void display_frequencies()
     
     for (i=0; i<no_abbreviations; i++) {
         int32 saving;
-        char abbrev_string[MAX_ABBREV_LENGTH];
+        char *astr;
         if (!glulx_mode)
             saving = 2*((abbreviations[i].freq-1)*abbreviations[i].quality)/3;
         else
             saving = (abbreviations[i].freq-1)*abbreviations[i].quality;
+
+        astr = abbreviation_text(i);
+        for (j=strlen(astr); j<10; j++) {
+            putchar(' ');
+        }
+        for (j=0; astr[j]; j++) {
+            putchar(astr[j] == ' ' ? '_' : astr[j]);
+        }
         
-        strcpy(abbrev_string,
-               abbreviation_text(i));
-        for (j=0; abbrev_string[j]!=0; j++)
-            if (abbrev_string[j]==' ') abbrev_string[j]='_';
-        
-        printf("%10s %5d/%5d   ",abbrev_string,abbreviations[i].freq, saving);
+        printf(" %5d/%5d   ", abbreviations[i].freq, saving);
         
         if ((i%3)==2) printf("\n");
     }

--- a/text.c
+++ b/text.c
@@ -198,7 +198,8 @@ static int try_abbreviations_from(unsigned char *text, int i, int from)
 {   int j, k; uchar *p, c;
     c=text[i];
     for (j=from, p=(uchar *)abbreviations_text+abbreviations[from].textpos;
-         (j<no_abbreviations)&&(c==p[0]); j++, p+=(1+abbreviations[from].textlen))
+         (j<no_abbreviations)&&(c==p[0]);
+         j++, p=(uchar *)abbreviations_text+abbreviations[from].textpos)
     {   if (text[i+1]==p[1])
         {   for (k=2; p[k]!=0; k++)
                 if (text[i+k]!=p[k]) goto NotMatched;
@@ -569,7 +570,8 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
                 c = text_in[j];
                 /* Loop on all abbreviations starting with what is in c. */
                 for (k=from, q=(uchar *)abbreviations_text+abbreviations[from].textpos;
-                    (k<no_abbreviations)&&(c==q[0]); k++, q+=(1+abbreviations[from].textlen))
+                    (k<no_abbreviations)&&(c==q[0]);
+                     k++, q=(uchar *)abbreviations_text+abbreviations[from].textpos)
                 {   
                     /* Let's compare; we also keep track of the length of the abbreviation. */
                     for (l=1; q[l]!=0; l++)

--- a/text.c
+++ b/text.c
@@ -159,8 +159,8 @@ static void make_abbrevs_lookup(void)
     {   bubble_sort = FALSE;
         for (j=0; j<no_abbreviations; j++)
             for (k=j+1; k<no_abbreviations; k++)
-            {   p1=(char *)abbreviations_at+j*MAX_ABBREV_LENGTH;
-                p2=(char *)abbreviations_at+k*MAX_ABBREV_LENGTH;
+            {   p1=abbreviation_text(j);
+                p2=abbreviation_text(k);
                 if (strcmp(p1,p2)<0)
                 {   strcpy(p,p1); strcpy(p1,p2); strcpy(p2,p);
                     l=abbreviations[j].value; abbreviations[j].value=abbreviations[k].value;
@@ -173,7 +173,7 @@ static void make_abbrevs_lookup(void)
     } while (bubble_sort);
 
     for (j=no_abbreviations-1; j>=0; j--)
-    {   p1=(char *)abbreviations_at+j*MAX_ABBREV_LENGTH;
+    {   p1=abbreviation_text(j);
         abbrevs_lookup[(uchar)p1[0]]=j;
         abbreviations[j].freq=0;
     }
@@ -615,7 +615,7 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
             ((j = abbreviations_optimal_parse_schedule[i]) != -1))
         {
             /* Fill with 1s, which will get ignored by everyone else. */
-            uchar *p = (uchar *)abbreviations_at+j*MAX_ABBREV_LENGTH;
+            uchar *p = (uchar *)abbreviation_text(j);
             for (k=0; p[k]!=0; k++) text_in[i+k]=1;
             /* Actually write the abbreviation in the story file. */
             abbreviations[j].freq++;
@@ -850,7 +850,7 @@ advance as part of 'Zcharacter table':", unicode);
       if ((economy_switch) && (compression_switch) && (!is_abbreviation)
         && ((k=abbrevs_lookup[text_in[i]])!=-1)
         && ((j=try_abbreviations_from(text_in, i, k)) != -1)) {
-        char *cx = (char *)abbreviations_at+j*MAX_ABBREV_LENGTH;
+        char *cx = abbreviation_text(j);
         i += (strlen(cx)-1);
         write_z_char_g('@');
         write_z_char_g('A');
@@ -1399,7 +1399,7 @@ static void compress_makebits(int entnum, int depth, int prevbit,
     compression_table_size += 2;
     break;
   case 3:
-    cx = (char *)abbreviations_at + ent->u.val*MAX_ABBREV_LENGTH;
+    cx = abbreviation_text(ent->u.val);
     compression_table_size += (1 + 1 + strlen(cx));
     break;
   case 4:

--- a/text.c
+++ b/text.c
@@ -197,10 +197,13 @@ static void make_abbrevs_lookup(void)
 static int try_abbreviations_from(unsigned char *text, int i, int from)
 {   int j, k; uchar *p, c;
     c=text[i];
-    for (j=from, p=(uchar *)abbreviations_text+abbreviations[j].textpos;
-         (j<no_abbreviations)&&(c==p[0]);
-         j++, p=(uchar *)abbreviations_text+abbreviations[j].textpos)
-    {   if (text[i+1]==p[1])
+    for (j=from;
+         j<no_abbreviations;
+         j++)
+    {
+        p=(uchar *)abbreviations_text+abbreviations[j].textpos;
+        if (c != p[0]) break;
+        if (text[i+1]==p[1])
         {   for (k=2; p[k]!=0; k++)
                 if (text[i+k]!=p[k]) goto NotMatched;
             if (!glulx_mode) {
@@ -569,10 +572,12 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
             {
                 c = text_in[j];
                 /* Loop on all abbreviations starting with what is in c. */
-                for (k=from, q=(uchar *)abbreviations_text+abbreviations[k].textpos;
-                    (k<no_abbreviations)&&(c==q[0]);
-                     k++, q=(uchar *)abbreviations_text+abbreviations[k].textpos)
-                {   
+                for (k=from;
+                     k<no_abbreviations;
+                     k++)
+                {
+                    q=(uchar *)abbreviations_text+abbreviations[k].textpos;
+                    if (c!=q[0]) break;
                     /* Let's compare; we also keep track of the length of the abbreviation. */
                     for (l=1; q[l]!=0; l++)
                     {    if (text_in[j+l]!=q[l]) {goto NotMatched;}

--- a/text.c
+++ b/text.c
@@ -197,9 +197,9 @@ static void make_abbrevs_lookup(void)
 static int try_abbreviations_from(unsigned char *text, int i, int from)
 {   int j, k; uchar *p, c;
     c=text[i];
-    for (j=from, p=(uchar *)abbreviations_text+abbreviations[from].textpos;
+    for (j=from, p=(uchar *)abbreviations_text+abbreviations[j].textpos;
          (j<no_abbreviations)&&(c==p[0]);
-         j++, p=(uchar *)abbreviations_text+abbreviations[from].textpos)
+         j++, p=(uchar *)abbreviations_text+abbreviations[j].textpos)
     {   if (text[i+1]==p[1])
         {   for (k=2; p[k]!=0; k++)
                 if (text[i+k]!=p[k]) goto NotMatched;
@@ -569,9 +569,9 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
             {
                 c = text_in[j];
                 /* Loop on all abbreviations starting with what is in c. */
-                for (k=from, q=(uchar *)abbreviations_text+abbreviations[from].textpos;
+                for (k=from, q=(uchar *)abbreviations_text+abbreviations[k].textpos;
                     (k<no_abbreviations)&&(c==q[0]);
-                     k++, q=(uchar *)abbreviations_text+abbreviations[from].textpos)
+                     k++, q=(uchar *)abbreviations_text+abbreviations[k].textpos)
                 {   
                     /* Let's compare; we also keep track of the length of the abbreviation. */
                     for (l=1; q[l]!=0; l++)

--- a/text.c
+++ b/text.c
@@ -214,6 +214,7 @@ static int try_abbreviations_from(unsigned char *text, int i, int from)
     return(-1);
 }
 
+/* Create an abbreviation. */
 extern void make_abbreviation(char *text)
 {
     /* If -e mode is off, we won't waste space creating an abbreviation entry. */
@@ -239,6 +240,14 @@ extern void make_abbreviation(char *text)
     }
     
     no_abbreviations++;
+}
+
+/* Return a pointer to the (uncompressed) abbreviation text.
+   This should be treated as temporary; it is only valid until the next
+   make_abbreviation() call. */
+extern char *abbreviation_text(int num)
+{
+    return (char *)abbreviations_at + num*MAX_ABBREV_LENGTH;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/text.c
+++ b/text.c
@@ -92,11 +92,10 @@ static int unicode_entity_index(int32 unicode);
 abbreviation *abbreviations;             /* Allocated up to no_abbreviations */
 static memory_list abbreviations_memlist;
 
-/* Memory to hold the text of any abbreviation strings declared. This is
-   counted in units of MAX_ABBREV_LENGTH bytes. (An abbreviation must fit
-   in that many bytes, null included.)                                       */
-uchar *abbreviations_at;                 /* Allocated up to no_abbreviations */
-static memory_list abbreviations_at_memlist;
+/* Memory to hold the text of any abbreviation strings declared.             */
+static int32 abbreviations_totaltext;
+static char *abbreviations_text;  /* Allocated up to abbreviations_totaltext */
+static memory_list abbreviations_text_memlist;
 
 static int *abbreviations_optimal_parse_schedule;
 static memory_list abbreviations_optimal_parse_schedule_memlist;
@@ -198,8 +197,8 @@ static void make_abbrevs_lookup(void)
 static int try_abbreviations_from(unsigned char *text, int i, int from)
 {   int j, k; uchar *p, c;
     c=text[i];
-    for (j=from, p=(uchar *)abbreviations_at+from*MAX_ABBREV_LENGTH;
-         (j<no_abbreviations)&&(c==p[0]); j++, p+=MAX_ABBREV_LENGTH)
+    for (j=from, p=(uchar *)abbreviations_text+abbreviations[from].textpos;
+         (j<no_abbreviations)&&(c==p[0]); j++, p+=(1+abbreviations[from].textlen))
     {   if (text[i+1]==p[1])
         {   for (k=2; p[k]!=0; k++)
                 if (text[i+k]!=p[k]) goto NotMatched;
@@ -217,16 +216,24 @@ static int try_abbreviations_from(unsigned char *text, int i, int from)
 /* Create an abbreviation. */
 extern void make_abbreviation(char *text)
 {
+    int alen;
+    int32 pos;
+    
     /* If -e mode is off, we won't waste space creating an abbreviation entry. */
     if (!economy_switch)
         return;
+
+    alen = strlen(text);
+    pos = abbreviations_totaltext;
     
     ensure_memory_list_available(&abbreviations_memlist, no_abbreviations+1);
-    ensure_memory_list_available(&abbreviations_at_memlist, no_abbreviations+1);
-    
-    strcpy((char *)abbreviations_at
-            + no_abbreviations*MAX_ABBREV_LENGTH, text);
+    ensure_memory_list_available(&abbreviations_text_memlist, pos+alen+1);
 
+    strcpy(abbreviations_text+pos, text);
+    abbreviations_totaltext += (alen+1);
+
+    abbreviations[no_abbreviations].textpos = pos;
+    abbreviations[no_abbreviations].textlen = alen;
     abbreviations[no_abbreviations].value = compile_string(text, STRCTX_ABBREV);
     abbreviations[no_abbreviations].freq = 0;
 
@@ -247,7 +254,12 @@ extern void make_abbreviation(char *text)
    make_abbreviation() call. */
 extern char *abbreviation_text(int num)
 {
-    return (char *)abbreviations_at + num*MAX_ABBREV_LENGTH;
+    if (num < 0 || num >= no_abbreviations) {
+        compiler_error("Invalid abbrev for abbreviation_text()");
+        return "";
+    }
+    
+    return abbreviations_text + abbreviations[num].textpos;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -556,8 +568,8 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
             {
                 c = text_in[j];
                 /* Loop on all abbreviations starting with what is in c. */
-                for (k=from, q=(uchar *)abbreviations_at+from*MAX_ABBREV_LENGTH;
-                    (k<no_abbreviations)&&(c==q[0]); k++, q+=MAX_ABBREV_LENGTH)
+                for (k=from, q=(uchar *)abbreviations_text+abbreviations[from].textpos;
+                    (k<no_abbreviations)&&(c==q[0]); k++, q+=(1+abbreviations[from].textlen))
                 {   
                     /* Let's compare; we also keep track of the length of the abbreviation. */
                     for (l=1; q[l]!=0; l++)
@@ -2715,6 +2727,7 @@ extern void init_text_vars(void)
 extern void text_begin_pass(void)
 {   abbrevs_lookup_table_made = FALSE;
     no_abbreviations=0;
+    abbreviations_totaltext=0;
     total_chars_trans=0; total_bytes_trans=0;
     all_text_top=0;
     dictionary_begin_pass();
@@ -2748,8 +2761,8 @@ extern void text_allocate_arrays(void)
         sizeof(uchar), 128, (void**)&static_strings_area,
         "static strings area");
     
-    initialise_memory_list(&abbreviations_at_memlist,
-        MAX_ABBREV_LENGTH, 64, (void**)&abbreviations_at,
+    initialise_memory_list(&abbreviations_text_memlist,
+        sizeof(char), 64, (void**)&abbreviations_text,
         "abbreviation text");
 
     initialise_memory_list(&abbreviations_memlist,
@@ -2835,7 +2848,7 @@ extern void text_free_arrays(void)
     deallocate_memory_list(&all_text_memlist);
     
     deallocate_memory_list(&low_strings_memlist);
-    deallocate_memory_list(&abbreviations_at_memlist);
+    deallocate_memory_list(&abbreviations_text_memlist);
     deallocate_memory_list(&abbreviations_memlist);
 
     deallocate_memory_list(&abbreviations_optimal_parse_schedule_memlist);

--- a/text.c
+++ b/text.c
@@ -153,7 +153,8 @@ static int text_out_overflow;          /* During text translation, becomes
 /* ------------------------------------------------------------------------- */
 
 static void make_abbrevs_lookup(void)
-{   int bubble_sort, j, k, l; char p[MAX_ABBREV_LENGTH]; char *p1, *p2;
+{   int bubble_sort, j, k;
+    char *p1, *p2;
     do
     {   bubble_sort = FALSE;
         for (j=0; j<no_abbreviations; j++)
@@ -161,11 +162,10 @@ static void make_abbrevs_lookup(void)
             {   p1=abbreviation_text(j);
                 p2=abbreviation_text(k);
                 if (strcmp(p1,p2)<0)
-                {   strcpy(p,p1); strcpy(p1,p2); strcpy(p2,p);
-                    l=abbreviations[j].value; abbreviations[j].value=abbreviations[k].value;
-                    abbreviations[k].value=l;
-                    l=abbreviations[j].quality; abbreviations[j].quality=abbreviations[k].quality;
-                    abbreviations[k].quality=l;
+                {
+                    abbreviation temp = abbreviations[j];
+                    abbreviations[j] = abbreviations[k];
+                    abbreviations[k] = temp;
                     bubble_sort = TRUE;
                 }
             }


### PR DESCRIPTION
This is the first half of https://github.com/DavidKinder/Inform6/issues/257. The MAX_ABBREV_LENGTH constant still exists, but it now only applies to the abbrevation *generator*. The Abbreviate directive can accept abbreviations of any length.

This required changing the `abbreviations_at` array (allocated in chunks of MAX_ABBREV_LENGTH) to a new `abbreviations_text` array (allocated in chars). The `abbreviation` struct now has a value saying where in `abbreviations_text`  to look.
