### PR TITLE
Generalize dict word flags

### DIFF
--- a/header.h
+++ b/header.h
@@ -2585,6 +2585,7 @@ extern int NUM_ATTR_BYTES, GLULX_OBJECT_EXT_BYTES;
 extern int WARN_UNUSED_ROUTINES, OMIT_UNUSED_ROUTINES;
 extern int STRIP_UNREACHABLE_LABELS;
 extern int OMIT_SYMBOL_TABLE;
+extern int LONG_DICT_FLAG_BUG;
 extern int TRANSCRIPT_FORMAT;
 
 /* These macros define offsets that depend on the value of NUM_ATTR_BYTES.

--- a/memory.c
+++ b/memory.c
@@ -270,6 +270,7 @@ int WARN_UNUSED_ROUTINES; /* 0: no, 1: yes except in system files, 2: yes always
 int OMIT_UNUSED_ROUTINES; /* 0: no, 1: yes */
 int STRIP_UNREACHABLE_LABELS; /* 0: no, 1: yes (default) */
 int OMIT_SYMBOL_TABLE; /* 0: no, 1: yes */
+int LONG_DICT_FLAG_BUG; /* 0: no bug, 1: bug (default for historic reasons) */
 int TRANSCRIPT_FORMAT; /* 0: classic, 1: prefixed */
 
 /* The way memory sizes are set causes great nuisance for those parameters
@@ -318,6 +319,7 @@ static void list_memory_sizes(void)
     printf("|  %25s = %-7d |\n","OMIT_UNUSED_ROUTINES",OMIT_UNUSED_ROUTINES);
     printf("|  %25s = %-7d |\n","STRIP_UNREACHABLE_LABELS",STRIP_UNREACHABLE_LABELS);
     printf("|  %25s = %-7d |\n","OMIT_SYMBOL_TABLE",OMIT_SYMBOL_TABLE);
+    printf("|  %25s = %-7d |\n","LONG_DICT_FLAG_BUG",LONG_DICT_FLAG_BUG);
     printf("+--------------------------------------+\n");
 }
 
@@ -351,6 +353,7 @@ extern void set_memory_sizes(void)
     WARN_UNUSED_ROUTINES = 0;
     STRIP_UNREACHABLE_LABELS = 1;
     OMIT_SYMBOL_TABLE = 0;
+    LONG_DICT_FLAG_BUG = 1;
     TRANSCRIPT_FORMAT = 0;
 
     adjust_memory_sizes();
@@ -506,6 +509,14 @@ static void explain_parameter(char *command)
         printf(
 "  OMIT_SYMBOL_TABLE, if set to 1, will skip compiling debug symbol names \n\
   into the game file.\n");
+        return;
+    }
+    if (strcmp(command,"LONG_DICT_FLAG_BUG")==0)
+    {
+        printf(
+"  LONG_DICT_FLAG_BUG, if set to 0, will fix the old bug which ignores \n\
+  the '//p' flag in long dictionary words. If 1, the buggy behavior is \n\
+  retained.\n");
         return;
     }
     if (strcmp(command,"SERIAL")==0)
@@ -921,6 +932,12 @@ extern void memory_command(char *command)
                 OMIT_SYMBOL_TABLE=j, flag=1;
                 if (OMIT_SYMBOL_TABLE > 1 || OMIT_SYMBOL_TABLE < 0)
                     OMIT_SYMBOL_TABLE = 1;
+            }
+            if (strcmp(command,"LONG_DICT_FLAG_BUG")==0)
+            {
+                LONG_DICT_FLAG_BUG=j, flag=1;
+                if (LONG_DICT_FLAG_BUG > 1 || LONG_DICT_FLAG_BUG < 0)
+                    LONG_DICT_FLAG_BUG = 1;
             }
             if (strcmp(command,"SERIAL")==0)
             {

--- a/text.c
+++ b/text.c
@@ -2571,11 +2571,13 @@ static void recursively_show_z(int node, int level)
 
         flags = (int) p[res];
         if (flags & 128)
-        {   printf("noun ");
-            if (flags & 4)  printf("p"); else printf(" ");
-            printf(" ");
-        }
-        else printf("       ");
+            printf("noun ");
+        else
+            printf("     ");
+        if (flags & 4)
+            printf("p ");
+        else
+            printf("  ");
         if (flags & 8)
         {   if (grammar_version_number == 1)
                 printf("preposition:%d  ", (int) p[res+2]);

--- a/text.c
+++ b/text.c
@@ -2017,6 +2017,7 @@ Define DICT_CHAR_SIZE=4 for a Unicode-compatible dictionary.");
     }
   }
 
+  /* Right-pad with zeroes */
   if (DICT_CHAR_SIZE == 1) {
     for (; i<DICT_WORD_SIZE; i++)
       prepared_sort[i] = 0;

--- a/text.c
+++ b/text.c
@@ -2211,17 +2211,17 @@ extern int dictionary_add(char *dword, int x, int y, int z)
         {
             if (!glulx_mode) {
                 p = dictionary+7 + at*DICT_ENTRY_BYTE_LENGTH + res;
-                p[0]=(p[0])|x; p[1]=(p[1])|y;
+                p[0] |= x; p[1] |= y;
                 if (!ZCODE_LESS_DICT_DATA)
-                    p[2]=(p[2])|z;
-                if (x & 128) p[0] = (p[0])|prepared_dictflags;
+                    p[2] |= z;
+                p[0] |= prepared_dictflags;
             }
             else {
                 p = dictionary+4 + at*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS;
-                p[0]=(p[0])|(x/256); p[1]=(p[1])|(x%256); 
-                p[2]=(p[2])|(y/256); p[3]=(p[3])|(y%256); 
-                p[4]=(p[4])|(z/256); p[5]=(p[5])|(z%256);
-                if (x & 128) p[1] = (p[1]) | prepared_dictflags;
+                p[0] |= (x/256); p[1] |= (x%256); 
+                p[2] |= (y/256); p[3] |= (y%256); 
+                p[4] |= (z/256); p[5] |= (z%256);
+                p[1] |= prepared_dictflags;
             }
             return at;
         }
@@ -2331,7 +2331,7 @@ extern int dictionary_add(char *dword, int x, int y, int z)
           {   p[4]=prepared_sort[4]; p[5]=prepared_sort[5]; }
         p[res]=x; p[res+1]=y;
         if (!ZCODE_LESS_DICT_DATA) p[res+2]=z;
-        if (x & 128) p[res] = (p[res])|prepared_dictflags;
+        p[res] |= prepared_dictflags;
 
         dictionary_top += DICT_ENTRY_BYTE_LENGTH;
 
@@ -2350,8 +2350,7 @@ extern int dictionary_add(char *dword, int x, int y, int z)
         p[0] = 0; p[1] = x;
         p[2] = y/256; p[3] = y%256;
         p[4] = 0; p[5] = z;
-        if (x & 128) 
-          p[1] |= prepared_dictflags;
+        p[1] |= prepared_dictflags;
         
         dictionary_top += DICT_ENTRY_BYTE_LENGTH;
 

--- a/text.c
+++ b/text.c
@@ -2231,8 +2231,9 @@ static int dictionary_find(char *dword)
 }
 
 /* ------------------------------------------------------------------------- */
