### PR TITLE
Fix the argument parsing of the @jump opcode

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -3059,7 +3059,9 @@ static assembly_operand parse_operand_z(void)
 }
 
 static void parse_assembly_z(void)
-{   int n, min, max, indirect_addressed, error_flag = FALSE;
+{   int n, min, max;
+    int indirect_addressed, jumplabel_args;
+    int error_flag = FALSE;
     opcodez O;
 
     AI.operand_count = 0;
@@ -3220,6 +3222,7 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
     }
 
     indirect_addressed = (O.op_rules == VARIAB);
+    jumplabel_args = (O.op_rules == LABEL);        /* only @jump */
 
     if (O.op_rules == TEXT)
     {   get_next_token();
@@ -3313,6 +3316,12 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
             {   ebf_curtoken_error("']'");
                 put_token_back();
             }
+        }
+        else if (jumplabel_args)
+        {   assembly_operand AO;
+            put_token_back();
+            INITAOTV(&AO, LONG_CONSTANT_OT, parse_label());
+            AI.operand[AI.operand_count++] = AO;
         }
         else
         {   put_token_back();


### PR DESCRIPTION
When parsing Z-code assembly, for the `@jump` opcode, parse the argument with parse_label() instead of parse_operand().

This brings `@jump` in line with the `jump` statement. It correctly supports forward and backward jumps; it throws the correct error when jumping to a nonexistent label.

(Apparently the `@jump` opcode was just never tested at all for Z-code assembly. Everybody's been using the statement form, which produces the same output, only without the bugs.)

This entirely fixes https://github.com/DavidKinder/Inform6/issues/200 as far as I know.

Test cases: https://github.com/erkyrath/Inform6-Testing/blob/jump-opcode/src/jumpopcodetest.inf , https://github.com/erkyrath/Inform6-Testing/blob/jump-opcode/src/jumpbadtest.inf .
