### PR TITLE
Correctly handling redeclaring a global

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -436,6 +436,8 @@ extern void make_global()
         compiler_error("Globalnum out of range");
     
     if (redefining) {
+        /* We permit a global to be redefined to the exact same value. */
+        
         /* We permit a global to be redefined to the same (constant) value.
            We also permit a zero global to be redefined, because (sigh)
            we can't distinguish "Global g;" from "Global g=0;" after

--- a/arrays.c
+++ b/arrays.c
@@ -436,6 +436,10 @@ extern void make_global()
         compiler_error("Globalnum out of range");
     
     if (redefining) {
+        /* We permit a global to be redefined to the same (constant) value.
+           We also permit a zero global to be redefined, because (sigh)
+           we can't distinguish "Global g;" from "Global g=0;" after
+           the fact. */
         if (!is_constant_ot(AO.type)
             || !is_constant_ot(global_initial_value[globalnum].type)
             || (global_initial_value[globalnum].value && global_initial_value[globalnum].value != AO.value)) {

--- a/arrays.c
+++ b/arrays.c
@@ -398,6 +398,8 @@ extern void make_global()
     directive_keywords.enabled = TRUE;
 
     RedefinitionOfSystemVar:
+    /* Note that if we jumped here to redefine a variable, it will wind
+       up with two debugfile entries. */
 
     get_next_token();
 
@@ -434,6 +436,13 @@ extern void make_global()
     if (!((token_type == SEP_TT) && (token_value == SETEQUALS_SEP)))
         put_token_back();
 
+    if (globalnum >= global_initial_value_memlist.count)
+        compiler_error("Globalnum out of range");
+    if (global_initial_value[globalnum].marker) {
+        error("A global which has been defined as a non-constant cannot later be redefined");
+        return;
+    }
+    
     AO = parse_expression(CONSTANT_CONTEXT);
     if (!glulx_mode) {
         if (AO.marker != 0)
@@ -446,8 +455,6 @@ extern void make_global()
                 4*globalnum);
     }
     
-    if (globalnum >= global_initial_value_memlist.count)
-        compiler_error("Globalnum out of range");
     global_initial_value[globalnum] = AO;
     
     if (debugfile_switch)

--- a/asm.c
+++ b/asm.c
@@ -255,6 +255,12 @@ static void mark_label_used(int label)
 /*   Useful tool for building operands                                       */
 /* ------------------------------------------------------------------------- */
 
+extern void set_constant_otv(assembly_operand *AO, int32 val)
+{
+    AO->value = val;
+    set_constant_ot(AO);
+}
+
 extern void set_constant_ot(assembly_operand *AO)
 {
   if (!glulx_mode) {

--- a/asm.c
+++ b/asm.c
@@ -306,6 +306,12 @@ extern int is_variable_ot(int otval)
   }
 }
 
+extern int operands_identical(const assembly_operand *o1, const assembly_operand *o2)
+{
+    /* We don't need to check the symindex; that doesn't affect value generation. */
+    return (o1->type == o2->type && o1->value == o2->value && o1->marker == o2->marker);
+}
+
 /* ------------------------------------------------------------------------- */
 /*   Used in printing assembly traces                                        */
 /* ------------------------------------------------------------------------- */

--- a/header.h
+++ b/header.h
@@ -2139,7 +2139,7 @@ extern memory_list dynamic_array_area_memlist;
 extern int static_array_area_size;
 extern uchar *static_array_area;
 extern memory_list static_array_area_memlist;
-extern int32 *global_initial_value;
+extern assembly_operand *global_initial_value;
 extern arrayinfo *arrays;
 
 extern void make_global(void);
@@ -2184,6 +2184,7 @@ extern int32 *named_routine_symbols;
 
 extern void print_operand(const assembly_operand *o, int annotate);
 extern char *variable_name(int32 i);
+extern void set_constant_otv(assembly_operand *AO, int32 val);
 extern void set_constant_ot(assembly_operand *AO);
 extern int  is_constant_ot(int otval);
 extern int  is_variable_ot(int otval);

--- a/header.h
+++ b/header.h
@@ -2188,6 +2188,7 @@ extern void set_constant_otv(assembly_operand *AO, int32 val);
 extern void set_constant_ot(assembly_operand *AO);
 extern int  is_constant_ot(int otval);
 extern int  is_variable_ot(int otval);
+extern int  operands_identical(const assembly_operand *o1, const assembly_operand *o2);
 extern void assemblez_instruction(const assembly_instruction *a);
 extern void assembleg_instruction(const assembly_instruction *a);
 extern void assemble_label_no(int n);

--- a/symbols.c
+++ b/symbols.c
@@ -533,7 +533,8 @@ extern void issue_unused_warnings(void)
 
     /*  Update any ad-hoc variables that might help the library  */
     if (glulx_mode)
-    {   global_initial_value[10]=statusline_flag;
+    {
+        set_constant_otv(&global_initial_value[10], statusline_flag);
     }
     /*  Now back to mark anything necessary as used  */
 

--- a/tables.c
+++ b/tables.c
@@ -520,7 +520,7 @@ static void construct_storyfile_z(void)
 
     if (ZCODE_COMPACT_GLOBALS) {
         for (i = 0; i < no_globals; i++) {
-            j = global_initial_value[i];
+            j = global_initial_value[i].value;
             p[mark++] = j / 256; p[mark++] = j % 256;
         }
 
@@ -538,7 +538,7 @@ static void construct_storyfile_z(void)
 
         for (i = 0; i < 240; i++)
         {
-            j = global_initial_value[i];
+            j = global_initial_value[i].value;
             p[globals_at + i * 2] = j / 256; p[globals_at + i * 2 + 1] = j % 256;
         }
         arrays_at = globals_at + (MAX_ZCODE_GLOBAL_VARS * WORDSIZE);
@@ -1231,7 +1231,7 @@ static void construct_storyfile_g(void)
 
     globals_at = mark;
     for (i=0; i<no_globals; i++) {
-      j = global_initial_value[i];
+      j = global_initial_value[i].value;
       WriteInt32(p+mark, j);
       mark += 4;
     }


### PR DESCRIPTION
You might think it's illegal to declare a global variable twice, but in fact we support it in two situations:

- You can declare one of the built-in globals (`self`, `sender`, `sw__var`, etc) in source even though the compiler defines it at startup. This was probably grandfathered in to support a single legacy example from 1993, but it's stayed in.
- In Glulx, you can redeclare any global. I don't remember if I did that deliberately or just screwed up the "is it a built-in" check. Given how long this has been legal, I suspect that there's source code that relies on it (although I haven't gone looking).

However, certain redeclaration cases could lead to a backpatch error (https://github.com/DavidKinder/Inform6/issues/313). It also wasn't clear how to handle a clash in initial values:

```
Global glob = 11;
Global glob = 22;
```

This PR cleans up the cases and makes everything consistent and, I hope, sensible.

It is now legal to redeclare a global (any number of times). If more than one declaration provides an initial value, they must all be exactly the same initial value, either by symbol or by having the same constant value.

So, all of these cases will work:

```
Global glob1;
Global glob1;

Global glob2 = 99;
Global glob2;

Global glob3;
Global glob3 = 98;

Global glob4 = 97;
Global glob4 = 97;

Global glob5 = obj;
Global glob5 = obj;
```

But this will produce an error:

```
Global glob6 = obj;
Global glob6 = 5;
```
> "glob6" is a name already in use and may not be used as a global variable with a different value 

(This will fail even if `obj` winds up being the value `5`; the check is made before backpatching.)