-/*  Add "dword" to the dictionary with (x,y,z) as its data fields; unless    */
-/*  it already exists, in which case OR the data with (x,y,z)                */
+/*  Add "dword" to the dictionary with (flag1,flag2,flag3) as its data       */
+/*  fields; unless it already exists, in which case OR the data with         */
+/*  those flags.                                                             */
 /*                                                                           */
 /*  These fields are one byte each in Z-code, two bytes each in Glulx.       */
 /*                                                                           */

--- a/text.c
+++ b/text.c
@@ -1874,7 +1874,7 @@ extern void copy_sorts(uchar *d1, uchar *d2)
 static memory_list prepared_sort_memlist;
 static uchar *prepared_sort;    /* Holds the sort code of current word */
 
-static int number_and_case;
+static int number_and_case;     /* Dict flags set by the current word */
 
 /* Also used by verbs.c */
 static void dictionary_prepare_z(char *dword, uchar *optresult)
@@ -2188,6 +2188,7 @@ extern int dictionary_add(char *dword, int x, int y, int z)
     int a, b;
     int res=((version_number==3)?4:6);
 
+    /* Fill in prepared_sort and number_and_case. */
     dictionary_prepare(dword, NULL);
 
     if (root == VACANT)

--- a/text.c
+++ b/text.c
@@ -1866,8 +1866,7 @@ static void dictionary_prepare_z(char *dword, uchar *optresult)
             {   switch(dword[j])
                 {   case 'p': number_and_case |= 4;  break;
                     default:
-                        error_named("Expected 'p' after '//' \
-to give number of dictionary word", dword);
+                        error_named("Expected 'p' after '//' in dict word (plural flag)", dword);
                         break;
                 }
             }
