### PR TITLE
Accept two Verb declarations for the same verb, with a warning

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -209,6 +209,7 @@ extern int parse_given_directive(int internal_flag)
 it is too late to change the grammar version.");
                 }
                 else if (no_actions > 0) {
+                    /* TODO: Check no_grammar_lines instead? Or no_Inform_verbs? */
                     error("Once an action has been defined \
 it is too late to change the grammar version.");
                 }

--- a/directs.c
+++ b/directs.c
@@ -208,8 +208,7 @@ extern int parse_given_directive(int internal_flag)
                     error("Once a fake action has been defined \
 it is too late to change the grammar version.");
                 }
-                else if (no_actions > 0) {
-                    /* TODO: Check no_grammar_lines instead? Or no_Inform_verbs? */
+                else if (no_grammar_lines > 0) {
                     error("Once an action has been defined \
 it is too late to change the grammar version.");
                 }

--- a/verbs.c
+++ b/verbs.c
@@ -1082,6 +1082,8 @@ tokens in any line (for grammar version 1)");
 /*                                                                           */
 /* ------------------------------------------------------------------------- */
 
+static void do_extend_verb(int Inform_verb, int extend_mode);
+
 extern void make_verb(void)
 {
     /*  Parse an entire Verb ... directive.                                  */
@@ -1242,7 +1244,7 @@ extern void extend_verb(void)
 {
     /*  Parse an entire Extend ... directive.                                */
 
-    int Inform_verb = -1, k, l, lines, extend_mode;
+    int Inform_verb = -1, k, l, extend_mode;
 
     directive_keywords.enabled = TRUE;
     directives.enabled = FALSE;
@@ -1321,6 +1323,16 @@ extern void extend_verb(void)
         }
     }
 
+    do_extend_verb(Inform_verb, extend_mode);
+
+    directive_keywords.enabled = FALSE;
+    directives.enabled = TRUE;
+}
+
+static void do_extend_verb(int Inform_verb, int extend_mode)
+{
+    int k, l, lines;
+    
     l = Inform_verbs[Inform_verb].lines;
     lines = 0;
     if (extend_mode == EXTEND_LAST) lines=l;
@@ -1344,10 +1356,8 @@ extern void extend_verb(void)
         }
     }
     else Inform_verbs[Inform_verb].lines = --lines;
-
-    directive_keywords.enabled = FALSE;
-    directives.enabled = TRUE;
 }
+
 
 /* ------------------------------------------------------------------------- */
 /*   Action table sorter.                                                    */

--- a/verbs.c
+++ b/verbs.c
@@ -1082,6 +1082,10 @@ tokens in any line (for grammar version 1)");
 /*                                                                           */
 /* ------------------------------------------------------------------------- */
 
+#define EXTEND_REPLACE 1
+#define EXTEND_FIRST   2
+#define EXTEND_LAST    3
+
 static void do_extend_verb(int Inform_verb, int extend_mode);
 
 extern void make_verb(void)
@@ -1137,8 +1141,20 @@ extern void make_verb(void)
                 }
                 if (foundverb >= 0
                     && ((token_type == SEP_TT) && (token_value == TIMES_SEP))) {
-                    printf("###YES\n");
-                    panic_mode_error_recovery(); return; //###
+                    tmpstr = English_verbs[evnum].textpos + English_verbs_text;
+                    warning_fmt("This verb definition refers to \"%s\", which has already been defined. Use \"Extend last\" instead.", tmpstr);
+
+                    put_token_back();
+                    
+                    /* Keyword settings used in extend_verb() */
+                    directive_keywords.enabled = TRUE;
+                    directives.enabled = FALSE;
+
+                    do_extend_verb(foundverb, EXTEND_LAST);
+
+                    directive_keywords.enabled = FALSE;
+                    directives.enabled = TRUE;
+                    return;
                 }
                 put_token_back();
             }
@@ -1236,10 +1252,6 @@ extern void make_verb(void)
 /*                                                                           */
 /* ------------------------------------------------------------------------- */
 
-#define EXTEND_REPLACE 1
-#define EXTEND_FIRST   2
-#define EXTEND_LAST    3
-
 extern void extend_verb(void)
 {
     /*  Parse an entire Extend ... directive.                                */
@@ -1331,6 +1343,9 @@ extern void extend_verb(void)
 
 static void do_extend_verb(int Inform_verb, int extend_mode)
 {
+    /* The execution of Extend. This is called both from extend_verb()
+       and from the implicit-extend case of make_verb(). */
+    
     int k, l, lines;
     
     l = Inform_verbs[Inform_verb].lines;

--- a/verbs.c
+++ b/verbs.c
@@ -1263,7 +1263,8 @@ extern void extend_verb(void)
         {
             int dictword;
             Inform_verb = get_existing_verb(&dictword);
-            if (Inform_verb == -1) return;
+            if (Inform_verb == -1)
+                return; /* error already printed */
             /* dictword is the dict index number of token_text */
             if ((l!=-1) && (Inform_verb!=l))
               warning_named("Verb disagrees with previous verbs:", token_text);

--- a/verbs.c
+++ b/verbs.c
@@ -1294,7 +1294,8 @@ extern void extend_verb(void)
     }
     else
     {   Inform_verb = get_existing_verb(NULL);
-        if (Inform_verb == -1) return;
+        if (Inform_verb == -1)
+            return; /* error already printed */
         get_next_token();
     }
 

--- a/verbs.c
+++ b/verbs.c
@@ -1092,6 +1092,8 @@ extern void make_verb(void)
     int ix;
 
     directive_keywords.enabled = TRUE;
+    /* TODO: We should really turn off directive_keywords for all exit paths.
+       Currently we don't bother after an error. */
 
     get_next_token();
 


### PR DESCRIPTION
This change is a big wodge of code in the "Two different verb definitions refer to..." part of make_verb(). We arrive at this case if we see:

```
Verb "foo" [...]
```

...where `"foo"` is already known as a verb.

Before printing that error, we check to see if this is valid to treat as "Extend last".

If there's just one verb (which is the I7-generated case), it's easy. The trick is if there's multiple verb words, which is legal in the `Verb` directive. (Though not in the `Extend` directive.)

```
Verb "foo" "bar" "baz" [...]
```

We accept this as a valid extend if all the verbs are known and refer to the *same* Inform verb. Otherwise, we fall back to the old "Two different verb definitions refer to..." error.

If it's a valid extend, we print a warning:

> This verb definition refers to "foo", which has already been defined. Use "Extend last" instead.

But we allow it, and therefore jump into the `Extend` machinery. Note that the end of the extend_verb() function has been factored out so that we can call it from two places.

---

Other changes:

I renamed find_verb() to find_verb_entry(); it now returns the `English_verbs[]` index number rather than the `verbnum` of that entry. Made some other stuff easier.

As noted on the forum, I've adjusted the check for this error:

> Once an action has been defined it is too late to change the grammar version.

It's okay if actions *names* have been defined (like `##Take`). The problem arises if action *grammar* has been defined. So we check for that more specifically.

(This tweaks https://github.com/DavidKinder/Inform6/commit/6a4de5b391379737831ac8ce2081a811c861b9a3 .)
