### PR TITLE
Code cleanup

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -2908,7 +2908,7 @@ void assemblez_jump(int n)
     if (n==-4) assemblez_0(rtrue_zc);
     else if (n==-3) assemblez_0(rfalse_zc);
     else
-    {   AO.type = LONG_CONSTANT_OT; AO.value = n; AO.marker = 0;
+    {   INITAOTV(&AO, LONG_CONSTANT_OT, n);
         assemblez_1(jump_zc, AO);
     }
 }

--- a/asm.c
+++ b/asm.c
@@ -860,6 +860,13 @@ static opcodez internal_number_to_opcode_z(int32 i)
     return extension_table_z[x.extension];
 }
 
+static char *opcode_name_z(int32 i)
+{
+    if (i >= 0 && i < MAX_KEYWORD_GROUP_SIZE && opcode_names.keywords[i])
+        return opcode_names.keywords[i];
+    return "(unnamed)";
+}
+
 static void make_opcode_syntax_z(opcodez opco)
 {   char *p = "", *q = opcode_syntax_string;
     /* TODO: opcode_syntax_string[128] is unsafe */
@@ -1031,7 +1038,7 @@ extern void assemblez_instruction(const assembly_instruction *AI)
     opco = internal_number_to_opcode_z(AI->internal_number);
     if (opco.version1==0)
     {   error_named("Opcode unavailable in this Z-machine version",
-            opcode_names.keywords[AI->internal_number]);
+            opcode_name_z(AI->internal_number));
         return;
     }
 