@@ -1962,8 +1961,7 @@ static void dictionary_prepare_g(char *dword, uchar *optresult)
           number_and_case |= 4;  
           break;
         default:
-          error_named("Expected 'p' after '//' \
-to give gender or number of dictionary word", dword);
+          error_named("Expected 'p' after '//' in dict word (plural flag)", dword);
           break;
         }
       }

--- a/text.c
+++ b/text.c
@@ -2632,11 +2632,13 @@ static void recursively_show_g(int node, int level)
             for (i=0; i<DICT_ENTRY_BYTE_LENGTH; i++) printf("%02x ",p[i]);
         }
         if (flags & 128)
-        {   printf("noun ");
-            if (flags & 4)  printf("p"); else printf(" ");
-            printf(" ");
-        }
-        else printf("       ");
+            printf("noun ");
+        else
+            printf("     ");
+        if (flags & 4)
+            printf("p ");
+        else
+            printf("  ");
         if (flags & 8)
         {   printf("preposition    ");
         }

--- a/text.c
+++ b/text.c
@@ -1922,6 +1922,9 @@ apostrophe in", dword);
         }
     }
 
+    if (i > dictsize)
+        compiler_error("dict word buffer overflow");
+
     /* Fill up to the end of the dictionary block with PAD characters
        (for safety, we right-pad to 9 chars even in V3)                      */
 
@@ -2019,6 +2022,9 @@ Define DICT_CHAR_SIZE=4 for a Unicode-compatible dictionary.");
       }
     }
   }
