### PR TITLE
Verb clash -- detect and report error

### DIFF
--- a/header.h
+++ b/header.h
@@ -2865,8 +2865,7 @@ extern void  sort_dictionary(void);
 extern void  dictionary_prepare(char *dword, uchar *optresult);
 extern int   dictionary_add(char *dword, int x, int y, int z);
 extern int   dictionary_find(char *dword);
-extern void  dictionary_set_verb_number(char *dword, int to);
-extern void  dictionary_set_verb_number_NEW(int dictword, int to);
+extern void  dictionary_set_verb_number(int dictword, int to);
 extern int   compare_sorts(uchar *d1, uchar *d2);
 extern void  copy_sorts(uchar *d1, uchar *d2);
 

--- a/header.h
+++ b/header.h
@@ -2865,6 +2865,7 @@ extern void  sort_dictionary(void);
 extern void  dictionary_prepare(char *dword, uchar *optresult);
 extern int   dictionary_add(char *dword, int x, int y, int z);
 extern void  dictionary_set_verb_number(char *dword, int to);
+extern void  dictionary_set_verb_number_NEW(int dictword, int to);
 extern int   compare_sorts(uchar *d1, uchar *d2);
 extern void  copy_sorts(uchar *d1, uchar *d2);
 

--- a/header.h
+++ b/header.h
@@ -2864,6 +2864,7 @@ extern void  write_dictionary_to_transcript(void);
 extern void  sort_dictionary(void);
 extern void  dictionary_prepare(char *dword, uchar *optresult);
 extern int   dictionary_add(char *dword, int x, int y, int z);
+extern int   dictionary_find(char *dword);
 extern void  dictionary_set_verb_number(char *dword, int to);
 extern void  dictionary_set_verb_number_NEW(int dictword, int to);
 extern int   compare_sorts(uchar *d1, uchar *d2);

--- a/header.h
+++ b/header.h
@@ -600,7 +600,6 @@
 
 #define  MAX_ERRORS            100
 #define  MAX_NUM_ATTR_BYTES     39
-#define  MAX_VERB_WORD_SIZE    120
 
 #define  VENEER_CONSTRAINT_ON_CLASSES_Z       256
 #define  VENEER_CONSTRAINT_ON_IP_TABLE_SIZE_Z 128

--- a/text.c
+++ b/text.c
@@ -2289,21 +2289,21 @@ extern void sort_dictionary(void)
 }
 
 /* ------------------------------------------------------------------------- */
-/*   If "dword" is in the dictionary, return its accession number plus 1;    */
-/*   If not, return 0.                                                       */
+/*   If "dword" is in the dictionary, return its accession number;           */
+/*   If not, return -1.                                                      */
 /* ------------------------------------------------------------------------- */
 
