### PR TITLE
Fix various bugs in GRAMMAR_META_FLAG

### DIFF
--- a/expressc.c
+++ b/expressc.c
@@ -1382,6 +1382,16 @@ static void generate_code_from(int n, int void_flag)
 
         if (oc >= 400) { oc = oc - 400; flag = FALSE; }
 
+        /*  A condition comparing to constant zero can be converted
+            to jz.
+            The marker check is *almost* redundant. Most backpatchable
+            values (DWORD_MV, etc) are stored as LONG_CONSTANT_OT
+            and thus fail the check against zero_operand.type. (This
+            was probably deliberate but it was never documented.)
+            ACTION_MV is stored as SHORT_CONSTANT_OT, but actions are
+            not backpatchable -- unless GRAMMAR_META_FLAG is set. Thus
+            the extra check.
+        */
         if ((oc == je_zc) && (arity == 2))
         {   i = ET[ET[n].down].right;
             if ((ET[i].value.value == zero_operand.value)

--- a/expressc.c
+++ b/expressc.c
@@ -1385,8 +1385,10 @@ static void generate_code_from(int n, int void_flag)
         if ((oc == je_zc) && (arity == 2))
         {   i = ET[ET[n].down].right;
             if ((ET[i].value.value == zero_operand.value)
-                && (ET[i].value.type == zero_operand.type))
-                oc = jz_zc;
+                && (ET[i].value.type == zero_operand.type)) {
+                if (ET[i].value.marker == 0 || (ET[i].value.marker == ACTION_MV && !GRAMMAR_META_FLAG))
+                    oc = jz_zc;
+            }
         }
 
         /*  If the condition has truth state flag, branch to

--- a/expressc.c
+++ b/expressc.c
@@ -1384,13 +1384,16 @@ static void generate_code_from(int n, int void_flag)
 
         /*  A condition comparing to constant zero can be converted
             to jz.
+            
             The marker check is *almost* redundant. Most backpatchable
             values (DWORD_MV, etc) are stored as LONG_CONSTANT_OT
             and thus fail the check against zero_operand.type. (This
             was probably deliberate but it was never documented.)
-            ACTION_MV is stored as SHORT_CONSTANT_OT, but actions are
-            not backpatchable -- unless GRAMMAR_META_FLAG is set. Thus
-            the extra check.
+            
+            ACTION_MV is stored as SHORT_CONSTANT_OT, so we check the
+            marker value to catch that case. But actions are only
+            backpatchable if GRAMMAR_META_FLAG is set. Thus the special
+            case.
         */
         if ((oc == je_zc) && (arity == 2))
         {   i = ET[ET[n].down].right;

--- a/tables.c
+++ b/tables.c
@@ -977,7 +977,7 @@ or less.");
                 }
             }
         }
-        else
+        else if (grammar_version_number == 2)
         {   for (l = 0; l<no_Inform_verbs; l++)
             {
                 int linecount;
@@ -1019,6 +1019,10 @@ or less.");
                     i++;
                 }
             }
+        }
+        else {
+            fatalerror_fmt(
+                "Invalid grammar version: %d", grammar_version_number);
         }
     }
 

--- a/tables.c
+++ b/tables.c
@@ -953,7 +953,9 @@ or less.");
         }
 
         if (grammar_version_number == 1 || grammar_version_number == 3)
-        {   mark = preactions_at;
+        {
+            /* backpatch the grammar routine addresses (in preactions) */
+            mark = preactions_at;
             for (i=0; i<no_grammar_token_routines; i++)
             {   j=grammar_token_routine[i];
                 if (OMIT_UNUSED_ROUTINES)
@@ -978,7 +980,8 @@ or less.");
             }
         }
         else if (grammar_version_number == 2)
-        {   for (l = 0; l<no_Inform_verbs; l++)
+        {
+            for (l = 0; l<no_Inform_verbs; l++)
             {
                 int linecount;
                 k = grammar_table_at + 2*l;
@@ -998,6 +1001,7 @@ or less.");
                         }
                     }
                     i = i + 2;
+                    /* backpatch the grammar routine addresses (in tokens) */
                     while (p[i] != 15)
                     {   topbits = (p[i]/0x40) & 3;
                         value = p[i+1]*256 + p[i+2];

--- a/tables.c
+++ b/tables.c
@@ -1606,8 +1606,6 @@ static void construct_storyfile_g(void)
           i -= Write_RAM_At;
           linecount = p[i++];
           for (j=0; j<linecount; j++) {
-            int topbits; 
-            int32 value;
             if (GRAMMAR_META_FLAG) {
               /* backpatch the action number */
               int action = (p[i+0] << 8) | (p[i+1]);
@@ -1617,8 +1615,8 @@ static void construct_storyfile_g(void)
             }
             i = i + 3;
             while (p[i] != 15) {
-              topbits = (p[i]/0x40) & 3;
-              value = ((p[i+1] << 24) | (p[i+2] << 16) 
+              int topbits = (p[i]/0x40) & 3;
+              int32 value = ((p[i+1] << 24) | (p[i+2] << 16) 
                 | (p[i+3] << 8) | (p[i+4]));
               switch(topbits) {
               case 1:

--- a/tables.c
+++ b/tables.c
@@ -975,6 +975,7 @@ or less.");
                         int action = p[i+7];
                         action = sorted_actions[action].internal_to_ext;
                         p[i+7] = action;
+                        i += 8;
                     }
                 }
             }


### PR DESCRIPTION
Fixes issues described in https://github.com/DavidKinder/Inform6/issues/315 . 

- Action numbers were wrong in grammar tables for grammar version 1 and 3
- Conditions like `(action == ##Go)` could be generated wrong for the first-referenced action

Both these problems appeared only in Z-code and only when GRAMMAR_META_FLAG was set. They were uncovered by the PunyInform test suite (thanks!) 

I guess we don't have to describe grammar version 3 as "experimental" now, since it's been used by somebody. `:)` 