+
+  if (i > DICT_WORD_SIZE)
+    compiler_error("dict word buffer overflow");
 
   /* Right-pad with zeroes */
   if (DICT_CHAR_SIZE == 1) {

--- a/text.c
+++ b/text.c
@@ -2239,7 +2239,7 @@ static int dictionary_find(char *dword)
 /*  Returns: the accession number.                                           */
 /* ------------------------------------------------------------------------- */
 
-extern int dictionary_add(char *dword, int x, int y, int z)
+extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 {   int n; uchar *p;
     int ggfr = 0, gfr = 0, fr = 0, r = 0;
     int ggf = VACANT, gf = VACANT, f = VACANT, at = root;
@@ -2259,16 +2259,16 @@ extern int dictionary_add(char *dword, int x, int y, int z)
         {
             if (!glulx_mode) {
                 p = dictionary+7 + at*DICT_ENTRY_BYTE_LENGTH + res;
-                p[0] |= x; p[1] |= y;
+                p[0] |= flag1; p[1] |= flag2;
                 if (!ZCODE_LESS_DICT_DATA)
-                    p[2] |= z;
+                    p[2] |= flag3;
                 p[0] |= prepared_dictflags_pos;
             }
             else {
                 p = dictionary+4 + at*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS;
-                p[0] |= (x/256); p[1] |= (x%256); 
-                p[2] |= (y/256); p[3] |= (y%256); 
-                p[4] |= (z/256); p[5] |= (z%256);
+                p[0] |= (flag1/256); p[1] |= (flag1%256); 
+                p[2] |= (flag2/256); p[3] |= (flag2%256); 
+                p[4] |= (flag3/256); p[5] |= (flag3%256);
                 p[1] |= prepared_dictflags_pos;
             }
             return at;
@@ -2377,8 +2377,8 @@ extern int dictionary_add(char *dword, int x, int y, int z)
         p[2]=prepared_sort[2]; p[3]=prepared_sort[3];
         if (version_number > 3)
           {   p[4]=prepared_sort[4]; p[5]=prepared_sort[5]; }
-        p[res]=x; p[res+1]=y;
-        if (!ZCODE_LESS_DICT_DATA) p[res+2]=z;
+        p[res]=flag1; p[res+1]=flag2;
+        if (!ZCODE_LESS_DICT_DATA) p[res+2]=flag3;
         p[res] |= prepared_dictflags_pos;
 
         dictionary_top += DICT_ENTRY_BYTE_LENGTH;
@@ -2395,9 +2395,9 @@ extern int dictionary_add(char *dword, int x, int y, int z)
           p[i] = prepared_sort[i];
         
         p += DICT_WORD_BYTES;
-        p[0] = 0; p[1] = x;
-        p[2] = y/256; p[3] = y%256;
-        p[4] = 0; p[5] = z;
+        p[0] = (flag1/256); p[1] = (flag1%256);
+        p[2] = (flag2/256); p[3] = (flag2%256);
+        p[4] = (flag3/256); p[5] = (flag3%256);
         p[1] |= prepared_dictflags_pos;
         
         dictionary_top += DICT_ENTRY_BYTE_LENGTH;

--- a/text.c
+++ b/text.c
@@ -1959,7 +1959,7 @@ static void dictionary_prepare_g(char *dword, uchar *optresult)
 
   number_and_case = 0;
 
-  for (i=0, j=0; (dword[j]!=0); i++, j++) {
+  for (i=0, j=0; (dword[j]!=0); j++) {
     if ((dword[j] == '/') && (dword[j+1] == '/')) {
       for (j+=2; dword[j] != 0; j++) {
         switch(dword[j]) {
@@ -1973,7 +1973,6 @@ static void dictionary_prepare_g(char *dword, uchar *optresult)
       }
       break;
     }
-    if (i>=DICT_WORD_SIZE) break;
 
     k= ((unsigned char *)dword)[j];
     if (k=='\'') 
@@ -2007,13 +2006,17 @@ Define DICT_CHAR_SIZE=4 for a Unicode-compatible dictionary.");
     ensure_memory_list_available(&prepared_sort_memlist, DICT_WORD_BYTES);
     
     if (DICT_CHAR_SIZE == 1) {
-      prepared_sort[i] = k;
+      if (i<DICT_WORD_SIZE)
+        prepared_sort[i++] = k;
     }
     else {
-      prepared_sort[4*i]   = (k >> 24) & 0xFF;
-      prepared_sort[4*i+1] = (k >> 16) & 0xFF;
-      prepared_sort[4*i+2] = (k >>  8) & 0xFF;
-      prepared_sort[4*i+3] = (k)       & 0xFF;
+      if (i<DICT_WORD_SIZE) {
+        prepared_sort[4*i]   = (k >> 24) & 0xFF;
+        prepared_sort[4*i+1] = (k >> 16) & 0xFF;
+        prepared_sort[4*i+2] = (k >>  8) & 0xFF;
+        prepared_sort[4*i+3] = (k)       & 0xFF;
+        i++;
+      }
     }
   }
 

--- a/text.c
+++ b/text.c
@@ -1860,7 +1860,7 @@ static void dictionary_prepare_z(char *dword, uchar *optresult)
 
     number_and_case = 0;
 
-    for (i=0, j=0; dword[j]!=0; i++, j++)
+    for (i=0, j=0; dword[j]!=0; j++)
     {   if ((dword[j] == '/') && (dword[j+1] == '/'))
         {   for (j+=2; dword[j] != 0; j++)
             {   switch(dword[j])
@@ -1872,7 +1872,6 @@ static void dictionary_prepare_z(char *dword, uchar *optresult)
             }
             break;
         }
-        if (i>=dictsize) break;
 
         k=(int) dword[j];
         if (k==(int) '\'')
@@ -1903,21 +1902,28 @@ apostrophe in", dword);
                 char_error("Character can be printed but not input:", k);
             else
             {   /* Use 4 more Z-chars to encode a ZSCII escape sequence      */
-
-                wd[i++] = 5; wd[i++] = 6;
+                if (i<dictsize)
+                    wd[i++] = 5;
+                if (i<dictsize)
+                    wd[i++] = 6;
                 k2 = -k2;
-                wd[i++] = k2/32; wd[i] = k2%32;
+                if (i<dictsize)
+                    wd[i++] = k2/32;
+                if (i<dictsize)
+                    wd[i++] = k2%32;
             }
         }
         else
         {   alphabet_used[k2] = 'Y';
-            if ((k2/26)!=0)
+            if ((k2/26)!=0 && i<dictsize)
                 wd[i++]=3+(k2/26);            /* Change alphabet for symbols */
-            wd[i]=6+(k2%26);                  /* Write the Z character       */
+            if (i<dictsize)
+                wd[i++]=6+(k2%26);            /* Write the Z character       */
         }
     }
 
-    /* Fill up to the end of the dictionary block with PAD characters        */
+    /* Fill up to the end of the dictionary block with PAD characters
+       (for safety, we right-pad to 9 chars even in V3)                      */
 
     for (; i<9; i++) wd[i]=5;
 

--- a/text.c
+++ b/text.c
@@ -1901,6 +1901,11 @@ static void dictionary_prepare_z(char *dword, uchar *optresult)
             break;
         }
 
+        /* LONG_DICT_FLAG_BUG emulates the old behavior where we stop looping
+           at dictsize. */
+        if (LONG_DICT_FLAG_BUG && i>=dictsize)
+            break;
+
         k=(int) dword[j];
         if (k==(int) '\'')
             warning_named("Obsolete usage: use the ^ character for the \
@@ -2004,6 +2009,11 @@ static void dictionary_prepare_g(char *dword, uchar *optresult)
       }
       break;
     }
+
+    /* LONG_DICT_FLAG_BUG emulates the old behavior where we stop looping
+       at DICT_WORD_SIZE. */
+    if (LONG_DICT_FLAG_BUG && i>=DICT_WORD_SIZE)
+        break;
 
     k= ((unsigned char *)dword)[j];
     if (k=='\'') 

--- a/text.c
+++ b/text.c
@@ -2232,7 +2232,7 @@ static int dictionary_find(char *dword)
 
 /* ------------------------------------------------------------------------- */
 /*  Add "dword" to the dictionary with (flag1,flag2,flag3) as its data       */
-/*  fields; unless it already exists, in which case OR the data with         */
+/*  fields; unless it already exists, in which case OR the data fields with  */
 /*  those flags.                                                             */
 /*                                                                           */
 /*  These fields are one byte each in Z-code, two bytes each in Glulx.       */
@@ -2250,6 +2250,10 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
     /* Fill in prepared_sort and prepared_dictflags. */
     dictionary_prepare(dword, NULL);
 
+    /* Adjust flag1 according to prepared_dictflags. */
+    flag1 &= (~prepared_dictflags_neg);
+    flag1 |= prepared_dictflags_pos;
+
     if (root == VACANT)
     {   root = 0; goto CreateEntry;
     }
@@ -2263,14 +2267,12 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
                 p[0] |= flag1; p[1] |= flag2;
                 if (!ZCODE_LESS_DICT_DATA)
                     p[2] |= flag3;
-                p[0] |= prepared_dictflags_pos;
             }
             else {
                 p = dictionary+4 + at*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS;
                 p[0] |= (flag1/256); p[1] |= (flag1%256); 
                 p[2] |= (flag2/256); p[3] |= (flag2%256); 
                 p[4] |= (flag3/256); p[5] |= (flag3%256);
-                p[1] |= prepared_dictflags_pos;
             }
             return at;
         }
