### PR TITLE
Fixed typo of "6.43" which was accidentally "6.42".

### DIFF
--- a/ReleaseNotes.html
+++ b/ReleaseNotes.html
@@ -27,7 +27,7 @@ specific ones to Graham Nelson for permitting it in the first place, and to Andr
 for most of the actual changes to the compiler code.
 
 <h2>Inform 6.43</h2>
-These are the changes delivered in version 6.42 of the Inform compiler.
+These are the changes delivered in version 6.43 of the Inform compiler.
 
 <h3>Features added</h3>
 <ul>


### PR DESCRIPTION
`ReleaseNotes.html` has this:

````
<h2>Inform 6.43</h2>
These are the changes delivered in version 6.42 of the Inform compiler.
````

This patch corrects the typo of `6.42`.