--- a/asm.c
+++ b/asm.c
@@ -1826,20 +1826,21 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
           if (define_INFIX_switch)
           {
             if (embedded_flag)
-            {   SLF.value = 251; SLF.type = VARIABLE_OT; SLF.marker = 0;
-                CON.value = 0; CON.type = SHORT_CONSTANT_OT; CON.marker = 0;
+            {
+                INITAOTV(&SLF, VARIABLE_OT, 251);
+                INITAOTV(&CON, SHORT_CONSTANT_OT, 0);
                 assemblez_2_branch(test_attr_zc, SLF, CON, ln2, FALSE);
             }
             else
             {   i = no_named_routines++;
                 ensure_memory_list_available(&named_routine_symbols_memlist, no_named_routines);
                 named_routine_symbols[i] = the_symbol;
-                CON.value = i/8; CON.type = LONG_CONSTANT_OT; CON.marker = 0;
-                RFA.value = routine_flags_array_SC;
-                RFA.type = LONG_CONSTANT_OT; RFA.marker = INCON_MV;
-                STP.value = 0; STP.type = VARIABLE_OT; STP.marker = 0;
+                INITAOTV(&CON, LONG_CONSTANT_OT, i/8);
+                INITAOTV(&RFA, LONG_CONSTANT_OT, routine_flags_array_SC);
+                RFA.marker = INCON_MV;
+                INITAOTV(&STP, VARIABLE_OT, 0);
                 assemblez_2_to(loadb_zc, RFA, CON, STP);
-                CON.value = (1 << (i%8)); CON.type = SHORT_CONSTANT_OT;
+                INITAOTV(&CON, SHORT_CONSTANT_OT, (1 << (i%8)));
                 assemblez_2_to(and_zc, STP, CON, STP);
                 assemblez_1_branch(jz_zc, STP, ln2, TRUE);
             }
@@ -1848,13 +1849,13 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
         AI.text = fnt; assemblez_0(print_zc);
         for (i=1; (i<=7)&&(i<=no_locals); i++)
         {   if (version_number >= 5)
-            {   PV.type = SHORT_CONSTANT_OT;
-                PV.value = i; PV.marker = 0;
+            {
+                INITAOTV(&PV, SHORT_CONSTANT_OT, i);
                 assemblez_1_branch(check_arg_count_zc, PV, ln, FALSE);
             }
             sprintf(fnt, "%s%s = ", (i==1)?"":", ", variable_name(i));
             AI.text = fnt; assemblez_0(print_zc);
-            PV.type = VARIABLE_OT; PV.value = i; PV.marker = 0;
+            INITAOTV(&PV, VARIABLE_OT, i);
             assemblez_1(print_num_zc, PV);
         }
         assemble_label_no(ln);
@@ -1913,6 +1914,8 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
             named_routine_symbols[i] = the_symbol;
           }
         }
+        INITAO(&AO);
+        INITAO(&AO2);
         sprintf(fnt, "[ %s(", name);
         AO.marker = STRING_MV;
         AO.type   = CONSTANT_OT;

--- a/asm.c
+++ b/asm.c
@@ -3148,7 +3148,7 @@ static void parse_assembly_z(void)
         custom_opcode_z.no = n;
 
         custom_opcode_z.code = atoi(token_text+i);
-        while (isdigit(token_text[i])) i++;
+        while (isdigit((uchar)token_text[i])) i++;
 
         {   max = 0; min = 0;
             switch(n)
@@ -3172,7 +3172,7 @@ static void parse_assembly_z(void)
                 case 'T': custom_opcode_z.op_rules = TEXT; break;
                 case 'I': custom_opcode_z.op_rules = VARIAB; break;
                 case 'F': custom_opcode_z.flags2_set = atoi(token_text+i);
-                          while (isdigit(token_text[i])) i++;
+                          while (isdigit((uchar)token_text[i])) i++;
                           break;
                 default:
                     error("Unknown flag: options are B (branch), S (store), \
@@ -3510,7 +3510,7 @@ static void parse_assembly_g(void)
                 custom_opcode_g.flags |= Rf;
                 break;
             default:
-                if (isdigit(*cx)) {
+                if (isdigit((uchar)*cx)) {
                     custom_opcode_g.no = (*cx) - '0';
                     break;
                 }

--- a/asm.c
+++ b/asm.c
@@ -883,6 +883,7 @@ static void make_opcode_syntax_z(opcodez opco)
         case LABEL: sprintf(q+strlen(q), " <label>"); return;
         case VARIAB:
             sprintf(q+strlen(q), " <variable>");
+            /* Fall through */
         case CALL:
             if (opco.op_rules==CALL) sprintf(q+strlen(q), " <routine>");
             switch(opco.no)
@@ -978,8 +979,10 @@ static void write_operand(assembly_operand op)
             byteout(j/256, op.marker); byteout(j%256, 0); return;
         case SHORT_CONSTANT_OT:
             if (op.marker == 0)
-            byteout(j, 0);
-            else byteout(j, 0x80 + op.marker); return;
+                byteout(j, 0);
+            else
+                byteout(j, 0x80 + op.marker);
+            return;
         case VARIABLE_OT:
             byteout(j, 0); return;
         case CONSTANT_OT:
@@ -2285,6 +2288,7 @@ static void transfer_routine_z(void)
                     if (!GRAMMAR_META_FLAG) break;
                     /* Actions are backpatchable if GRAMMAR_META_FLAG; fall
                        through and create entry */
+                    /* Fall through */
                 default:
                     if ((zcode_markers[i] & 0x7f) > LARGEST_BPATCH_MV)
                     {   compiler_error("Illegal code backpatch value");
@@ -2513,6 +2517,7 @@ static void transfer_routine_g(void)
             if (!GRAMMAR_META_FLAG) break;
             /* Actions are backpatchable if GRAMMAR_META_FLAG; fall
                through and create entry */
+            /* Fall through */
         case OBJECT_MV:
         case VARIABLE_MV:
         default:
@@ -3164,7 +3169,8 @@ static void parse_assembly_z(void)
                 case 'T': custom_opcode_z.op_rules = TEXT; break;
                 case 'I': custom_opcode_z.op_rules = VARIAB; break;
                 case 'F': custom_opcode_z.flags2_set = atoi(token_text+i);
-                          while (isdigit(token_text[i])) i++; break;
+                          while (isdigit(token_text[i])) i++;
+                          break;
                 default:
                     error("Unknown flag: options are B (branch), S (store), \
 T (text), I (indirect addressing), F** (set this Flags 2 bit)");

--- a/asm.c
+++ b/asm.c
@@ -988,6 +988,8 @@ static void write_operand(assembly_operand op)
     }
 }
 
+#define MAX_TRACE_STRING_LEN (35)
+
 extern void assemblez_instruction(const assembly_instruction *AI)
 {
     int32 operands_pc;
@@ -1200,8 +1202,20 @@ extern void assemblez_instruction(const assembly_instruction *AI)
         if ((AI->internal_number == print_zc)
             || (AI->internal_number == print_ret_zc))
         {   printf("\"");
-            for (i=0;(AI->text)[i]!=0 && i<35; i++) printf("%c",(AI->text)[i]);
-            if (i == 35) printf("...");
+            for (i=0;(AI->text)[i]!=0 && i<MAX_TRACE_STRING_LEN; i++) {
+                if ((AI->text)[i] == 1) {
+                    /* This text has been overwritten with an abbreviation
+                       marker. Print "<ABBR>" for the first null character
+                       only.
+                       (Unimportant bug: two adjacent abbreviations only
+                       print one "<ABBR>" flag.) */
+                    if (!(i>0 && (AI->text)[i-1] == 1))
+                        printf("<ABBR>");
+                    continue;
+                }
+                printf("%c",(AI->text)[i]);
+            }
+            if (i == MAX_TRACE_STRING_LEN) printf("...");
             printf("\"");
         }
 

--- a/asm.c
+++ b/asm.c
@@ -3367,7 +3367,7 @@ T (text), I (indirect addressing), F** (set this Flags 2 bit)");
 
     if (O.version1 == 0)
     {   error_named("Opcode unavailable in this Z-machine version:",
-            opcode_names.keywords[AI.internal_number]);
+            opcode_name_z(AI.internal_number));
         return;
     }
 

--- a/asm.c
+++ b/asm.c
@@ -1825,9 +1825,9 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
 
           if (define_INFIX_switch)
           {
-                if (embedded_flag)
+            if (embedded_flag)
             {   SLF.value = 251; SLF.type = VARIABLE_OT; SLF.marker = 0;
-                  CON.value = 0; CON.type = SHORT_CONSTANT_OT; CON.marker = 0;
+                CON.value = 0; CON.type = SHORT_CONSTANT_OT; CON.marker = 0;
                 assemblez_2_branch(test_attr_zc, SLF, CON, ln2, FALSE);
             }
             else

--- a/chars.c
+++ b/chars.c
@@ -1143,7 +1143,7 @@ extern int32 text_to_unicode(char *text)
         }
     }
 
-    if ((isdigit(text[1])) || (text[1] == '@'))
+    if ((isdigit((uchar)text[1])) || (text[1] == '@'))
     {   ebf_error("'@' plus an accent code or '@{...}'", text);
         textual_form_length = 1;
         return '?';
@@ -1246,13 +1246,13 @@ extern void change_character_set(void)
 extern void make_lower_case(char *str)
 {   int i;
     for (i=0; str[i]!=0; i++)
-        if ((((uchar)str[i])<128) && (isupper(str[i]))) str[i]=tolower(str[i]);
+        if ((((uchar)str[i])<128) && (isupper((uchar)str[i]))) str[i]=tolower((uchar)str[i]);
 }
 
 extern void make_upper_case(char *str)
 {   int i;
     for (i=0; str[i]!=0; i++)
-        if ((((uchar)str[i])<128) && (islower(str[i]))) str[i]=toupper(str[i]);
+        if ((((uchar)str[i])<128) && (islower((uchar)str[i]))) str[i]=toupper((uchar)str[i]);
 }
 
 /* ========================================================================= */

--- a/directs.c
+++ b/directs.c
@@ -830,7 +830,7 @@ it is too late to change the grammar version.");
         {   error("The serial number must be a 6-digit date in double-quotes");
             panic_mode_error_recovery(); return FALSE;
         }
-        for (i=0; i<6; i++) if (isdigit(token_text[i])==0)
+        for (i=0; i<6; i++) if (isdigit((uchar)token_text[i])==0)
         {   error("The serial number must be a 6-digit date in double-quotes");
             panic_mode_error_recovery(); return FALSE;
         }

--- a/expressc.c
+++ b/expressc.c
@@ -740,6 +740,7 @@ static void compile_conditional_z(int oc,
                 error("'has'/'hasnt' applied to illegal attribute number");
                         break;
                     }
+                    /* Fall through */
                 case VARIABLE_OT:
                 {   int pa_label = next_label++, fa_label = next_label++;
                     assembly_operand en_ao, zero_ao, max_ao;

--- a/expressp.c
+++ b/expressp.c
@@ -1269,12 +1269,14 @@ static void emit_token(const token_data *t)
                 case MPROP_ADD_OP: case MESSAGE_OP:
                 case PROPERTY_OP:
                     if (i < arity) break;
+                    /* Fall through */
                 case GE_OP: case LE_OP:
                     /* Direction properties "n_to", etc *are* compared
                        in some libraries. They have STAR_SFLAG to tell us
                        to skip the warning. */
                     if ((i < arity)
                         && (symbols[o1.symindex].flags & STAR_SFLAG)) break;
+                    /* Fall through */
                 default:
                     warning("Property name in expression is not qualified by object");
             }
@@ -1794,6 +1796,7 @@ static void insert_exp_to_cond(int n, int context)
         case 1:                                 /* Forms of '=' have level 1 */
             if (context == CONDITION_CONTEXT)
                 warning("'=' used as condition: '==' intended?");
+            /* Fall through */
         default:
             if (context != CONDITION_CONTEXT) break;
 
@@ -2068,6 +2071,7 @@ extern assembly_operand parse_expression(int context)
             case ASSOC_E:            /* Associativity error                  */
                 error_named("Brackets mandatory to clarify order of:",
                     a.text);
+                /* Fall through */
 
             case LOWER_P:
             case EQUAL_P:
@@ -2107,6 +2111,7 @@ extern assembly_operand parse_expression(int context)
                                     }
                                     /* Non-argument-separating commas get treated like any other operator; we fall through to the default case. */
                                 }
+                                /* Fall through */
                             default:
                                 {
                                     /* Add a marker for the brackets implied by operator precedence */

--- a/expressp.c
+++ b/expressp.c
@@ -272,21 +272,24 @@ but not used as a value:", unicode);
                     if ((previous_token.type == OP_TT)
                         || (previous_token.type == SUBOPEN_TT)
                         || (previous_token.type == ENDEXP_TT))
-                    current_token.value = UNARY_MINUS_SEP; break;
+                        current_token.value = UNARY_MINUS_SEP;
+                    break;
 
                 case INC_SEP:
                     if ((previous_token.type == VARIABLE_TT)
                         || (previous_token.type == SUBCLOSE_TT)
                         || (previous_token.type == LARGE_NUMBER_TT)
                         || (previous_token.type == SMALL_NUMBER_TT))
-                    current_token.value = POST_INC_SEP; break;
+                        current_token.value = POST_INC_SEP;
+                    break;
 
                 case DEC_SEP:
                     if ((previous_token.type == VARIABLE_TT)
                         || (previous_token.type == SUBCLOSE_TT)
                         || (previous_token.type == LARGE_NUMBER_TT)
                         || (previous_token.type == SMALL_NUMBER_TT))
-                    current_token.value = POST_DEC_SEP; break;
+                        current_token.value = POST_DEC_SEP;
+                    break;
 
                 case HASHHASH_SEP:
                     token_text = current_token.text + 2;

--- a/expressp.c
+++ b/expressp.c
@@ -405,7 +405,7 @@ but not used as a value:", unicode);
     {   v = separators_to_operators[current_token.value];
         if (v != NOT_AN_OPERATOR)
         {   if ((veneer_mode)
-                || ((v!=MESSAGE_OP) && (v!=MPROP_NUM_OP) && (v!=MPROP_NUM_OP)))
+                || ((v!=MESSAGE_OP) && (v!=MPROP_NUM_OP)))
             {   current_token.type = OP_TT; current_token.value = v;
                 if (array_init_ambiguity &&
                     ((v==MINUS_OP) || (v==UNARY_MINUS_OP)) &&

--- a/files.c
+++ b/files.c
@@ -445,7 +445,7 @@ static void output_file_z(void)
            we're in a live function or a dead one.
            (This logic is simplified by the assumption that a backpatch
            marker will never straddle a function break.) */
-        if (zmachine_pc != df_total_size_before_stripping)
+        if ((uint32)zmachine_pc != df_total_size_before_stripping)
             compiler_error("Code size does not match (zmachine_pc and df_total_size).");
         code_length = df_total_size_after_stripping;
         use_function = TRUE;

--- a/files.c
+++ b/files.c
@@ -309,7 +309,7 @@ static void sf_put(int c)
 
 /* Recursive procedure to generate the Glulx compression table. */
 
-static void output_compression(int entnum, int32 *size, int *count)
+static void output_compression(int entnum, uint32 *size, int *count)
 {
   huffentity_t *ent = &(huff_entities[entnum]);
   int32 val;
@@ -374,8 +374,8 @@ static void output_compression(int entnum, int32 *size, int *count)
 
 static void output_file_z(void)
 {   char new_name[PATHLEN];
-    int32 length, blanks=0, size, i, j, offset;
-    uint32 code_length, size_before_code, next_cons_check;
+    int32 length, blanks=0, i, j, offset;
+    uint32 size, code_length, size_before_code, next_cons_check;
     int use_function;
 
     ASSERT_ZCODE();
@@ -546,7 +546,7 @@ static void output_file_z(void)
     /*  (3)  Output any null bytes (required to reach a packed address)
              before the strings area.                                        */
 
-    while (size<Write_Strings_At) { sf_put(0); size++; }
+    while (size<(uint32)Write_Strings_At) { sf_put(0); size++; }
 
     /*  (4)  Output the static strings area.                                 */
 
@@ -610,8 +610,8 @@ static void output_file_z(void)
 
 static void output_file_g(void)
 {   char new_name[PATHLEN];
-    int32 size, i, j, offset;
-    uint32 code_length, size_before_code, next_cons_check;
+    int32 i, j, offset;
+    uint32 size, code_length, size_before_code, next_cons_check;
     int use_function;
     int first_byte_of_triple, second_byte_of_triple, third_byte_of_triple;
 
@@ -767,7 +767,7 @@ static void output_file_g(void)
            we're in a live function or a dead one.
            (This logic is simplified by the assumption that a backpatch
            marker will never straddle a function break.) */
-        if (zmachine_pc != df_total_size_before_stripping)
+        if ((uint32)zmachine_pc != df_total_size_before_stripping)
             compiler_error("Code size does not match (zmachine_pc and df_total_size).");
         code_length = df_total_size_after_stripping;
         use_function = TRUE;
@@ -936,7 +936,7 @@ static void output_file_g(void)
           compiler_error("Compression table count mismatch.");
       }
 
-      if (size - origsize != compression_table_size)
+      if ((int32)size - origsize != compression_table_size)
         compiler_error("Compression table size mismatch.");
 
       origsize = size;
@@ -1043,7 +1043,7 @@ static void output_file_g(void)
         }
       }
       
-      if (size - origsize != compression_string_size)
+      if ((int32)size - origsize != compression_string_size)
         compiler_error("Compression string size mismatch.");
 
     }
@@ -1089,7 +1089,7 @@ static void output_file_g(void)
             jx++;
         }
 
-        if (size_before_arrays + static_array_area_size != size)
+        if (size_before_arrays + static_array_area_size != (int32)size)
             compiler_error("Static array output length did not match");
     }
 

--- a/files.c
+++ b/files.c
@@ -374,7 +374,8 @@ static void output_compression(int entnum, uint32 *size, int *count)
 
 static void output_file_z(void)
 {   char new_name[PATHLEN];
-    int32 length, blanks=0, i, j, offset;
+    int32 length, blanks=0, i;
+    uint32 j, offset;
     uint32 size, code_length, size_before_code, next_cons_check;
     int use_function;
 
@@ -610,7 +611,8 @@ static void output_file_z(void)
 
 static void output_file_g(void)
 {   char new_name[PATHLEN];
-    int32 i, j, offset;
+    int32 i;
+    uint32 j, offset;
     uint32 size, code_length, size_before_code, next_cons_check;
     int use_function;
     int first_byte_of_triple, second_byte_of_triple, third_byte_of_triple;
@@ -1052,7 +1054,8 @@ static void output_file_g(void)
     {
         /* We have to backpatch entries mentioned in staticarray_backpatch_table. */
         int32 size_before_arrays = size;
-        int32 val, ix, jx;
+        int32 val, ix;
+        uint32 jx;
         for (ix=0, jx=0; ix<staticarray_backpatch_size; ix += 5) {
             backpatch_error_flag = FALSE;
             backpatch_marker = staticarray_backpatch_table[ix];

--- a/header.h
+++ b/header.h
@@ -562,8 +562,8 @@
 
 /* These checked the glulx_mode global during development, but are no
    longer needed. */
-#define ASSERT_ZCODE() (0)
-#define ASSERT_GLULX() (0)
+#define ASSERT_ZCODE()
+#define ASSERT_GLULX()
 
 
 #define ReadInt32(ptr)                               \

--- a/inform.c
+++ b/inform.c
@@ -1343,7 +1343,7 @@ extern void switches(char *p, int cmode)
         case 'h': switch(p[i+1])
                   {   case '1': cli_print_help(1); s=2; break;
                       case '2': cli_print_help(2); s=2; break;
-                      case '0': s=2;
+                      case '0': s=2; /* Fall through */
                       default:  cli_print_help(0); break;
                   }
                   break;
@@ -1357,7 +1357,8 @@ extern void switches(char *p, int cmode)
         case 'r': if (cmode == 0)
                       error("The switch '-r' can't be set with 'Switches'");
                   else
-                      transcript_switch = state; break;
+                      transcript_switch = state;
+                  break;
         case 's': statistics_switch = state; break;
         case 'u': if (cmode == 0) {
                       error("The switch '-u' can't be set with 'Switches'");

--- a/inform.c
+++ b/inform.c
@@ -60,15 +60,15 @@ static int select_glulx_version(char *str)
   char *cx = str;
   int major=0, minor=0, patch=0;
 
-  while (isdigit(*cx))
+  while (isdigit((uchar)*cx))
     major = major*10 + ((*cx++)-'0');
   if (*cx == '.') {
     cx++;
-    while (isdigit(*cx))
+    while (isdigit((uchar)*cx))
       minor = minor*10 + ((*cx++)-'0');
     if (*cx == '.') {
       cx++;
-      while (isdigit(*cx))
+      while (isdigit((uchar)*cx))
         patch = patch*10 + ((*cx++)-'0');
     }
   }
@@ -519,7 +519,7 @@ or ICL_Path variables. Other paths are for output only.\n", FN_ALT);
             }
             if ((path != Debugging_Name) && (path != Transcript_Name)
                  && (path != Language_Name) && (path != Charset_Map)
-                 && (i>0) && (isalnum(path[i-1]))) path[i++] = FN_SEP;
+                 && (i>0) && (isalnum((uchar)path[i-1]))) path[i++] = FN_SEP;
             path[i++] = value[j++];
             if (value[j-1] == 0) return;
         }
@@ -561,7 +561,7 @@ or ICL_Path variables. Other paths are for output only.\n");
         if ((value[j] == FN_ALT) || (value[j] == 0))
         {   if ((path != Debugging_Name) && (path != Transcript_Name)
                  && (path != Language_Name) && (path != Charset_Map)
-                 && (i>0) && (isalnum(new_path[i-1]))) new_path[i++] = FN_SEP;
+                 && (i>0) && (isalnum((uchar)new_path[i-1]))) new_path[i++] = FN_SEP;
             new_path[i++] = value[j++];
             if (value[j-1] == 0) {
                 newlen = i-1;

--- a/lexer.c
+++ b/lexer.c
@@ -784,8 +784,8 @@ extern void construct_local_variable_tables(void)
         local_variables.keywords[i] = p;
         if (p[1] == 0)
         {   one_letter_locals[(uchar)p[0]] = i;
-            if (isupper(p[0])) one_letter_locals[tolower(p[0])] = i;
-            if (islower(p[0])) one_letter_locals[toupper(p[0])] = i;
+            if (isupper((uchar)p[0])) one_letter_locals[tolower((uchar)p[0])] = i;
+            if (islower((uchar)p[0])) one_letter_locals[toupper((uchar)p[0])] = i;
         }
         h = hash_code_from_string(p);
         if (local_variable_hash_table[h] == -1)

--- a/memory.c
+++ b/memory.c
@@ -660,8 +660,8 @@ static void add_predefined_symbol(char *command)
     }
     
     for (ix=0; command[ix]; ix++) {
-        if ((ix == 0 && isdigit(command[ix]))
-            || !(isalnum(command[ix]) || command[ix] == '_')) {
+        if ((ix == 0 && isdigit((uchar)command[ix]))
+            || !(isalnum((uchar)command[ix]) || command[ix] == '_')) {
             printf("Attempt to define invalid symbol: %s\n", command);
             return;
         }
@@ -817,7 +817,7 @@ extern void memory_command(char *command)
 {   int i, k;
 
     for (k=0; command[k]!=0; k++)
-        if (islower(command[k])) command[k]=toupper(command[k]);
+        if (islower((uchar)command[k])) command[k]=toupper((uchar)command[k]);
 
     if (command[0]=='?') { explain_parameter(command+1); return; }
     if (command[0]=='#') { add_predefined_symbol(command+1); return; }

--- a/states.c
+++ b/states.c
@@ -473,6 +473,7 @@ static void parse_print_z(int finally_return)
                           QUANTITY_CONTEXT, -1));
                   break;
               }
+              /* Fall through */
 
             default:
               put_token_back(); misc_keywords.enabled = FALSE;
@@ -704,6 +705,7 @@ static void parse_print_g(int finally_return)
                           QUANTITY_CONTEXT, -1));
                   break;
               }
+              /* Fall through */
 
             default:
               put_token_back(); misc_keywords.enabled = FALSE;

--- a/states.c
+++ b/states.c
@@ -861,7 +861,7 @@ static void parse_statement_z(int break_label, int continue_label)
                              if (token_text[i] == '@')
                              {   if (token_text[i+1] == '@')
                                  {   i = i + 2;
-                                     while (isdigit(token_text[i])) i++;
+                                     while (isdigit((uchar)token_text[i])) i++;
                                  }
                                  else
                                  {   i++;
@@ -1830,7 +1830,7 @@ static void parse_statement_g(int break_label, int continue_label)
                              if (token_text[i] == '@')
                              {   if (token_text[i+1] == '@')
                                  {   i = i + 2;
-                                     while (isdigit(token_text[i])) i++;
+                                     while (isdigit((uchar)token_text[i])) i++;
                                  }
                                  else
                                  {   i++;

--- a/symbols.c
+++ b/symbols.c
@@ -1250,8 +1250,10 @@ extern void df_note_function_symbol(int symbol)
        we're in global scope, in which case it might be slower.
        (I suppose we could cache the df_function_t pointer of the
        current function, to speed things up.) */
-    if (!df_current_function || df_current_function_addr != df_current_function->address)
+    if (!df_current_function || df_current_function_addr != df_current_function->address) {
         compiler_error("DF: df_current_function does not match current address.");
+        return;
+    }
     ent->refsnext = df_current_function->refs;
     df_current_function->refs = ent;
 }
@@ -1547,10 +1549,14 @@ uint32 df_stripped_offset_for_code_offset(uint32 offset, int *stripped)
 extern void df_prepare_function_iterate(void)
 {
     df_iterator = df_functions_head;
-    if (!df_iterator || df_iterator->address != DF_NOT_IN_FUNCTION)
+    if (!df_iterator || df_iterator->address != DF_NOT_IN_FUNCTION) {
         compiler_error("DF: Global namespace entry is not at the head of the chain.");
-    if (!df_iterator->funcnext || df_iterator->funcnext->address != 0)
+        return;
+    }
+    if (!df_iterator->funcnext || df_iterator->funcnext->address != 0) {
         compiler_error("DF: First function entry is not second in the chain.");
+        return;
+    }
 }
 
 /* This returns the end of the next function, and whether the next function

--- a/tables.c
+++ b/tables.c
@@ -708,7 +708,7 @@ or less.");
         code_length = zmachine_pc;
     }
     else {
-        if (zmachine_pc != df_total_size_before_stripping)
+        if ((uint32)zmachine_pc != df_total_size_before_stripping)
             compiler_error("Code size does not match (zmachine_pc and df_total_size).");
         code_length = df_total_size_after_stripping;
     }
@@ -1178,7 +1178,7 @@ static void construct_storyfile_g(void)
         code_length = zmachine_pc;
     }
     else {
-        if (zmachine_pc != df_total_size_before_stripping)
+        if ((uint32)zmachine_pc != df_total_size_before_stripping)
             compiler_error("Code size does not match (zmachine_pc and df_total_size).");
         code_length = df_total_size_after_stripping;
     }

--- a/text.c
+++ b/text.c
@@ -692,7 +692,8 @@ advance as part of 'Zcharacter table':", unicode);
 
                     default:   write_zscii(j); break;
                 }
-                while (isdigit(text_in[i])) i++; i--;
+                while (isdigit(text_in[i])) i++;
+                i--;
             }
             else if (text_in[i+1]=='(')
             {
@@ -894,7 +895,8 @@ string.");
             }
           }
           write_z_char_g(j);
-          while (isdigit(text_in[i])) i++; i--;
+          while (isdigit(text_in[i])) i++;
+          i--;
         }
         else if (text_in[i+1]=='(') {
             int len = 0, digits = 0;

--- a/text.c
+++ b/text.c
@@ -2160,7 +2160,7 @@ Define DICT_CHAR_SIZE=4 for a Unicode-compatible dictionary.");
       k = '?';
     }
     
-    if (k >= (unsigned)'A' && k <= (unsigned)'Z')
+    if (k >= 'A' && k <= 'Z')
       k += ('a' - 'A');
 
     ensure_memory_list_available(&prepared_sort_memlist, DICT_WORD_BYTES);


### PR DESCRIPTION
Changes from @heasm66, somewhat tidied up. These allow the code to pass extra-super-careful compile-time checks.

- The error message "Opcode unavailable in this Z-machine version" safety-checks the opcode value before printing. (Utility function opcode_name_z().)
- isdigit(), isalnum(), etc macros wants argument cast to `uchar`.
- In Infix code in asm.c, use INITAO() and related macros to initialize `assembly_operand` structs.
- In `--trace asm` output, when a Z-string has abbreviation marks, print `"<ABBR>"` rather than ctrl-A characters.
- Replace hardcoded constant 35 with `MAX_TRACE_STRING_LEN`.
- Added `/* Fall through */` comments to silence compiler warnings.
- Added line breaks between statements to silence compiler warnings.
- Changed some local variables to `uint32` and added casts where necessary.
- Added `return;` after a couple of compiler_error() calls.
- Changed ASSERT_ZCODE() and ASSERT_GLULX() macros to complete no-ops rather than `0` expressions.