@@ -2380,7 +2382,6 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
           {   p[4]=prepared_sort[4]; p[5]=prepared_sort[5]; }
         p[res]=flag1; p[res+1]=flag2;
         if (!ZCODE_LESS_DICT_DATA) p[res+2]=flag3;
-        p[res] |= prepared_dictflags_pos;
 
         dictionary_top += DICT_ENTRY_BYTE_LENGTH;
 
@@ -2399,7 +2400,6 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
         p[0] = (flag1/256); p[1] = (flag1%256);
         p[2] = (flag2/256); p[3] = (flag2%256);
         p[4] = (flag3/256); p[5] = (flag3%256);
-        p[1] |= prepared_dictflags_pos;
         
         dictionary_top += DICT_ENTRY_BYTE_LENGTH;
 


### PR DESCRIPTION
Handles https://github.com/DavidKinder/Inform6/issues/259 .

This PR is on top of (and includes) https://github.com/DavidKinder/Inform6/pull/261 . It'll be easier to read the changes here if you merge that one first.

Dict flags (for dict_par1) now include `//p`, `//n`, `//~p`, `//~n`. These are handled consistently:

- `//p` sets the PLURAL flag (bit 2)
- `//n` sets the NOUN flag (bit 7)
- `//~p` means don't set the PLURAL flag (this time)
- `//~n` means don't set the NOUN flag (this time)

