### PR TITLE
Code-generation optimizations

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -300,6 +300,13 @@ extern int is_variable_ot(int otval)
   }
 }
 
+extern int operands_equal(const assembly_operand *AO1, const assembly_operand *AO2)
+{
+    return (AO1->value == AO2->value
+        && AO1->type == AO2->type
+        && AO1->marker == AO2->marker);
+}
+
 /* ------------------------------------------------------------------------- */
 /*   Used in printing assembly traces                                        */
 /* ------------------------------------------------------------------------- */

--- a/asm.c
+++ b/asm.c
@@ -2132,8 +2132,9 @@ static void transfer_routine_z(void)
             they are jumping to the very next instruction). The opcode and
             both label bytes get DELETED_MV.
             And also for jumps that can be eliminated because they
-            are jumping to a return opcode. These are replaced by a copy
-            of the return opcode. */
+            are jumping to a (one-byte) return opcode. The jump opcode is
+            replaced by a copy of the return opcode; the label bytes get
+            DELETED_MV. */
 
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++)
     {   if (zcode_markers[i] == BRANCH_MV)
@@ -2163,9 +2164,14 @@ static void transfer_routine_z(void)
                 zcode_markers[i] = DELETED_MV;
                 zcode_markers[i+1] = DELETED_MV;
             }
-            else if (opcode_at_label == opcodes_table_z[rtrue_zc].code
-                || opcode_at_label == opcodes_table_z[rfalse_zc].code
-                || opcode_at_label == opcodes_table_z[ret_popped_zc].code) {
+            else if (opcode_at_label == 176
+                || opcode_at_label == 177
+                || opcode_at_label == 184) {
+                /* 176, 177, and 184 are the encoded forms of rtrue_zc,
+                   rfalse_zc, and ret_popped_zc. It would be cleaner
+                   to pull these from opcodes_table_z[] (adding 0xB0 for
+                   the opcode form) but it's not like they're going to
+                   ever change. */
                 if (asm_trace_level >= 4) printf("...Replacing jump with return opcode\n");
                 zcode_holding_area[i - 1] = opcode_at_label;
                 zcode_markers[i] = DELETED_MV;

--- a/asm.c
+++ b/asm.c
@@ -2131,7 +2131,7 @@ static void transfer_routine_z(void)
             We also look for jumps that can be entirely eliminated (because
             they are jumping to the very next instruction). The opcode and
             both label bytes get DELETED_MV.
-            And also for jumps that can be eliminated because they
+            We also look for jumps that can be eliminated because they
             are jumping to a (one-byte) return opcode. The jump opcode is
             replaced by a copy of the return opcode; the label bytes get
             DELETED_MV. */

--- a/asm.c
+++ b/asm.c
@@ -2133,8 +2133,9 @@ static void transfer_routine_z(void)
             both label bytes get DELETED_MV.
             We also look for jumps that can be eliminated because they
             are jumping to a (one-byte) return opcode. The jump opcode is
-            replaced by a copy of the return opcode; the label bytes get
-            DELETED_MV. */
+            replaced by a copy of the destination opcode; the label bytes
+            get DELETED_MV. (However, we don't do the extra work to detect
+            whether this orphans the destination opcode.) */
 
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++)
     {   if (zcode_markers[i] == BRANCH_MV)

--- a/asm.c
+++ b/asm.c
@@ -2356,7 +2356,8 @@ static void transfer_routine_g(void)
             they are jumping to the very next instruction). The opcode and
             all label bytes get DELETED_MV.
             (This doesn't bother with the "replace jump with return"
-            optimization that Z-code does.) */
+            optimization that Z-code does. Figuring out the operand
+            lengths is too much work.) */
 
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++) {
       if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV) {

--- a/asm.c
+++ b/asm.c
@@ -2354,7 +2354,9 @@ static void transfer_routine_g(void)
             short form) with DELETED_MV.
             We also look for branches that can be entirely eliminated (because
             they are jumping to the very next instruction). The opcode and
-            all label bytes get DELETED_MV. */
+            all label bytes get DELETED_MV.
+            (This doesn't bother with the "replace jump with return"
+            optimization that Z-code does.) */
 
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++) {
       if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV) {

--- a/asm.c
+++ b/asm.c
@@ -2130,7 +2130,10 @@ static void transfer_routine_z(void)
             short form) with DELETED_MV.
             We also look for jumps that can be entirely eliminated (because
             they are jumping to the very next instruction). The opcode and
-            both label bytes get DELETED_MV. */
+            both label bytes get DELETED_MV.
+            And also for jumps that can be eliminated because they
+            are jumping to a return opcode. These are replaced by a copy
+            of the return opcode. */
 
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++)
     {   if (zcode_markers[i] == BRANCH_MV)
@@ -2160,21 +2163,11 @@ static void transfer_routine_z(void)
                 zcode_markers[i] = DELETED_MV;
                 zcode_markers[i+1] = DELETED_MV;
             }
