### PR TITLE
No warnings on a while loop that continues manually

### DIFF
--- a/states.c
+++ b/states.c
@@ -1742,7 +1742,8 @@ static void parse_statement_z(int break_label, int continue_label)
 
                  parse_code_block(ln2, ln, 0);
                  sequence_point_follows = FALSE;
-                 assemblez_jump(ln);
+                 if (!execution_never_reaches_here)
+                     assemblez_jump(ln);
                  assemble_forward_label_no(ln2);
                  return;
 
@@ -2704,7 +2705,8 @@ static void parse_statement_g(int break_label, int continue_label)
 
                  parse_code_block(ln2, ln, 0);
                  sequence_point_follows = FALSE;
-                 assembleg_jump(ln);
+                 if (!execution_never_reaches_here)
+                     assembleg_jump(ln);
                  assemble_forward_label_no(ln2);
                  return;
 


### PR DESCRIPTION
Fixes https://github.com/DavidKinder/Inform6/issues/295 .

These are loops that look like

```
[ Test4 word;
	while (true) {
		word--;
		if (word < 3) {
			continue;
		}
		break;
	}
];
```

We had a spurious "cannot reach" warning on the loop's close-brace. (The auto-generated jump-back instruction.) This fixes that.

This does _not_ address the equivalent warning in a `do {...} until` loop. That's harder, because of the way the code is generated. But it's also never come up. Unlike the above case!