Note that `//~p` or `//~n` does not *clear* a flag. If a word appears with both `//p` and `//~p`, the flag winds up set; `//p` wins. Similarly for `//n` and `//~n`.

Dict words used in most contexts default to `//n`. So only the `//p` and `//~n` flags are useful. The others are implemented for the sake of consistency.

You can chain them: `//p~n` if you really want. `//~` with no letter is invalid. Letters other than `p` and `n` are invalid. `//` with nothing after it means "this is a dict word", as it always has.

---

Motivation: 

Existing I6 code will compile exactly as it used to.

The `//~n` flag is meant to be used in library routines like LanguageVerbMayBeName() and LanguageVerbLikesAdverb(), to avoid giving common library verbs the NOUN flag. I don't expect game authors to use or care about it.

I thought about adding `//v` for VERB. But setting the VERB flag without creating a grammar table entry (in dict_par2) will only screw up the parser.

Remember that you can set any dict flag on any word with the `Dictionary` directive. (But not clear.)

---

Details:

The compiler used to ignore the `//p` flag in `Verb` directives. I guess that was intended as a safety check. But I can't imagine it ever came up, and it complicated the logic unnecessarily. I removed that check.

I renamed the `number_and_case` global to `prepared_dictflags_pos`, and added `prepared_dictflags_neg`. These values are set up by the dictionary_prepare_z/g() routines.

I tidied up the dictionary_add() code considerably. I also fixed a place where the flags were being treated as 8-bit values in Glulx. (We only use the low eight bits, but they are 16-bit values in Glulx. The dictionary_add() routine might as well handle that consistently.)

I also renamed the `x`, `y`, `z` arguments of dictionary_add() to `flag1`, `flag2`, `flag3`.

The test file https://github.com/erkyrath/Inform6-Testing/blob/antinoun/src/dictnewflagtest.inf goes through a bunch of cases. I also created https://github.com/erkyrath/Inform6-Testing/blob/antinoun/i6lib-611w/English.h , a modified version of the i6lib-611/English.h, which uses `//~n` in the recommended way.