-static int dictionary_find(char *dword)
+extern int dictionary_find(char *dword)
 {   int at = root, n;
 
     dictionary_prepare(dword, NULL);
 
     while (at != VACANT)
     {   n = compare_sorts(prepared_sort, dict_sort_codes+at*DICT_WORD_BYTES);
-        if (n==0) return at + 1;
+        if (n==0) return at;
         if (n>0) at = dtree[at].branch[1]; else at = dtree[at].branch[0];
     }
-    return 0;
+    return -1;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -2504,14 +2504,14 @@ extern void dictionary_set_verb_number(char *dword, int to)
 {   int i; uchar *p;
     int res=((version_number==3)?4:6);
     i=dictionary_find(dword);
-    if (i!=0)
+    if (i >= 0)
     {   
         if (!glulx_mode) {
-            p=dictionary+7+(i-1)*DICT_ENTRY_BYTE_LENGTH+res; 
+            p=dictionary+7+i*DICT_ENTRY_BYTE_LENGTH+res; 
             p[1]=to;
         }
         else {
-            p=dictionary+4 + (i-1)*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
+            p=dictionary+4 + i*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
             p[2]=to/256; p[3]=to%256;
         }
     }

--- a/text.c
+++ b/text.c
@@ -2502,19 +2502,19 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 /* ------------------------------------------------------------------------- */
 
 extern void dictionary_set_verb_number(int dictword, int infverb)
-{   uchar *p;
-    int i = dictword;
-    int to = ((glulx_mode)?(0xffff-infverb):(0xff-infverb));
+{
+    int flag2 = ((glulx_mode)?(0xffff-infverb):(0xff-infverb));
     int res = ((version_number==3)?4:6);
-    if (i >= 0 && i < dict_entries)
-    {   
+    if (dictword >= 0 && dictword < dict_entries)
+    {
+        uchar *p;
         if (!glulx_mode) {
-            p=dictionary+7+i*DICT_ENTRY_BYTE_LENGTH+res; 
-            p[1]=to;
+            p=dictionary+7+dictword*DICT_ENTRY_BYTE_LENGTH+res; 
+            p[1]=flag2;
         }
         else {
-            p=dictionary+4 + i*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
-            p[2]=to/256; p[3]=to%256;
+            p=dictionary+4 + dictword*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
+            p[2]=flag2/256; p[3]=flag2%256;
         }
     }
 }

--- a/text.c
+++ b/text.c
@@ -2517,6 +2517,23 @@ extern void dictionary_set_verb_number(char *dword, int to)
     }
 }
 
+extern void dictionary_set_verb_number_NEW(int dictword, int to)
+{   uchar *p;
+    int i = dictword;
+    int res=((version_number==3)?4:6);
+    if (i >= 0 && i < dict_entries)
+    {   
+        if (!glulx_mode) {
+            p=dictionary+7+(i-1)*DICT_ENTRY_BYTE_LENGTH+res; 
+            p[1]=to;
+        }
+        else {
+            p=dictionary+4 + (i-1)*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
+            p[2]=to/256; p[3]=to%256;
+        }
+    }
+}
+
 /* ------------------------------------------------------------------------- */
 /*   Tracing code for the dictionary: used by "trace" and text               */
 /*   transcription.                                                          */

--- a/text.c
+++ b/text.c
@@ -2524,11 +2524,11 @@ extern void dictionary_set_verb_number_NEW(int dictword, int to)
     if (i >= 0 && i < dict_entries)
     {   
         if (!glulx_mode) {
-            p=dictionary+7+(i-1)*DICT_ENTRY_BYTE_LENGTH+res; 
+            p=dictionary+7+i*DICT_ENTRY_BYTE_LENGTH+res; 
             p[1]=to;
         }
         else {
-            p=dictionary+4 + (i-1)*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
+            p=dictionary+4 + i*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
             p[2]=to/256; p[3]=to%256;
         }
     }

--- a/text.c
+++ b/text.c
@@ -2504,11 +2504,11 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 extern void dictionary_set_verb_number(int dictword, int infverb)
 {
     int flag2 = ((glulx_mode)?(0xffff-infverb):(0xff-infverb));
-    int res = ((version_number==3)?4:6);
     if (dictword >= 0 && dictword < dict_entries)
     {
         uchar *p;
         if (!glulx_mode) {
+            int res = ((version_number==3)?4:6);
             p=dictionary+7+dictword*DICT_ENTRY_BYTE_LENGTH+res; 
             p[1]=flag2;
         }

--- a/text.c
+++ b/text.c
@@ -2500,23 +2500,6 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 /*   change their verb-numbers.)                                             */
 /* ------------------------------------------------------------------------- */
 
-extern void dictionary_set_verb_number(char *dword, int to)
-{   int i; uchar *p;
-    int res=((version_number==3)?4:6);
-    i=dictionary_find(dword);
-    if (i >= 0)
-    {   
-        if (!glulx_mode) {
-            p=dictionary+7+i*DICT_ENTRY_BYTE_LENGTH+res; 
-            p[1]=to;
-        }
-        else {
-            p=dictionary+4 + i*DICT_ENTRY_BYTE_LENGTH + DICT_ENTRY_FLAG_POS; 
-            p[2]=to/256; p[3]=to%256;
-        }
-    }
-}
-
 extern void dictionary_set_verb_number_NEW(int dictword, int to)
 {   uchar *p;
     int i = dictword;

--- a/text.c
+++ b/text.c
@@ -2496,14 +2496,16 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 
 /* ------------------------------------------------------------------------- */
 /*   Used for "Verb" and "Extend ... only", to initially set or renumber a   */
-/*   verb-word to a new Inform verb index. The verb number is stored in      */
-/*   #dict_par2.                                                             */
+/*   verb-word to a new Inform verb index.                                   */
+/*   The verb number is inverted (we count down from $FF/$FFFF) and stored   */
+/*   in #dict_par2.                                                          */
 /* ------------------------------------------------------------------------- */
 
-extern void dictionary_set_verb_number(int dictword, int to)
+extern void dictionary_set_verb_number(int dictword, int infverb)
 {   uchar *p;
     int i = dictword;
-    int res=((version_number==3)?4:6);
+    int to = ((glulx_mode)?(0xffff-infverb):(0xff-infverb));
+    int res = ((version_number==3)?4:6);
     if (i >= 0 && i < dict_entries)
     {   
         if (!glulx_mode) {

--- a/text.c
+++ b/text.c
@@ -2495,12 +2495,12 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 }
 
 /* ------------------------------------------------------------------------- */
-/*   Used in "verbs.c" for "Extend ... only", to renumber a verb-word to a   */
-/*   new verb syntax of its own.  (Otherwise existing verb-words never       */
-/*   change their verb-numbers.)                                             */
+/*   Used for "Verb" and "Extend ... only", to initially set or renumber a   */
+/*   verb-word to a new Inform verb index. The verb number is stored in      */
+/*   #dict_par2.                                                             */
 /* ------------------------------------------------------------------------- */
 
-extern void dictionary_set_verb_number_NEW(int dictword, int to)
+extern void dictionary_set_verb_number(int dictword, int to)
 {   uchar *p;
     int i = dictword;
     int res=((version_number==3)?4:6);

--- a/text.c
+++ b/text.c
@@ -2495,7 +2495,7 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 }
 
 /* ------------------------------------------------------------------------- */
-/*   Used in "tables.c" for "Extend ... only", to renumber a verb-word to a  */
+/*   Used in "verbs.c" for "Extend ... only", to renumber a verb-word to a   */
 /*   new verb syntax of its own.  (Otherwise existing verb-words never       */
 /*   change their verb-numbers.)                                             */
 /* ------------------------------------------------------------------------- */

--- a/verbs.c
+++ b/verbs.c
@@ -1113,7 +1113,8 @@ extern void make_verb(void)
        to English_verbs_count. */
 
     if (first_given_verb == English_verbs_count)
-    {   ebf_curtoken_error("English verb in quotes");
+    {   /* No E-verbs given at all! */
+        ebf_curtoken_error("English verb in quotes");
         panic_mode_error_recovery(); return;
     }
 

--- a/verbs.c
+++ b/verbs.c
@@ -1174,7 +1174,7 @@ extern void make_verb(void)
 
     for (ix=first_given_verb; ix<English_verbs_count; ix++) {
         English_verbs[ix].verbnum = Inform_verb;
-        dictionary_set_verb_number_NEW(English_verbs[ix].dictword,
+        dictionary_set_verb_number(English_verbs[ix].dictword,
             (glulx_mode)?(0xffff-Inform_verb):(0xff-Inform_verb));
     }
 
@@ -1233,7 +1233,7 @@ extern void extend_verb(void)
             if ((l!=-1) && (Inform_verb!=l))
               warning_named("Verb disagrees with previous verbs:", token_text);
             l = Inform_verb;
-            dictionary_set_verb_number_NEW(dictword,
+            dictionary_set_verb_number(dictword,
               (glulx_mode)?(0xffff-no_Inform_verbs):(0xff-no_Inform_verbs));
             /* make call to renumber verb in English_verb_list too */
             if (renumber_verb(token_text, no_Inform_verbs) == -1)

--- a/verbs.c
+++ b/verbs.c
@@ -1136,7 +1136,7 @@ extern void make_verb(void)
     {   /* Define those E-verbs to match an existing I-verb. */
         verb_equals_form = TRUE;
         get_next_token();
-        Inform_verb = get_existing_verb(); //### by dict word
+        Inform_verb = get_existing_verb();
         if (Inform_verb == -1)
             return; /* error already printed */
         get_next_token();

--- a/verbs.c
+++ b/verbs.c
@@ -1141,7 +1141,8 @@ extern void make_verb(void)
     {   verb_equals_form = TRUE;
         get_next_token();
         Inform_verb = get_verb();
-        if (Inform_verb == -1) return;
+        if (Inform_verb == -1)
+            return; /* error already printed */
         get_next_token();
         if (!((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)))
             ebf_curtoken_error("';' after English verb");

--- a/verbs.c
+++ b/verbs.c
@@ -67,9 +67,9 @@ int no_adjectives;                     /* Number of adjectives made so far   */
 /*   Verbs.  Note that Inform-verbs are not quite the same as English verbs: */
 /*           for example the English verbs "take" and "drop" both normally   */
 /*           correspond in a game's dictionary to the same Inform verb.  An  */
-/*           Inform verb is essentially a list of grammar lines.             */
-/*           (Calling them "English verbs" is of course out of date. Read    */
-/*           this as jargon for "dict words which are verbs".)               */
+/*           Inform verb (I-verb) is essentially a list of grammar lines.    */
+/*           An English verb (E-verb, although of course it might not be     */
+/*           English!) is a dict word which is known to be a verb.           */
 /* ------------------------------------------------------------------------- */
 /*   Arrays defined below:                                                   */
 /*                                                                           */

--- a/verbs.c
+++ b/verbs.c
@@ -673,29 +673,28 @@ static int get_existing_verb(int *dictref)
     if (dictref)
         *dictref = -1;
 
-    //###
-    if ((token_type == DQ_TT) || (token_type == SQ_TT))
-    {
-        dictword = dictionary_find(token_text);
-        if (dictword < 0) {
-            error_named("There is no previous grammar for the verb",
-                token_text);
-            return -1;
-        }
-        j = find_verb(dictword);
-        if (j < 0) {
-            error_named("There is no previous grammar for the verb",
-                token_text);
-            return -1;
-        }
-        if (dictref)
-            *dictref = dictword;
-        return j;
+    if ((token_type != DQ_TT) && (token_type != SQ_TT)) {
+        ebf_curtoken_error("an English verb in quotes");
+        return -1;
     }
 
-    ebf_curtoken_error("an English verb in quotes");
-
-    return -1;
+    dictword = dictionary_find(token_text);
+    if (dictword < 0) {
+        error_named("There is no previous grammar for the verb",
+            token_text);
+        return -1;
+    }
+    
+    j = find_verb(dictword);
+    if (j < 0) {
+        error_named("There is no previous grammar for the verb",
+            token_text);
+        return -1;
+    }
+    
+    if (dictref)
+        *dictref = dictword;
+    return j;
 }
 
 void locate_dead_grammar_lines()

--- a/verbs.c
+++ b/verbs.c
@@ -616,13 +616,13 @@ static int find_or_renumber_verb(char *English_verb, int *new_number)
 {
     /*  If new_number is null, returns the Inform-verb number which the
      *  given English verb causes, or -1 if the given verb is not in the
-     *  dictionary                     */
+     *  dictionary. */
 
     /*  If new_number is non-null, renumbers the Inform-verb number which
      *  English_verb matches in English_verb_list to account for the case
      *  when we are extending a verb.  Returns 0 if successful, or -1 if
      *  the given verb is not in the dictionary (which shouldn't happen as
-     *  get_verb has already run) */
+     *  get_verb has already run). */
 
     char *p;
     p=English_verb_list;

--- a/verbs.c
+++ b/verbs.c
@@ -674,13 +674,6 @@ static void register_verb(int textpos, int number)
         number.  (See comments above for format of the list.) ###            */
     int vx;
 
-    char *str = textpos + English_verbs_text;
-    
-    if (find_verb(str) != -1)
-    {   error_named("Two different verb definitions refer to", str);
-        return;
-    }
-
     vx = English_verbs_count;
     ensure_memory_list_available(&English_verbs_memlist, English_verbs_count+1);
 
@@ -1116,8 +1109,16 @@ extern void make_verb(void)
 
     while ((token_type == DQ_TT) || (token_type == SQ_TT))
     {
-        int wordlen = strlen(token_text);
-        int textpos = English_verbs_text_size;
+        int wordlen, textpos;
+        
+        if (find_verb(token_text) != -1)
+        {   error_named("Two different verb definitions refer to", token_text);
+            get_next_token();
+            continue;
+        }
+
+        wordlen = strlen(token_text);
+        textpos = English_verbs_text_size;
         ensure_memory_list_available(&English_verbs_text_memlist, English_verbs_text_size + (wordlen+1));
         strcpy(English_verbs_text+textpos, token_text);
         

--- a/verbs.c
+++ b/verbs.c
@@ -627,21 +627,6 @@ static int find_verb(int dictword)
     return(-1);
 }
 
-//###
-static int find_verb_by_text(char *English_verb)
-{
-    /*  Returns the Inform-verb number which the given English verb
-     *  causes, or -1 if the given verb is not in the dictionary. */
-    int ix;
-    for (ix=0; ix<English_verbs_count; ix++) {
-        char *str = English_verbs[ix].textpos + English_verbs_text;
-        if (!strcmp(English_verb, str)) {
-            return English_verbs[ix].verbnum;
-        }
-    }
-    return(-1);
-}
-
 static int renumber_verb(char *English_verb, int new_number)
 {
     /*  Renumbers the Inform-verb number which English_verb matches in

--- a/verbs.c
+++ b/verbs.c
@@ -69,7 +69,7 @@ int no_adjectives;                     /* Number of adjectives made so far   */
 /*           correspond in a game's dictionary to the same Inform verb.  An  */
 /*           Inform verb is essentially a list of grammar lines.             */
 /*           (Calling them "English verbs" is of course out of date. Read    */
-/*           this as jargon for "dict words which are verbs".                */
+/*           this as jargon for "dict words which are verbs".)               */
 /* ------------------------------------------------------------------------- */
 /*   Arrays defined below:                                                   */
 /*                                                                           */
@@ -1108,7 +1108,7 @@ extern void make_verb(void)
         get_next_token();
     }
     
-    /* The verbs defined in this directive run from first_given_verb
+    /* The E-verbs defined in this directive run from first_given_verb
        to English_verbs_count. */
 
     if (first_given_verb == English_verbs_count)
@@ -1117,7 +1117,7 @@ extern void make_verb(void)
     }
 
     if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
-    {   /* Define those verbs to match an existing verb. */
+    {   /* Define those E-verbs to match an existing I-verb. */
         verb_equals_form = TRUE;
         get_next_token();
         Inform_verb = get_verb();
@@ -1128,7 +1128,7 @@ extern void make_verb(void)
             ebf_curtoken_error("';' after English verb");
     }
     else
-    {   /* Define those verbs to be a brand-new verb. */
+    {   /* Define those E-verbs to be a brand-new I-verb. */
         verb_equals_form = FALSE;
         if (!glulx_mode && no_Inform_verbs >= 255) {
             error("Z-code is limited to 255 verbs.");
@@ -1146,6 +1146,8 @@ extern void make_verb(void)
         Inform_verbs[no_Inform_verbs].line = get_brief_location(&ErrorReport);
         Inform_verbs[no_Inform_verbs].used = FALSE;
     }
+
+    /* Inform_verb is now the I-verb which those E-verbs should invoke. */
 
     for (ix=first_given_verb; ix<English_verbs_count; ix++) {
         char *wd = English_verbs[ix].textpos + English_verbs_text;

--- a/verbs.c
+++ b/verbs.c
@@ -1172,8 +1172,7 @@ extern void make_verb(void)
 
     for (ix=first_given_verb; ix<English_verbs_count; ix++) {
         English_verbs[ix].verbnum = Inform_verb;
-        dictionary_set_verb_number(English_verbs[ix].dictword,
-            (glulx_mode)?(0xffff-Inform_verb):(0xff-Inform_verb));
+        dictionary_set_verb_number(English_verbs[ix].dictword, Inform_verb);
     }
 
     if (!verb_equals_form)
@@ -1232,8 +1231,7 @@ extern void extend_verb(void)
             if ((l!=-1) && (Inform_verb!=l))
               warning_named("Verb disagrees with previous verbs:", token_text);
             l = Inform_verb;
-            dictionary_set_verb_number(dictword,
-              (glulx_mode)?(0xffff-no_Inform_verbs):(0xff-no_Inform_verbs));
+            dictionary_set_verb_number(dictword, no_Inform_verbs);
             /* make call to renumber verb in English_verbs too */
             if (renumber_verb(dictword, no_Inform_verbs) == -1)
               warning_named("Verb to extend not found in English_verbs:",

--- a/verbs.c
+++ b/verbs.c
@@ -670,37 +670,26 @@ static void print_verbs_by_number(int num)
 }
 
 /*### just pass in a verbs_given entry to clone! */
-static void register_verb(char *English_verb, int number)
+static void register_verb(int textpos, int number)
 {
     /*  Registers a new English verb as referring to the given Inform-verb
         number.  (See comments above for format of the list.)                */
-    int wordlen;
-    int textpos;
     int vx;
+
+    char *str = textpos + English_verbs_text;
     
-    if (find_verb(English_verb) != -1)
-    {   error_named("Two different verb definitions refer to", English_verb);
+    if (find_verb(str) != -1)
+    {   error_named("Two different verb definitions refer to", str);
         return;
     }
 
     vx = English_verbs_count;
     ensure_memory_list_available(&English_verbs_memlist, English_verbs_count+1);
 
-    textpos = English_verbs_text_size;
-    
     English_verbs[vx].textpos = textpos;
     English_verbs[vx].verbnum = number;
     English_verbs[vx].dictword = -1;
     
-    /* We set a hard limit of MAX_VERB_WORD_SIZE=120 for historical
-       reasons that no longer apply. */
-    wordlen = strlen(English_verb);
-    if (wordlen > MAX_VERB_WORD_SIZE)
-        error_fmt("Verb word is too long -- max length is %d", MAX_VERB_WORD_SIZE);
-    ensure_memory_list_available(&English_verbs_text_memlist, English_verbs_text_size + (wordlen+1));
-    strcpy(English_verbs_text+textpos, English_verb);
-    
-    English_verbs_text_size += (wordlen+1);
     English_verbs_count++;
 }
 
@@ -1186,7 +1175,7 @@ extern void make_verb(void)
         dictionary_add(wd,
             flags,
             (glulx_mode)?(0xffff-Inform_verb):(0xff-Inform_verb), 0);
-        register_verb(wd, Inform_verb);
+        register_verb(English_verbs_given[ix].textpos, Inform_verb);
     }
 
     if (!verb_equals_form)

--- a/verbs.c
+++ b/verbs.c
@@ -70,6 +70,8 @@ int no_adjectives;                     /* Number of adjectives made so far   */
 /*           Inform verb (I-verb) is essentially a list of grammar lines.    */
 /*           An English verb (E-verb, although of course it might not be     */
 /*           English!) is a dict word which is known to be a verb.           */
+/*           Each E-verb's #dict_par2 field contains the I-verb index that   */
+/*           it corresponds to.                                              */
 /* ------------------------------------------------------------------------- */
 /*   Arrays defined below:                                                   */
 /*                                                                           */

--- a/verbs.c
+++ b/verbs.c
@@ -627,17 +627,16 @@ static int find_verb(int dictword)
     return(-1);
 }
 
-static int renumber_verb(char *English_verb, int new_number)
+static int renumber_verb(int dictword, int new_number)
 {
     /*  Renumbers the Inform-verb number which English_verb matches in
-     *  English_verb_list to account for the case when we are
+     *  English_verbs to account for the case when we are
      *  extending a verb. Returns 0 if successful, or -1 if the given
      *  verb is not in the dictionary (which shouldn't happen as
-     *  get_verb has already run). */
+     *  get_existing_verb() has already run). */
     int ix;
     for (ix=0; ix<English_verbs_count; ix++) {
-        char *str = English_verbs[ix].textpos + English_verbs_text;
-        if (!strcmp(English_verb, str)) {
+        if (English_verbs[ix].dictword == dictword) {
             English_verbs[ix].verbnum = new_number;
             return 0;
         }
@@ -1230,14 +1229,15 @@ extern void extend_verb(void)
             int dictword;
             Inform_verb = get_existing_verb(&dictword);
             if (Inform_verb == -1) return;
+            /* dictword is the dict index number of token_text */
             if ((l!=-1) && (Inform_verb!=l))
               warning_named("Verb disagrees with previous verbs:", token_text);
             l = Inform_verb;
             dictionary_set_verb_number(dictword,
               (glulx_mode)?(0xffff-no_Inform_verbs):(0xff-no_Inform_verbs));
-            /* make call to renumber verb in English_verb_list too */
-            if (renumber_verb(token_text, no_Inform_verbs) == -1)
-              warning_named("Verb to extend not found in English_verb_list:",
+            /* make call to renumber verb in English_verbs too */
+            if (renumber_verb(dictword, no_Inform_verbs) == -1)
+              warning_named("Verb to extend not found in English_verbs:",
                  token_text);
         }
 

--- a/verbs.c
+++ b/verbs.c
@@ -87,13 +87,11 @@ int no_Inform_verbs,                   /* Number of Inform-verbs made so far */
 /*   We keep a list of English verb-words known (e.g. "take" or "eat") and   */
 /*   which Inform-verbs they correspond to.  (This list is needed for some   */
 /*   of the grammar extension operations.)                                   */
-/*   The format of this list is a sequence of variable-length records:       */
-/*                                                                           */
-/*     Byte offset to start of next record  (1 byte)                         */
-/*     Inform verb number this word corresponds to  (2 bytes)                */
-/*     The English verb-word (reduced to lower case), null-terminated        */
 /* ------------------------------------------------------------------------- */
 
+/* This struct is used in two lists. In make_verb() we create entries in
+   English_verbs_given[]; then we transfer those entries to English_verbs[].
+   (### The two-step process is probably no longer necessary.) */
 typedef struct English_verb_s {
     int textpos;  /* in English_verbs_text */
     int dictword; /* dict word accession num */
@@ -673,7 +671,7 @@ static void print_verbs_by_number(int num)
 static void register_verb(int textpos, int number)
 {
     /*  Registers a new English verb as referring to the given Inform-verb
-        number.  (See comments above for format of the list.)                */
+        number.  (See comments above for format of the list.) ###            */
     int vx;
 
     char *str = textpos + English_verbs_text;

--- a/verbs.c
+++ b/verbs.c
@@ -1170,9 +1170,9 @@ extern void make_verb(void)
     /* Inform_verb is now the I-verb which those E-verbs should invoke. */
 
     for (ix=first_given_verb; ix<English_verbs_count; ix++) {
+        English_verbs[ix].verbnum = Inform_verb;
         dictionary_set_verb_number_NEW(English_verbs[ix].dictword,
             (glulx_mode)?(0xffff-Inform_verb):(0xff-Inform_verb));
-        English_verbs[ix].verbnum = Inform_verb;
     }
 
     if (!verb_equals_form)

--- a/verbs.c
+++ b/verbs.c
@@ -627,6 +627,7 @@ static int find_verb(int dictword)
     return(-1);
 }
 
+//###
 static int find_verb_by_text(char *English_verb)
 {
     /*  Returns the Inform-verb number which the given English verb
@@ -675,19 +676,29 @@ static void print_verbs_by_number(int num)
         printf(" <none>");
 }
 
-static int get_verb(void)
+static int get_existing_verb(void)
 {
     /*  Look at the last-read token: if it's the name of an English verb
         understood by Inform, in double-quotes, then return the Inform-verb
-        that word refers to: otherwise give an error and return -1.          */
+        that word refers to: otherwise give an error and return -1.
+    */
 
-    int j;
+    int j, dictword;
 
     if ((token_type == DQ_TT) || (token_type == SQ_TT))
-    {   j = find_verb_by_text(token_text);
-        if (j==-1)
+    {
+        dictword = dictionary_find(token_text);
+        if (dictword < 0) {
             error_named("There is no previous grammar for the verb",
                 token_text);
+            return -1;
+        }
+        j = find_verb(dictword);
+        if (j < 0) {
+            error_named("There is no previous grammar for the verb",
+                token_text);
+            return -1;
+        }
         return j;
     }
 
@@ -1140,7 +1151,7 @@ extern void make_verb(void)
     {   /* Define those E-verbs to match an existing I-verb. */
         verb_equals_form = TRUE;
         get_next_token();
-        Inform_verb = get_verb();
+        Inform_verb = get_existing_verb(); //### by dict word
         if (Inform_verb == -1)
             return; /* error already printed */
         get_next_token();
@@ -1223,7 +1234,7 @@ extern void extend_verb(void)
         l = -1;
         while (get_next_token(),
                ((token_type == DQ_TT) || (token_type == SQ_TT)))
-        {   Inform_verb = get_verb();
+        {   Inform_verb = get_existing_verb();
             if (Inform_verb == -1) return;
             if ((l!=-1) && (Inform_verb!=l))
               warning_named("Verb disagrees with previous verbs:", token_text);
@@ -1253,7 +1264,7 @@ extern void extend_verb(void)
         Inform_verb = no_Inform_verbs++;
     }
     else
-    {   Inform_verb = get_verb();
+    {   Inform_verb = get_existing_verb();
         if (Inform_verb == -1) return;
         get_next_token();
     }

--- a/verbs.c
+++ b/verbs.c
@@ -1107,6 +1107,9 @@ extern void make_verb(void)
         
         get_next_token();
     }
+    
+    /* The verbs defined in this directive run from first_given_verb
+       to English_verbs_count. */
 
     if (first_given_verb == English_verbs_count)
     {   ebf_curtoken_error("English verb in quotes");
@@ -1114,7 +1117,8 @@ extern void make_verb(void)
     }
 
     if ((token_type == SEP_TT) && (token_value == SETEQUALS_SEP))
-    {   verb_equals_form = TRUE;
+    {   /* Define those verbs to match an existing verb. */
+        verb_equals_form = TRUE;
         get_next_token();
         Inform_verb = get_verb();
         if (Inform_verb == -1)
@@ -1124,7 +1128,8 @@ extern void make_verb(void)
             ebf_curtoken_error("';' after English verb");
     }
     else
-    {   verb_equals_form = FALSE;
+    {   /* Define those verbs to be a brand-new verb. */
+        verb_equals_form = FALSE;
         if (!glulx_mode && no_Inform_verbs >= 255) {
             error("Z-code is limited to 255 verbs.");
             panic_mode_error_recovery(); return;

--- a/verbs.c
+++ b/verbs.c
@@ -1101,7 +1101,6 @@ extern void make_verb(void)
         English_verbs_text_size += (wordlen+1);
         
         ensure_memory_list_available(&English_verbs_memlist, English_verbs_count+1);
-        
         English_verbs[English_verbs_count].textpos = textpos;
         English_verbs[English_verbs_count].verbnum = -1;
         English_verbs[English_verbs_count].dictword = -1;


### PR DESCRIPTION
This PR is built on https://github.com/DavidKinder/Inform6/pull/286 . It will be easier to read if you merge that one first.

When parsing the Verb and Extend directives, we now convert strings to dict words before searching or comparing them.

The routines dictionary_set_verb_number(), find_verb(), renumber_verb() therefore now take int arguments instead of char*.

get_verb() is renamed get_existing_verb() and now optionally returns a dict word as well as a verb number.

https://github.com/erkyrath/Inform6-Testing/blob/verbclash2/src/verbclash.inf contains various test cases.

This finishes off https://github.com/DavidKinder/Inform6/issues/285 , unless we want to do the "implicit Extend" thing. I haven't heard back from Graham about that yet.