-            if (opcode_at_label == 176) { //opcodes_table_z[rtrue_zc].code)
-                if (asm_trace_level >= 4) printf("...Opcode at label is %s, replacing jump\n", opcodes_table_z[rtrue_zc].name);
-                zcode_holding_area[i - 1] = 176;
-                zcode_markers[i] = DELETED_MV;
-                zcode_markers[i + 1] = DELETED_MV;
-            }
-            if (opcode_at_label == 177) { //opcodes_table_z[rfalse_zc].code)
-                if (asm_trace_level >= 4) printf("...Opcode at label is %s, replacing jump\n", opcodes_table_z[rfalse_zc].name);
-                zcode_holding_area[i - 1] = 177;
-                zcode_markers[i] = DELETED_MV;
-                zcode_markers[i + 1] = DELETED_MV;
-            }
-            if (opcode_at_label == 184) { //opcodes_table_z[ret_popped_zc].code)
-                if (asm_trace_level >= 4) printf("...Opcode at label is %s, replacing jump\n", opcodes_table_z[ret_popped_zc].name);
-                zcode_holding_area[i - 1] = 184;
+            else if (opcode_at_label == opcodes_table_z[rtrue_zc].code
+                || opcode_at_label == opcodes_table_z[rfalse_zc].code
+                || opcode_at_label == opcodes_table_z[ret_popped_zc].code) {
+                if (asm_trace_level >= 4) printf("...Replacing jump with return opcode\n");
+                zcode_holding_area[i - 1] = opcode_at_label;
                 zcode_markers[i] = DELETED_MV;
                 zcode_markers[i + 1] = DELETED_MV;
             }

--- a/asm.c
+++ b/asm.c
@@ -2116,7 +2116,7 @@ void assemble_routine_end(int embedded_flag, debug_locations locations)
 static void transfer_routine_z(void)
 {   int32 i, j, pc, new_pc, label, long_form, offset_of_next, addr,
           branch_on_true, rstart_pc;
-    int32 adjusted_pc;
+    int32 adjusted_pc, opcode_at_label;
 
     adjusted_pc = zmachine_pc - zcode_ha_size; rstart_pc = adjusted_pc;
 
@@ -2150,6 +2150,7 @@ static void transfer_routine_z(void)
             if (asm_trace_level >= 4)
                 printf("Jump detected at offset %04x\n", pc);
             j = (256*zcode_holding_area[i] + zcode_holding_area[i+1]) & 0x7fff;
+            opcode_at_label = zcode_holding_area[i + labels[j].offset - pc];
             if (asm_trace_level >= 4)
                 printf("...To label %d, which is %d from here\n",
                     j, labels[j].offset-pc);
@@ -2158,6 +2159,24 @@ static void transfer_routine_z(void)
                 zcode_markers[i-1] = DELETED_MV;
                 zcode_markers[i] = DELETED_MV;
                 zcode_markers[i+1] = DELETED_MV;
+            }
+            if (opcode_at_label == 176) { //opcodes_table_z[rtrue_zc].code)
+                if (asm_trace_level >= 4) printf("...Opcode at label is %s, replacing jump\n", opcodes_table_z[rtrue_zc].name);
+                zcode_holding_area[i - 1] = 176;
+                zcode_markers[i] = DELETED_MV;
+                zcode_markers[i + 1] = DELETED_MV;
+            }
+            if (opcode_at_label == 177) { //opcodes_table_z[rfalse_zc].code)
+                if (asm_trace_level >= 4) printf("...Opcode at label is %s, replacing jump\n", opcodes_table_z[rfalse_zc].name);
+                zcode_holding_area[i - 1] = 177;
+                zcode_markers[i] = DELETED_MV;
+                zcode_markers[i + 1] = DELETED_MV;
+            }
+            if (opcode_at_label == 184) { //opcodes_table_z[ret_popped_zc].code)
+                if (asm_trace_level >= 4) printf("...Opcode at label is %s, replacing jump\n", opcodes_table_z[ret_popped_zc].name);
+                zcode_holding_area[i - 1] = 184;
+                zcode_markers[i] = DELETED_MV;
+                zcode_markers[i + 1] = DELETED_MV;
             }
         }
     }

--- a/asm.c
+++ b/asm.c
@@ -306,7 +306,7 @@ extern int is_variable_ot(int otval)
   }
 }
 
-extern int operands_equal(const assembly_operand *AO1, const assembly_operand *AO2)
+extern int operands_identical(const assembly_operand *AO1, const assembly_operand *AO2)
 {
     /* We don't need to check the symindex; that doesn't affect value generation. */
     return (AO1->value == AO2->value

--- a/expressc.c
+++ b/expressc.c
@@ -868,9 +868,16 @@ static int try_optimize_expr_z(int o_n,
         break;
 
     case div_zc:
-        /* x = x / 1 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
-            return TRUE;
+        if (o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
+            if (operands_equal(&o1, &st)) {
+                /* x = x / 1 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x / 1 ==> store */
+                assemblez_store(st, o1);
+                return TRUE;
+            }
         }
         break;
     }
@@ -948,9 +955,16 @@ static int try_optimize_expr_g(int o_n,
         break;
 
     case div_gc:
-        /* x = x / 1 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
-            return TRUE;
+        if (o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
+            if (operands_equal(&o1, &st)) {
+                /* x = x / 1 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x / 1 ==> store */
+                assembleg_store(st, o1);
+                return TRUE;
+            }
         }
         break;
     }

--- a/expressc.c
+++ b/expressc.c
@@ -785,42 +785,42 @@ static int try_to_simplify_operand_z(int o_n,
     assembly_operand o1, assembly_operand o2, assembly_operand st) 
 {
     /* x = x + 1 ==> x++ */
-    if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == add_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         assemblez_inc(st);
         return TRUE;
     }
     /* x = 1 + x ==> x++ */
-    if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
+    if (o_n == add_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
         assemblez_inc(st);
         return TRUE;
     }
     /* x = x + 0 ==> skip */
-    if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
+    if (o_n == add_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
         return TRUE;
     }
     /* x = 0 + x ==> skip */
-    if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 0) {
+    if (o_n == add_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 0) {
         return TRUE;
     }
     /* x = x - 1 ==> x-- */
-    if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == sub_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         assemblez_dec(st);
         return TRUE;
     }
     /* x = x - 0 ==> skip */
-    if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
+    if (o_n == sub_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
         return TRUE;
     }
     /* x = x * 1 ==> skip */
-    if (o_n == mul_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == mul_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         return TRUE;
     }
     /* x = 1 * x ==> skip */
