### PR TITLE
Weight space as one byte, not four, when applying abbreviations

### DIFF
--- a/text.c
+++ b/text.c
@@ -454,7 +454,9 @@ static void write_z_char_g(int i)
 /* Helper routine to compute the weight, in units, of a character handled by the Z-Machine */
 static int zchar_weight(int c)
 {
-    int lookup = iso_to_alphabet_grid[c];
+    int lookup;
+    if (c == ' ') return 1;
+    lookup = iso_to_alphabet_grid[c];
     if (lookup < 0) return 4;
     if (lookup < 26) return 1;
     return 2;


### PR DESCRIPTION
Fixes https://github.com/DavidKinder/Inform6/issues/264 .

This modestly improves the efficiency of economy (`-e`) mode for Z-code. (It has no effect on the abbreviation generator, `-u`.)

For Advent.inf with 64 abbreviations, this shaves 252 bytes off the game file.

For a minimal I7 6G60 game with 64 abbreviations, in .z8, this shaves 112 bytes off the game file.
