### PR TITLE
Verb clash -- initial cleanup

### DIFF
--- a/header.h
+++ b/header.h
@@ -600,7 +600,6 @@
 
 #define  MAX_ERRORS            100
 #define  MAX_NUM_ATTR_BYTES     39
-#define  MAX_VERB_WORD_SIZE    120
 
 #define  VENEER_CONSTRAINT_ON_CLASSES_Z       256
 #define  VENEER_CONSTRAINT_ON_IP_TABLE_SIZE_Z 128

--- a/text.c
+++ b/text.c
@@ -2495,7 +2495,7 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 }
 
 /* ------------------------------------------------------------------------- */
-/*   Used in "tables.c" for "Extend ... only", to renumber a verb-word to a  */
+/*   Used in "verbs.c" for "Extend ... only", to renumber a verb-word to a   */
 /*   new verb syntax of its own.  (Otherwise existing verb-words never       */
 /*   change their verb-numbers.)                                             */
 /* ------------------------------------------------------------------------- */

--- a/verbs.c
+++ b/verbs.c
@@ -1113,7 +1113,8 @@ extern void make_verb(void)
        to English_verbs_count. */
 
     if (first_given_verb == English_verbs_count)
-    {   ebf_curtoken_error("English verb in quotes");
+    {   /* No E-verbs given at all! */
+        ebf_curtoken_error("English verb in quotes");
         panic_mode_error_recovery(); return;
     }
 

--- a/verbs.c
+++ b/verbs.c
@@ -1141,7 +1141,8 @@ extern void make_verb(void)
     {   verb_equals_form = TRUE;
         get_next_token();
         Inform_verb = get_verb();
-        if (Inform_verb == -1) return;
+        if (Inform_verb == -1)
+            return; /* error already printed */
         get_next_token();
         if (!((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)))
             ebf_curtoken_error("';' after English verb");

--- a/verbs.c
+++ b/verbs.c
@@ -67,9 +67,9 @@ int no_adjectives;                     /* Number of adjectives made so far   */
 /*   Verbs.  Note that Inform-verbs are not quite the same as English verbs: */
 /*           for example the English verbs "take" and "drop" both normally   */
 /*           correspond in a game's dictionary to the same Inform verb.  An  */
-/*           Inform verb is essentially a list of grammar lines.             */
-/*           (Calling them "English verbs" is of course out of date. Read    */
-/*           this as jargon for "dict words which are verbs".)               */
+/*           Inform verb (I-verb) is essentially a list of grammar lines.    */
+/*           An English verb (E-verb, although of course it might not be     */
+/*           English!) is a dict word which is known to be a verb.           */
 /* ------------------------------------------------------------------------- */
 /*   Arrays defined below:                                                   */
 /*                                                                           */

--- a/verbs.c
+++ b/verbs.c
@@ -616,13 +616,13 @@ static int find_or_renumber_verb(char *English_verb, int *new_number)
 {
     /*  If new_number is null, returns the Inform-verb number which the
      *  given English verb causes, or -1 if the given verb is not in the
-     *  dictionary                     */
+     *  dictionary. */
 
     /*  If new_number is non-null, renumbers the Inform-verb number which
      *  English_verb matches in English_verb_list to account for the case
      *  when we are extending a verb.  Returns 0 if successful, or -1 if
      *  the given verb is not in the dictionary (which shouldn't happen as
-     *  get_verb has already run) */
+     *  get_verb has already run). */
 
     char *p;
     p=English_verb_list;

--- a/verbs.c
+++ b/verbs.c
@@ -674,13 +674,6 @@ static void register_verb(int textpos, int number)
         number.  (See comments above for format of the list.) ###            */
     int vx;
 
-    char *str = textpos + English_verbs_text;
-    
-    if (find_verb(str) != -1)
-    {   error_named("Two different verb definitions refer to", str);
-        return;
-    }
-
     vx = English_verbs_count;
     ensure_memory_list_available(&English_verbs_memlist, English_verbs_count+1);
 
@@ -1116,8 +1109,16 @@ extern void make_verb(void)
 
     while ((token_type == DQ_TT) || (token_type == SQ_TT))
     {
-        int wordlen = strlen(token_text);
-        int textpos = English_verbs_text_size;
+        int wordlen, textpos;
+        
+        if (find_verb(token_text) != -1)
+        {   error_named("Two different verb definitions refer to", token_text);
+            get_next_token();
+            continue;
+        }
+
+        wordlen = strlen(token_text);
+        textpos = English_verbs_text_size;
         ensure_memory_list_available(&English_verbs_text_memlist, English_verbs_text_size + (wordlen+1));
         strcpy(English_verbs_text+textpos, token_text);
         

--- a/verbs.c
+++ b/verbs.c
@@ -69,7 +69,7 @@ int no_adjectives;                     /* Number of adjectives made so far   */
 /*           correspond in a game's dictionary to the same Inform verb.  An  */
 /*           Inform verb is essentially a list of grammar lines.             */
 /*           (Calling them "English verbs" is of course out of date. Read    */
-/*           this as jargon for "dict words which are verbs".                */
+/*           this as jargon for "dict words which are verbs".)               */
 /* ------------------------------------------------------------------------- */
 /*   Arrays defined below:                                                   */
 /*                                                                           */
@@ -1108,7 +1108,7 @@ extern void make_verb(void)
         get_next_token();
     }
     
-    /* The verbs defined in this directive run from first_given_verb
+    /* The E-verbs defined in this directive run from first_given_verb
        to English_verbs_count. */
 
     if (first_given_verb == English_verbs_count)
@@ -1117,7 +1117,7 @@ extern void make_verb(void)
     }
 
     if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
-    {   /* Define those verbs to match an existing verb. */
+    {   /* Define those E-verbs to match an existing I-verb. */
         verb_equals_form = TRUE;
         get_next_token();
         Inform_verb = get_verb();
@@ -1128,7 +1128,7 @@ extern void make_verb(void)
             ebf_curtoken_error("';' after English verb");
     }
     else
-    {   /* Define those verbs to be a brand-new verb. */
+    {   /* Define those E-verbs to be a brand-new I-verb. */
         verb_equals_form = FALSE;
         if (!glulx_mode && no_Inform_verbs >= 255) {
             error("Z-code is limited to 255 verbs.");
@@ -1146,6 +1146,8 @@ extern void make_verb(void)
         Inform_verbs[no_Inform_verbs].line = get_brief_location(&ErrorReport);
         Inform_verbs[no_Inform_verbs].used = FALSE;
     }
+
+    /* Inform_verb is now the I-verb which those E-verbs should invoke. */
 
     for (ix=first_given_verb; ix<English_verbs_count; ix++) {
         char *wd = English_verbs[ix].textpos + English_verbs_text;

--- a/verbs.c
+++ b/verbs.c
@@ -670,37 +670,26 @@ static void print_verbs_by_number(int num)
 }
 
 /*### just pass in a verbs_given entry to clone! */
-static void register_verb(char *English_verb, int number)
+static void register_verb(int textpos, int number)
 {
     /*  Registers a new English verb as referring to the given Inform-verb
         number.  (See comments above for format of the list.)                */
-    int wordlen;
-    int textpos;
     int vx;
+
+    char *str = textpos + English_verbs_text;
     
-    if (find_verb(English_verb) != -1)
-    {   error_named("Two different verb definitions refer to", English_verb);
+    if (find_verb(str) != -1)
+    {   error_named("Two different verb definitions refer to", str);
         return;
     }
 
     vx = English_verbs_count;
     ensure_memory_list_available(&English_verbs_memlist, English_verbs_count+1);
 
-    textpos = English_verbs_text_size;
-    
     English_verbs[vx].textpos = textpos;
     English_verbs[vx].verbnum = number;
     English_verbs[vx].dictword = -1;
     
-    /* We set a hard limit of MAX_VERB_WORD_SIZE=120 for historical
-       reasons that no longer apply. */
-    wordlen = strlen(English_verb);
-    if (wordlen > MAX_VERB_WORD_SIZE)
-        error_fmt("Verb word is too long -- max length is %d", MAX_VERB_WORD_SIZE);
-    ensure_memory_list_available(&English_verbs_text_memlist, English_verbs_text_size + (wordlen+1));
-    strcpy(English_verbs_text+textpos, English_verb);
-    
-    English_verbs_text_size += (wordlen+1);
     English_verbs_count++;
 }
 
@@ -1186,7 +1175,7 @@ extern void make_verb(void)
         dictionary_add(wd,
             flags,
             (glulx_mode)?(0xffff-Inform_verb):(0xff-Inform_verb), 0);
-        register_verb(wd, Inform_verb);
+        register_verb(English_verbs_given[ix].textpos, Inform_verb);
     }
 
     if (!verb_equals_form)

--- a/verbs.c
+++ b/verbs.c
@@ -70,6 +70,8 @@ int no_adjectives;                     /* Number of adjectives made so far   */
 /*           Inform verb (I-verb) is essentially a list of grammar lines.    */
 /*           An English verb (E-verb, although of course it might not be     */
 /*           English!) is a dict word which is known to be a verb.           */
+/*           Each E-verb's #dict_par2 field contains the I-verb index that   */
+/*           it corresponds to.                                              */
 /* ------------------------------------------------------------------------- */
 /*   Arrays defined below:                                                   */
 /*                                                                           */

--- a/verbs.c
+++ b/verbs.c
@@ -87,13 +87,11 @@ int no_Inform_verbs,                   /* Number of Inform-verbs made so far */
 /*   We keep a list of English verb-words known (e.g. "take" or "eat") and   */
 /*   which Inform-verbs they correspond to.  (This list is needed for some   */
 /*   of the grammar extension operations.)                                   */
-/*   The format of this list is a sequence of variable-length records:       */
-/*                                                                           */
-/*     Byte offset to start of next record  (1 byte)                         */
-/*     Inform verb number this word corresponds to  (2 bytes)                */
-/*     The English verb-word (reduced to lower case), null-terminated        */
 /* ------------------------------------------------------------------------- */
 
+/* This struct is used in two lists. In make_verb() we create entries in
+   English_verbs_given[]; then we transfer those entries to English_verbs[].
+   (### The two-step process is probably no longer necessary.) */
 typedef struct English_verb_s {
     int textpos;  /* in English_verbs_text */
     int dictword; /* dict word accession num */
@@ -673,7 +671,7 @@ static void print_verbs_by_number(int num)
 static void register_verb(int textpos, int number)
 {
     /*  Registers a new English verb as referring to the given Inform-verb
-        number.  (See comments above for format of the list.)                */
+        number.  (See comments above for format of the list.) ###            */
     int vx;
 
     char *str = textpos + English_verbs_text;

--- a/verbs.c
+++ b/verbs.c
@@ -1107,6 +1107,9 @@ extern void make_verb(void)
         
         get_next_token();
     }
+    
+    /* The verbs defined in this directive run from first_given_verb
+       to English_verbs_count. */
 
     if (first_given_verb == English_verbs_count)
     {   ebf_curtoken_error("English verb in quotes");
@@ -1114,7 +1117,8 @@ extern void make_verb(void)
     }
 
     if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
-    {   verb_equals_form = TRUE;
+    {   /* Define those verbs to match an existing verb. */
+        verb_equals_form = TRUE;
         get_next_token();
         Inform_verb = get_verb();
         if (Inform_verb == -1)
@@ -1124,7 +1128,8 @@ extern void make_verb(void)
             ebf_curtoken_error("';' after English verb");
     }
     else
-    {   verb_equals_form = FALSE;
+    {   /* Define those verbs to be a brand-new verb. */
+        verb_equals_form = FALSE;
         if (!glulx_mode && no_Inform_verbs >= 255) {
             error("Z-code is limited to 255 verbs.");
             panic_mode_error_recovery(); return;

--- a/verbs.c
+++ b/verbs.c
@@ -1101,7 +1101,6 @@ extern void make_verb(void)
         English_verbs_text_size += (wordlen+1);
         
         ensure_memory_list_available(&English_verbs_memlist, English_verbs_count+1);
-        
         English_verbs[English_verbs_count].textpos = textpos;
         English_verbs[English_verbs_count].verbnum = -1;
         English_verbs[English_verbs_count].dictword = -1;


### PR DESCRIPTION
I want to tackle https://github.com/DavidKinder/Inform6/issues/285 , but first I'm cleaning up a bunch of grotty verb code. 

This PR does not change any functionality except that one hard-coded size limit is gone.

The make_verb() sequence used to store verb info in two byte-encoded arrays, `English_verb_list` and `English_verbs_given`. It was unnecessarily complicated and also led to a requirement that the verb word length fit in a byte. (The MAX_VERB_WORD_SIZE header define.) 

I have changed this to an array of structs (`English_verbs`) and a separate array of strings referred to by those structs (`English_verbs_text`). The flow of make_verb() is simpler. I have gotten rid of the MAX_VERB_WORD_SIZE constant and the register_verb() helper function.

I've also split find_or_renumber_verb() into find_verb() and renumber_verb(). Both are simpler because they iterate through an array of structs rather than variable-length strings.