-    if (o_n == mul_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
+    if (o_n == mul_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
         return TRUE;
     }
     /* x = x / 1 ==> skip */
-    if (o_n == div_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == div_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         return TRUE;
     }
     return FALSE;
@@ -830,27 +830,27 @@ static int try_to_simplify_operand_g(int o_n,
     assembly_operand o1, assembly_operand o2, assembly_operand st) 
 {
     /* x = x + 0 ==> skip */
-    if (o_n == add_gc && o1.type == st.type && o1.value == st.value && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
+    if (o_n == add_gc && operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
         return TRUE;
     }
     /* x = 0 + x ==> skip */
-    if (o_n == add_gc && o2.type == st.type && o2.value == st.value && o1.type == ZEROCONSTANT_OT && o1.value == 0) {
+    if (o_n == add_gc && operands_equal(&o2, &st) && o1.type == ZEROCONSTANT_OT && o1.value == 0) {
         return TRUE;
     }
     /* x = x - 0 ==> skip */
-    if (o_n == sub_gc && o1.type == st.type && o1.value == st.value && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
+    if (o_n == sub_gc && operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
         return TRUE;
     }
     /* x = x * 1 ==> skip */
-    if (o_n == mul_gc && o1.type == st.type && o1.value == st.value && o2.type == BYTECONSTANT_OT && o2.value == 1) {
+    if (o_n == mul_gc && operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1) {
         return TRUE;
     }
     /* x = 1 * x ==> skip */
-    if (o_n == mul_gc && o2.type == st.type && o2.value == st.value && o1.type == BYTECONSTANT_OT && o1.value == 1) {
+    if (o_n == mul_gc && operands_equal(&o2, &st) && o1.type == BYTECONSTANT_OT && o1.value == 1) {
         return TRUE;
     }
     /* x = x / 1 ==> skip */
-    if (o_n == div_gc && o1.type == st.type && o1.value == st.value && o2.type == BYTECONSTANT_OT && o2.value == 1) {
+    if (o_n == div_gc && operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1) {
         return TRUE;
     }
     return FALSE;

--- a/expressc.c
+++ b/expressc.c
@@ -781,7 +781,9 @@ static void compile_conditional_z(int oc,
     assemblez_1_branch(jz_zc, AO3, label, !flag);
 }
 
-static int try_to_simplify_operand_z(int o_n,
+/* Pinhole optimizer for simple expression trees. */
+
+static int try_optimize_expr_z(int o_n,
     assembly_operand o1, assembly_operand o2, assembly_operand st) 
 {
     /* x = x + 1 ==> x++ */
@@ -836,7 +838,7 @@ static int try_to_simplify_operand_z(int o_n,
     return FALSE;
 }
 
-static int try_to_simplify_operand_g(int o_n,
+static int try_optimize_expr_g(int o_n,
     assembly_operand o1, assembly_operand o2, assembly_operand st) 
 {
     /* x = x + 0 ==> skip */
@@ -1793,7 +1795,7 @@ static void generate_code_from(int n, int void_flag)
                     assemblez_2_to(o_n, temp_var1, temp_var2, Result);
                 }
             }
-            else if (try_to_simplify_operand_z(o_n, ET[below].value,
+            else if (try_optimize_expr_z(o_n, ET[below].value,
                 ET[ET[below].right].value, Result)) {
                 /* generated simplified code */
             }
@@ -2408,7 +2410,7 @@ static void generate_code_from(int n, int void_flag)
                     assembleg_3(o_n, temp_var1, temp_var2, Result);
                 }
             }
-            else if (try_to_simplify_operand_g(o_n, ET[below].value,
+            else if (try_optimize_expr_g(o_n, ET[below].value,
                 ET[ET[below].right].value, Result)) {
                 /* generated simplified code */
             }

--- a/expressc.c
+++ b/expressc.c
@@ -1744,9 +1744,10 @@ static void generate_code_from(int n, int void_flag)
                 }
             }
             else {
-                if (!try_to_simplify_operand_z(o_n,ET[below].value,ET[ET[below].right].value,Result))
+                if (!try_to_simplify_operand_z(o_n, ET[below].value, ET[ET[below].right].value, Result)) {
                     assemblez_2_to(o_n, ET[below].value,
                         ET[ET[below].right].value, Result);
+                }
             }
         }
         else

--- a/expressc.c
+++ b/expressc.c
@@ -790,18 +790,18 @@ static int try_optimize_expr_z(int o_n,
     switch (o_n) {
         
     case add_zc:
-        if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
+        if (operands_identical(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
             /* x = x + 1 ==> x++ */
             assemblez_inc(st);
             return TRUE;
         }
-        if (operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
+        if (operands_identical(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
             /* x = 1 + x ==> x++ */
             assemblez_inc(st);
             return TRUE;
         }
         if (o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x + 0 ==> skip */
                 return TRUE;
             }
@@ -812,7 +812,7 @@ static int try_optimize_expr_z(int o_n,
             }
         }
         if (o1.type == SHORT_CONSTANT_OT && o1.value == 0 && !o1.marker) {
-            if (operands_equal(&o2, &st)) {
+            if (operands_identical(&o2, &st)) {
                 /* x = 0 + x ==> skip */
                 return TRUE;
             }
@@ -825,13 +825,13 @@ static int try_optimize_expr_z(int o_n,
         break;
 
     case sub_zc:
-        if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
+        if (operands_identical(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
             /* x = x - 1 ==> x-- */
             assemblez_dec(st);
             return TRUE;
         }
         if (o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x - 0 ==> skip */
                 return TRUE;
             }
@@ -845,7 +845,7 @@ static int try_optimize_expr_z(int o_n,
 
     case mul_zc:
         if (o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x * 1 ==> skip */
                 return TRUE;
             }
@@ -856,7 +856,7 @@ static int try_optimize_expr_z(int o_n,
             }
         }
         if (o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
-            if (operands_equal(&o2, &st)) {
+            if (operands_identical(&o2, &st)) {
                 /* x = 1 * x ==> skip */
                 return TRUE;
             }
@@ -870,7 +870,7 @@ static int try_optimize_expr_z(int o_n,
 
     case div_zc:
         if (o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x / 1 ==> skip */
                 return TRUE;
             }
@@ -893,7 +893,7 @@ static int try_optimize_expr_g(int o_n,
 
     case add_gc:
         if (o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x + 0 ==> skip */
                 return TRUE;
             }
@@ -904,7 +904,7 @@ static int try_optimize_expr_g(int o_n,
             }
         }
         if (o1.type == ZEROCONSTANT_OT && o1.value == 0 && !o1.marker) {
-            if (operands_equal(&o2, &st)) {
+            if (operands_identical(&o2, &st)) {
                 /* x = 0 + x ==> skip */
                 return TRUE;
             }
@@ -918,7 +918,7 @@ static int try_optimize_expr_g(int o_n,
 
     case sub_gc:
         if (o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x - 0 ==> skip */
                 return TRUE;
             }
@@ -932,7 +932,7 @@ static int try_optimize_expr_g(int o_n,
 
     case mul_gc:
         if (o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x * 1 ==> skip */
                 return TRUE;
             }
@@ -943,7 +943,7 @@ static int try_optimize_expr_g(int o_n,
             }
         }
         if (o1.type == BYTECONSTANT_OT && o1.value == 1 && !o1.marker) {
-            if (operands_equal(&o2, &st)) {
+            if (operands_identical(&o2, &st)) {
                 /* x = 1 * x ==> skip */
                 return TRUE;
             }
@@ -957,7 +957,7 @@ static int try_optimize_expr_g(int o_n,
 
     case div_gc:
         if (o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
-            if (operands_equal(&o1, &st)) {
+            if (operands_identical(&o1, &st)) {
                 /* x = x / 1 ==> skip */
                 return TRUE;
             }

--- a/expressc.c
+++ b/expressc.c
@@ -798,8 +798,18 @@ static int try_to_simplify_operand_z(int o_n,
     if (o_n == add_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
         return TRUE;
     }
+    /* y = x + 0 ==> store */
+    if (o_n == add_zc && o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
+        assemblez_store(st, o1);
+        return TRUE;
+    }
     /* x = 0 + x ==> skip */
     if (o_n == add_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 0 && !o1.marker) {
+        return TRUE;
+    }
+    /* y = 0 + x ==> store */
+    if (o_n == add_zc && o1.type == SHORT_CONSTANT_OT && o1.value == 0 && !o1.marker) {
+        assemblez_store(st, o2);
         return TRUE;
     }
     /* x = x - 1 ==> x-- */
@@ -833,8 +843,18 @@ static int try_to_simplify_operand_g(int o_n,
     if (o_n == add_gc && operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
         return TRUE;
     }
+    /* y = x + 0 ==> store */
+    if (o_n == add_gc && o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
+        assembleg_store(st, o1);
+        return TRUE;
+    }
     /* x = 0 + x ==> skip */
     if (o_n == add_gc && operands_equal(&o2, &st) && o1.type == ZEROCONSTANT_OT && o1.value == 0 && !o1.marker) {
+        return TRUE;
+    }
+    /* y = 0 + x ==> store */
+    if (o_n == add_gc && o1.type == ZEROCONSTANT_OT && o1.value == 0 && !o1.marker) {
+        assembleg_store(st, o2);
         return TRUE;
     }
     /* x = x - 0 ==> skip */

--- a/expressc.c
+++ b/expressc.c
@@ -784,42 +784,42 @@ static void compile_conditional_z(int oc,
 static int try_to_simplify_operand_z(int o_n,
     assembly_operand o1, assembly_operand o2, assembly_operand st) 
 {
-    // x = x + 1 ==> x++
+    /* x = x + 1 ==> x++ */
     if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         assemblez_inc(st);
         return TRUE;
     }
-    // x = 1 + x ==> x++
+    /* x = 1 + x ==> x++ */
     if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
         assemblez_inc(st);
         return TRUE;
     }
-    // x = x + 0 ==> skip
+    /* x = x + 0 ==> skip */
     if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
         return TRUE;
     }
-    // x = 0 + x ==> skip
+    /* x = 0 + x ==> skip */
     if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 0) {
         return TRUE;
     }
-    // x = x - 1 ==> x--
+    /* x = x - 1 ==> x-- */
     if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         assemblez_dec(st);
         return TRUE;
     }
-    // x = x - 0 ==> skip
+    /* x = x - 0 ==> skip */
     if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
         return TRUE;
     }
-    // x = x * 1 ==> skip
+    /* x = x * 1 ==> skip */
     if (o_n == mul_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         return TRUE;
     }
-    // x = 1 * x ==> skip
+    /* x = 1 * x ==> skip */
     if (o_n == mul_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
         return TRUE;
     }
-    // x = x / 1 ==> skip
+    /* x = x / 1 ==> skip */
     if (o_n == div_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
         return TRUE;
     }

--- a/expressc.c
+++ b/expressc.c
@@ -841,6 +841,18 @@ static int try_to_simplify_operand_g(int o_n,
     if (o_n == sub_gc && o1.type == st.type && o1.value == st.value && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
         return TRUE;
     }
+    /* x = x * 1 ==> skip */
+    if (o_n == mul_gc && o1.type == st.type && o1.value == st.value && o2.type == BYTECONSTANT_OT && o2.value == 1) {
+        return TRUE;
+    }
+    /* x = 1 * x ==> skip */
+    if (o_n == mul_gc && o2.type == st.type && o2.value == st.value && o1.type == BYTECONSTANT_OT && o1.value == 1) {
+        return TRUE;
+    }
+    /* x = x / 1 ==> skip */
+    if (o_n == div_gc && o1.type == st.type && o1.value == st.value && o2.type == BYTECONSTANT_OT && o2.value == 1) {
+        return TRUE;
+    }
     return FALSE;
 }
 

--- a/expressc.c
+++ b/expressc.c
@@ -1762,13 +1762,6 @@ static void generate_code_from(int n, int void_flag)
              {
                  check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
                  check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-                 //if (runtime_error_checking_switch && (!veneer_mode))
-                 //      assemblez_3_to(call_vs_zc, veneer_routine(RT__ChPR_VR),
-                 //        ET[below].value, ET[ET[below].right].value, temp_var1);
-                 //else
-                 //assemblez_2_to(get_prop_zc, ET[below].value,
-                 //    ET[ET[below].right].value, temp_var1);
-                 //if (!void_flag) write_result_z(Result, temp_var1);
                  if (runtime_error_checking_switch && (!veneer_mode)) {
                      assemblez_3_to(call_vs_zc, veneer_routine(RT__ChPR_VR),
                          ET[below].value, ET[ET[below].right].value, temp_var1);

--- a/expressc.c
+++ b/expressc.c
@@ -781,6 +781,51 @@ static void compile_conditional_z(int oc,
     assemblez_1_branch(jz_zc, AO3, label, !flag);
 }
 
+static int try_to_simplify_operand_z(int o_n,
+    assembly_operand o1, assembly_operand o2, assembly_operand st) 
+{
+    // x = x + 1 ==> x++
+    if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+        assemblez_inc(st);
+        return TRUE;
+    }
+    // x = 1 + x ==> x++
+    if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
+        assemblez_inc(st);
+        return TRUE;
+    }
+    // x = x + 0 ==> skip
+    if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
+        return TRUE;
+    }
+    // x = 0 + x ==> skip
+    if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 0) {
+        return TRUE;
+    }
+    // x = x - 1 ==> x--
+    if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+        assemblez_dec(st);
+        return TRUE;
+    }
+    // x = x - 0 ==> skip
+    if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
+        return TRUE;
+    }
+    // x = x * 1 ==> skip
+    if (o_n == mul_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+        return TRUE;
+    }
+    // x = 1 * x ==> skip
+    if (o_n == mul_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
+        return TRUE;
+    }
+    // x = x / 1 ==> skip
+    if (o_n == div_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
 static void value_in_void_context_g(assembly_operand AO)
 {   char *t;
 
@@ -3103,48 +3148,3 @@ extern void expressc_free_arrays(void)
 }
 
 /* ========================================================================= */
-
-int try_to_simplify_operand_z(int o_n,
-    assembly_operand o1, assembly_operand o2, assembly_operand st) 
-{
-    // x = x + 1 ==> x++
-    if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
-        assemblez_inc(st);
-        return TRUE;
-    }
-    // x = 1 + x ==> x++
-    if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
-        assemblez_inc(st);
-        return TRUE;
-    }
-    // x = x + 0 ==> skip
-    if (o_n == add_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
-        return TRUE;
-    }
-    // x = 0 + x ==> skip
-    if (o_n == add_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 0) {
-        return TRUE;
-    }
-    // x = x - 1 ==> x--
-    if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
-        assemblez_dec(st);
-        return TRUE;
-    }
-    // x = x - 0 ==> skip
-    if (o_n == sub_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
-        return TRUE;
-    }
-    // x = x * 1 ==> skip
-    if (o_n == mul_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
-        return TRUE;
-    }
-    // x = 1 * x ==> skip
-    if (o_n == mul_zc && o2.type == st.type && o2.value == st.value && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
-        return TRUE;
-    }
-    // x = x / 1 ==> skip
-    if (o_n == div_zc && o1.type == st.type && o1.value == st.value && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
-        return TRUE;
-    }
-    return FALSE;
-}

--- a/expressc.c
+++ b/expressc.c
@@ -1730,10 +1730,8 @@ static void generate_code_from(int n, int void_flag)
                  check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
                  if (runtime_error_checking_switch && (!veneer_mode))
                      AO = check_nonzero_at_runtime(AO, -1, PROP_ADD_RTE);
-                 //assemblez_2_to(get_prop_addr_zc, AO,
-                 //    ET[ET[below].right].value, temp_var1);
-                 //if (!void_flag) write_result_z(Result, temp_var1);
-                 if ((!void_flag) && (Result.value == 0)) {  // can be optimized and written directly to stack_pointer
+                 if ((!void_flag) && (Result.value == 0)) {
+                     /* store directly to stack_pointer */
                      assemblez_2_to(get_prop_addr_zc, AO,
                          ET[ET[below].right].value, Result);
                  }
@@ -1742,7 +1740,6 @@ static void generate_code_from(int n, int void_flag)
                          ET[ET[below].right].value, temp_var1);
                      if (!void_flag) write_result_z(Result, temp_var1);
                  }
-
              }
              break;
 
@@ -1778,7 +1775,8 @@ static void generate_code_from(int n, int void_flag)
                      if (!void_flag) write_result_z(Result, temp_var1);
                  }
                  else {
-                     if ((!void_flag) && (Result.value == 0)) {  // can be optimized and written directly to stack_pointer
+                     if ((!void_flag) && (Result.value == 0)) {
+                         /* store directly to stack_pointer */
                          assemblez_2_to(get_prop_zc, ET[below].value,
                              ET[ET[below].right].value, Result);
                      }

--- a/expressc.c
+++ b/expressc.c
@@ -785,42 +785,42 @@ static int try_to_simplify_operand_z(int o_n,
     assembly_operand o1, assembly_operand o2, assembly_operand st) 
 {
     /* x = x + 1 ==> x++ */
-    if (o_n == add_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == add_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
         assemblez_inc(st);
         return TRUE;
     }
     /* x = 1 + x ==> x++ */
-    if (o_n == add_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
+    if (o_n == add_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
         assemblez_inc(st);
         return TRUE;
     }
     /* x = x + 0 ==> skip */
-    if (o_n == add_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
+    if (o_n == add_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
         return TRUE;
     }
     /* x = 0 + x ==> skip */
-    if (o_n == add_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 0) {
+    if (o_n == add_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 0 && !o1.marker) {
         return TRUE;
     }
     /* x = x - 1 ==> x-- */
-    if (o_n == sub_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == sub_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
         assemblez_dec(st);
         return TRUE;
     }
     /* x = x - 0 ==> skip */
-    if (o_n == sub_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0) {
+    if (o_n == sub_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
         return TRUE;
     }
     /* x = x * 1 ==> skip */
-    if (o_n == mul_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == mul_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
         return TRUE;
     }
     /* x = 1 * x ==> skip */
-    if (o_n == mul_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1) {
+    if (o_n == mul_zc && operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
         return TRUE;
     }
     /* x = x / 1 ==> skip */
-    if (o_n == div_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1) {
+    if (o_n == div_zc && operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
         return TRUE;
     }
     return FALSE;
@@ -830,27 +830,27 @@ static int try_to_simplify_operand_g(int o_n,
     assembly_operand o1, assembly_operand o2, assembly_operand st) 
 {
     /* x = x + 0 ==> skip */
-    if (o_n == add_gc && operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
+    if (o_n == add_gc && operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
         return TRUE;
     }
     /* x = 0 + x ==> skip */
-    if (o_n == add_gc && operands_equal(&o2, &st) && o1.type == ZEROCONSTANT_OT && o1.value == 0) {
+    if (o_n == add_gc && operands_equal(&o2, &st) && o1.type == ZEROCONSTANT_OT && o1.value == 0 && !o1.marker) {
         return TRUE;
     }
     /* x = x - 0 ==> skip */
-    if (o_n == sub_gc && operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
+    if (o_n == sub_gc && operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
         return TRUE;
     }
     /* x = x * 1 ==> skip */
-    if (o_n == mul_gc && operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1) {
+    if (o_n == mul_gc && operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
         return TRUE;
     }
     /* x = 1 * x ==> skip */
-    if (o_n == mul_gc && operands_equal(&o2, &st) && o1.type == BYTECONSTANT_OT && o1.value == 1) {
+    if (o_n == mul_gc && operands_equal(&o2, &st) && o1.type == BYTECONSTANT_OT && o1.value == 1 && !o1.marker) {
         return TRUE;
     }
     /* x = x / 1 ==> skip */
-    if (o_n == div_gc && operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1) {
+    if (o_n == div_gc && operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
         return TRUE;
     }
     return FALSE;

--- a/expressc.c
+++ b/expressc.c
@@ -829,20 +829,41 @@ static int try_optimize_expr_z(int o_n,
             assemblez_dec(st);
             return TRUE;
         }
-        /* x = x - 0 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
-            return TRUE;
+        if (o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
+            if (operands_equal(&o1, &st)) {
+                /* x = x - 0 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x - 0 ==> store */
+                assemblez_store(st, o1);
+                return TRUE;
+            }
         }
         break;
 
     case mul_zc:
-        /* x = x * 1 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
-            return TRUE;
+        if (o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
+            if (operands_equal(&o1, &st)) {
+                /* x = x * 1 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x * 1 ==> store */
+                assemblez_store(st, o1);
+                return TRUE;
+            }
         }
-        /* x = 1 * x ==> skip */
-        if (operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
-            return TRUE;
+        if (o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
+            if (operands_equal(&o2, &st)) {
+                /* x = 1 * x ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = 1 * x ==> store */
+                assemblez_store(st, o2);
+                return TRUE;
+            }
         }
         break;
 
@@ -888,20 +909,41 @@ static int try_optimize_expr_g(int o_n,
         break;
 
     case sub_gc:
-        /* x = x - 0 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
-            return TRUE;
+        if (o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
+            if (operands_equal(&o1, &st)) {
+                /* x = x - 0 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x - 0 ==> store */
+                assembleg_store(st, o1);
+                return TRUE;
+            }
         }
         break;
 
     case mul_gc:
-        /* x = x * 1 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
-            return TRUE;
+        if (o2.type == BYTECONSTANT_OT && o2.value == 1 && !o2.marker) {
+            if (operands_equal(&o1, &st)) {
+                /* x = x * 1 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x * 1 ==> store */
+                assembleg_store(st, o1);
+                return TRUE;
+            }
         }
-        /* x = 1 * x ==> skip */
-        if (operands_equal(&o2, &st) && o1.type == BYTECONSTANT_OT && o1.value == 1 && !o1.marker) {
-            return TRUE;
+        if (o1.type == BYTECONSTANT_OT && o1.value == 1 && !o1.marker) {
+            if (operands_equal(&o2, &st)) {
+                /* x = 1 * x ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = 1 * x ==> store */
+                assembleg_store(st, o2);
+                return TRUE;
+            }
         }
         break;
 

--- a/expressc.c
+++ b/expressc.c
@@ -1743,16 +1743,18 @@ static void generate_code_from(int n, int void_flag)
                     assemblez_2_to(o_n, temp_var1, temp_var2, Result);
                 }
             }
+            else if (try_to_simplify_operand_z(o_n, ET[below].value, ET[ET[below].right].value, Result)) {
+                /* generated simplified code */
+            }
             else {
-                if (!try_to_simplify_operand_z(o_n, ET[below].value, ET[ET[below].right].value, Result)) {
-                    assemblez_2_to(o_n, ET[below].value,
-                        ET[ET[below].right].value, Result);
-                }
+                assemblez_2_to(o_n, ET[below].value,
+                    ET[ET[below].right].value, Result);
             }
         }
-        else
+        else {
             assemblez_1_to(operators[opnum].opcode_number_z, ET[below].value,
                 Result);
+        }
     }
     else
     switch(opnum)

--- a/expressc.c
+++ b/expressc.c
@@ -789,13 +789,13 @@ static int try_optimize_expr_z(int o_n,
     switch (o_n) {
         
     case add_zc:
-        /* x = x + 1 ==> x++ */
         if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
+            /* x = x + 1 ==> x++ */
             assemblez_inc(st);
             return TRUE;
         }
-        /* x = 1 + x ==> x++ */
         if (operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 1 && !o1.marker) {
+            /* x = 1 + x ==> x++ */
             assemblez_inc(st);
             return TRUE;
         }
@@ -824,8 +824,8 @@ static int try_optimize_expr_z(int o_n,
         break;
 
     case sub_zc:
-        /* x = x - 1 ==> x-- */
         if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 1 && !o2.marker) {
+            /* x = x - 1 ==> x-- */
             assemblez_dec(st);
             return TRUE;
         }

--- a/expressc.c
+++ b/expressc.c
@@ -799,23 +799,27 @@ static int try_optimize_expr_z(int o_n,
             assemblez_inc(st);
             return TRUE;
         }
-        /* x = x + 0 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
-            return TRUE;
-        }
-        /* y = x + 0 ==> store */
         if (o2.type == SHORT_CONSTANT_OT && o2.value == 0 && !o2.marker) {
-            assemblez_store(st, o1);
-            return TRUE;
+            if (operands_equal(&o1, &st)) {
+                /* x = x + 0 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x + 0 ==> store */
+                assemblez_store(st, o1);
+                return TRUE;
+            }
         }
-        /* x = 0 + x ==> skip */
-        if (operands_equal(&o2, &st) && o1.type == SHORT_CONSTANT_OT && o1.value == 0 && !o1.marker) {
-            return TRUE;
-        }
-        /* y = 0 + x ==> store */
         if (o1.type == SHORT_CONSTANT_OT && o1.value == 0 && !o1.marker) {
-            assemblez_store(st, o2);
-            return TRUE;
+            if (operands_equal(&o2, &st)) {
+                /* x = 0 + x ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = 0 + x ==> store */
+                assemblez_store(st, o2);
+                return TRUE;
+            }
         }
         break;
 
@@ -859,23 +863,27 @@ static int try_optimize_expr_g(int o_n,
     switch (o_n) {
 
     case add_gc:
-        /* x = x + 0 ==> skip */
-        if (operands_equal(&o1, &st) && o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
-            return TRUE;
-        }
-        /* y = x + 0 ==> store */
         if (o2.type == ZEROCONSTANT_OT && o2.value == 0 && !o2.marker) {
-            assembleg_store(st, o1);
-            return TRUE;
+            if (operands_equal(&o1, &st)) {
+                /* x = x + 0 ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = x + 0 ==> store */
+                assembleg_store(st, o1);
+                return TRUE;
+            }
         }
-        /* x = 0 + x ==> skip */
-        if (operands_equal(&o2, &st) && o1.type == ZEROCONSTANT_OT && o1.value == 0 && !o1.marker) {
-            return TRUE;
-        }
-        /* y = 0 + x ==> store */
         if (o1.type == ZEROCONSTANT_OT && o1.value == 0 && !o1.marker) {
-            assembleg_store(st, o2);
-            return TRUE;
+            if (operands_equal(&o2, &st)) {
+                /* x = 0 + x ==> skip */
+                return TRUE;
+            }
+            else {
+                /* y = 0 + x ==> store */
+                assembleg_store(st, o2);
+                return TRUE;
+            }
         }
         break;
 

--- a/expressc.c
+++ b/expressc.c
@@ -837,6 +837,10 @@ static int try_to_simplify_operand_g(int o_n,
     if (o_n == add_gc && o2.type == st.type && o2.value == st.value && o1.type == ZEROCONSTANT_OT && o1.value == 0) {
         return TRUE;
     }
+    /* x = x - 0 ==> skip */
+    if (o_n == sub_gc && o1.type == st.type && o1.value == st.value && o2.type == ZEROCONSTANT_OT && o2.value == 0) {
+        return TRUE;
+    }
     return FALSE;
 }
 

--- a/expressc.c
+++ b/expressc.c
@@ -1943,7 +1943,7 @@ static void generate_code_from(int n, int void_flag)
                  if (runtime_error_checking_switch && (!veneer_mode))
                      AO = check_nonzero_at_runtime(AO, -1, PROP_ADD_RTE);
                  if ((!void_flag) && Result.type == VARIABLE_OT) {
-                     /* store directly to stack_pointer */
+                     /* store directly to variable */
                      assemblez_2_to(get_prop_addr_zc, AO,
                          ET[ET[below].right].value, Result);
                  }
@@ -1981,7 +1981,7 @@ static void generate_code_from(int n, int void_flag)
                  }
                  else {
                      if ((!void_flag) && Result.type == VARIABLE_OT) {
-                         /* store directly to stack_pointer */
+                         /* store directly to variable */
                          assemblez_2_to(get_prop_zc, ET[below].value,
                              ET[ET[below].right].value, Result);
                      }

--- a/expressc.c
+++ b/expressc.c
@@ -1779,7 +1779,7 @@ static void generate_code_from(int n, int void_flag)
                  check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
                  if (runtime_error_checking_switch && (!veneer_mode))
                      AO = check_nonzero_at_runtime(AO, -1, PROP_ADD_RTE);
-                 if ((!void_flag) && (Result.value == 0) && Result.type == VARIABLE_OT) {
+                 if ((!void_flag) && Result.type == VARIABLE_OT) {
                      /* store directly to stack_pointer */
                      assemblez_2_to(get_prop_addr_zc, AO,
                          ET[ET[below].right].value, Result);
@@ -1817,7 +1817,7 @@ static void generate_code_from(int n, int void_flag)
                      if (!void_flag) write_result_z(Result, temp_var1);
                  }
                  else {
-                     if ((!void_flag) && (Result.value == 0) && Result.type == VARIABLE_OT) {
+                     if ((!void_flag) && Result.type == VARIABLE_OT) {
                          /* store directly to stack_pointer */
                          assemblez_2_to(get_prop_zc, ET[below].value,
                              ET[ET[below].right].value, Result);

--- a/expressc.c
+++ b/expressc.c
@@ -1730,9 +1730,19 @@ static void generate_code_from(int n, int void_flag)
                  check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
                  if (runtime_error_checking_switch && (!veneer_mode))
                      AO = check_nonzero_at_runtime(AO, -1, PROP_ADD_RTE);
-                 assemblez_2_to(get_prop_addr_zc, AO,
-                     ET[ET[below].right].value, temp_var1);
-                 if (!void_flag) write_result_z(Result, temp_var1);
+                 //assemblez_2_to(get_prop_addr_zc, AO,
+                 //    ET[ET[below].right].value, temp_var1);
+                 //if (!void_flag) write_result_z(Result, temp_var1);
+                 if ((!void_flag) && (Result.value == 0)) {  // can be optimized and written directly to stack_pointer
+                     assemblez_2_to(get_prop_addr_zc, AO,
+                         ET[ET[below].right].value, Result);
+                 }
+                 else {
+                     assemblez_2_to(get_prop_addr_zc, AO,
+                         ET[ET[below].right].value, temp_var1);
+                     if (!void_flag) write_result_z(Result, temp_var1);
+                 }
+
              }
              break;
 
@@ -1755,13 +1765,29 @@ static void generate_code_from(int n, int void_flag)
              {
                  check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
                  check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-                 if (runtime_error_checking_switch && (!veneer_mode))
-                       assemblez_3_to(call_vs_zc, veneer_routine(RT__ChPR_VR),
+                 //if (runtime_error_checking_switch && (!veneer_mode))
+                 //      assemblez_3_to(call_vs_zc, veneer_routine(RT__ChPR_VR),
+                 //        ET[below].value, ET[ET[below].right].value, temp_var1);
+                 //else
+                 //assemblez_2_to(get_prop_zc, ET[below].value,
+                 //    ET[ET[below].right].value, temp_var1);
+                 //if (!void_flag) write_result_z(Result, temp_var1);
+                 if (runtime_error_checking_switch && (!veneer_mode)) {
+                     assemblez_3_to(call_vs_zc, veneer_routine(RT__ChPR_VR),
                          ET[below].value, ET[ET[below].right].value, temp_var1);
-                 else
-                 assemblez_2_to(get_prop_zc, ET[below].value,
-                     ET[ET[below].right].value, temp_var1);
-                 if (!void_flag) write_result_z(Result, temp_var1);
+                     if (!void_flag) write_result_z(Result, temp_var1);
+                 }
+                 else {
+                     if ((!void_flag) && (Result.value == 0)) {  // can be optimized and written directly to stack_pointer
+                         assemblez_2_to(get_prop_zc, ET[below].value,
+                             ET[ET[below].right].value, Result);
+                     }
+                     else {
+                         assemblez_2_to(get_prop_zc, ET[below].value,
+                             ET[ET[below].right].value, temp_var1);
+                         if (!void_flag) write_result_z(Result, temp_var1);
+                     }
+                 }
              }
              break;
 

--- a/header.h
+++ b/header.h
@@ -2188,7 +2188,7 @@ extern void set_constant_otv(assembly_operand *AO, int32 val);
 extern void set_constant_ot(assembly_operand *AO);
 extern int  is_constant_ot(int otval);
 extern int  is_variable_ot(int otval);
-extern int  operands_equal(const assembly_operand *AO1, const assembly_operand *AO2);
+extern int  operands_identical(const assembly_operand *AO1, const assembly_operand *AO2);
 extern void assemblez_instruction(const assembly_instruction *a);
 extern void assembleg_instruction(const assembly_instruction *a);
 extern void assemble_label_no(int n);

--- a/header.h
+++ b/header.h
@@ -2174,6 +2174,7 @@ extern char *variable_name(int32 i);
 extern void set_constant_ot(assembly_operand *AO);
 extern int  is_constant_ot(int otval);
 extern int  is_variable_ot(int otval);
+extern int  operands_equal(const assembly_operand *AO1, const assembly_operand *AO2);
 extern void assemblez_instruction(const assembly_instruction *a);
 extern void assembleg_instruction(const assembly_instruction *a);
 extern void assemble_label_no(int n);


### PR DESCRIPTION
This includes three improvements, originally by @heasm66 :

Various arithmetic opcodes are replaced with shorter versions (try_optimize_expr_z(), try_optimize_expr_g()). 

- `@add x 0 -> x` ⇒ (skip)
- `@add x 0 -> y` ⇒ `@store y x`
- `@add x 1 -> x` ⇒ `@inc x`
- `@sub x 0 -> x` ⇒ (skip)
- `@sub x 0 -> y` ⇒ `@store y x`
- `@sub x 1 -> x` ⇒ `@dec x`
- `@mul x 1 -> x` ⇒ (skip)
- `@mul x 1 -> y` ⇒ `@store y x`
- `@div x 1 -> x` ⇒ (skip)
- `@div x 1 -> y` ⇒ `@store y x`

The property operator previously generated code like the following:

```
@get_prop x p -> TEMP1 
@store y TEMP1 
```

This now skips the `TEMP1` step and stores directly to the variable.

When doing branch optimizations (transfer_routine_z()), if there's a `@jump` to an `@rtrue/@rfalse/@ret_popped`, we replace the `@jump` with the return opcode. This shortens the jump by one byte. 

(In some cases this leaves the original return opcode unreachable. Unfortunately we've already finished the dead-code-strip phase so it's not convenient to detect this and strip it out. It's still an improvement, even without doing that.)

(This might be a valid optimization for Glulx, but it's harder to do because the return opcodes are variable length and not necessarily shorter. I'm not bothering.)

