### PR TITLE
`#dict_par1/2/3` fix

### DIFF
--- a/expressp.c
+++ b/expressp.c
@@ -967,16 +967,22 @@ static int evaluate_term(const token_data *t, assembly_operand *o)
                      o->type = BYTECONSTANT_OT;
                      o->marker = 0;
                      v = DICT_ENTRY_FLAG_POS+1;
+                     o->value = v;
+                     set_constant_ot(o);
                      break;
                  case dict_par2_SC:
                      o->type = BYTECONSTANT_OT;
                      o->marker = 0;
                      v = DICT_ENTRY_FLAG_POS+3;
+                     o->value = v;
+                     set_constant_ot(o);
                      break;
                  case dict_par3_SC:
                      o->type = BYTECONSTANT_OT;
                      o->marker = 0;
                      v = DICT_ENTRY_FLAG_POS+5;
+                     o->value = v;
+                     set_constant_ot(o);
                      break;
 
                  case lowest_attribute_number_SC:

--- a/expressp.c
+++ b/expressp.c
@@ -964,21 +964,18 @@ static int evaluate_term(const token_data *t, assembly_operand *o)
                     to expect one-byte fields, even though the compiler
                     generates a dictionary with room for two. */
                  case dict_par1_SC:
-                     o->type = BYTECONSTANT_OT;
                      o->marker = 0;
                      v = DICT_ENTRY_FLAG_POS+1;
                      o->value = v;
                      set_constant_ot(o);
                      break;
                  case dict_par2_SC:
-                     o->type = BYTECONSTANT_OT;
                      o->marker = 0;
                      v = DICT_ENTRY_FLAG_POS+3;
                      o->value = v;
                      set_constant_ot(o);
                      break;
                  case dict_par3_SC:
-                     o->type = BYTECONSTANT_OT;
                      o->marker = 0;
                      v = DICT_ENTRY_FLAG_POS+5;
                      o->value = v;


### PR DESCRIPTION
In Glulx, we were always storing these constants with BYTECONSTANT_OT. But that assumes the values are less than 128. For sufficiently large DICT_WORD_SIZE, this failed.

