### PR TITLE
Fix a couple of recent bugs in gameinfo.dbg

### DIFF
--- a/header.h
+++ b/header.h
@@ -2694,7 +2694,7 @@ extern void make_class(char *metaclass_name);
 extern int  object_provides(int obj, int id);
 extern void list_object_tree(void);
 extern void write_the_identifier_names(void);
-extern void emit_debug_information_for_actions(void);
+extern void write_debug_information_for_actions(void);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "symbols"                                        */

--- a/header.h
+++ b/header.h
@@ -2694,6 +2694,7 @@ extern void make_class(char *metaclass_name);
 extern int  object_provides(int obj, int id);
 extern void list_object_tree(void);
 extern void write_the_identifier_names(void);
+extern void emit_debug_information_for_actions(void);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "symbols"                                        */

--- a/symbols.c
+++ b/symbols.c
@@ -720,7 +720,7 @@ extern void write_the_identifier_names(void)
     veneer_mode = FALSE;
 }
 
-extern void emit_debug_information_for_actions(void)
+extern void write_debug_information_for_actions(void)
 {
     int i;
     for (i=0; i<no_symbols; i++) {
@@ -731,13 +731,11 @@ extern void emit_debug_information_for_actions(void)
             sprintf(temp_symbol_buf, "%s", symbols[i].name);
             temp_symbol_buf[strlen(temp_symbol_buf)-3] = 0;
 
-            if (debugfile_switch)
-            {   debug_file_printf("<action>");
-                debug_file_printf
-                    ("<identifier>##%s</identifier>", temp_symbol_buf);
-                debug_file_printf("<value>%d</value>", symbols[i].value);
-                debug_file_printf("</action>");
-            }
+            debug_file_printf("<action>");
+            debug_file_printf
+                ("<identifier>##%s</identifier>", temp_symbol_buf);
+            debug_file_printf("<value>%d</value>", symbols[i].value);
+            debug_file_printf("</action>");
         }
     }
 }

--- a/symbols.c
+++ b/symbols.c
@@ -663,14 +663,6 @@ extern void write_the_identifier_names(void)
             sprintf(temp_symbol_buf, "%s", symbols[i].name);
             temp_symbol_buf[strlen(temp_symbol_buf)-3] = 0;
 
-            if (debugfile_switch)
-            {   debug_file_printf("<action>");
-                debug_file_printf
-                    ("<identifier>##%s</identifier>", temp_symbol_buf);
-                debug_file_printf("<value>%d</value>", symbols[i].value);
-                debug_file_printf("</action>");
-            }
-
             action_name_strings[symbols[i].value]
                 = compile_string(temp_symbol_buf, STRCTX_SYMBOL);
         }
@@ -727,6 +719,29 @@ extern void write_the_identifier_names(void)
 
     veneer_mode = FALSE;
 }
+
+extern void emit_debug_information_for_actions(void)
+{
+    int i;
+    for (i=0; i<no_symbols; i++) {
+        if (symbols[i].flags & ACTION_SFLAG)
+        {
+            int sleni = strlen(symbols[i].name);
+            ensure_memory_list_available(&temp_symbol_buf_memlist, sleni+1);
+            sprintf(temp_symbol_buf, "%s", symbols[i].name);
+            temp_symbol_buf[strlen(temp_symbol_buf)-3] = 0;
+
+            if (debugfile_switch)
+            {   debug_file_printf("<action>");
+                debug_file_printf
+                    ("<identifier>##%s</identifier>", temp_symbol_buf);
+                debug_file_printf("<value>%d</value>", symbols[i].value);
+                debug_file_printf("</action>");
+            }
+        }
+    }
+}
+
 /* ------------------------------------------------------------------------- */
 /*   Creating symbols                                                        */
 /* ------------------------------------------------------------------------- */

--- a/symbols.c
+++ b/symbols.c
@@ -722,7 +722,8 @@ extern void write_the_identifier_names(void)
 
 extern void write_debug_information_for_actions(void)
 {
-    int i;
+    int i, action;
+    
     for (i=0; i<no_symbols; i++) {
         if (symbols[i].flags & ACTION_SFLAG)
         {
@@ -731,10 +732,15 @@ extern void write_debug_information_for_actions(void)
             sprintf(temp_symbol_buf, "%s", symbols[i].name);
             temp_symbol_buf[strlen(temp_symbol_buf)-3] = 0;
 
+            action = symbols[i].value;
+            if (GRAMMAR_META_FLAG) {
+                action = sorted_actions[action].internal_to_ext;
+            }
+            
             debug_file_printf("<action>");
             debug_file_printf
                 ("<identifier>##%s</identifier>", temp_symbol_buf);
-            debug_file_printf("<value>%d</value>", symbols[i].value);
+            debug_file_printf("<value>%d</value>", action);
             debug_file_printf("</action>");
         }
     }

--- a/tables.c
+++ b/tables.c
@@ -1025,7 +1025,10 @@ or less.");
     /*  ---- From here on, it's all reportage: construction is finished ---- */
 
     if (debugfile_switch)
-    {   begin_writing_debug_sections();
+    {
+        write_debug_information_for_actions();
+        
+        begin_writing_debug_sections();
         write_debug_section("abbreviations", 64);
         write_debug_section("abbreviations table", abbrevs_at);
         write_debug_section("header extension", headerext_at);
@@ -1601,7 +1604,10 @@ static void construct_storyfile_g(void)
     /*  ---- From here on, it's all reportage: construction is finished ---- */
 
     if (debugfile_switch)
-    {   begin_writing_debug_sections();
+    {
+        write_debug_information_for_actions();
+        
+        begin_writing_debug_sections();
         write_debug_section("memory layout id", GLULX_HEADER_SIZE);
         write_debug_section("code area", Write_Code_At);
         write_debug_section("string decoding table", Write_Strings_At);


### PR DESCRIPTION
- With the `$OMIT_SYMBOL_TABLE` option, the `<action>` section was missing from gameinfo.dbg. See https://github.com/DavidKinder/Inform6/issues/317 .
- With the `$GRAMMAR_META_FLAG` option, the value number of the `<action>` was not correctly backpatched.

I split out code that writes `<action>` lines into its own function: write_debug_information_for_actions().
