### PR TITLE
Action constant error line number

### DIFF
--- a/syntax.c
+++ b/syntax.c
@@ -332,7 +332,10 @@ static void parse_switch_spec(assembly_operand switch_value, int label,
         }
 
         if (action_switch)
-        {   get_next_token();
+        {
+            dont_enter_into_symbol_table = TRUE;
+            get_next_token();
+            dont_enter_into_symbol_table = FALSE;
             if (token_type == SQ_TT || token_type == DQ_TT) {
                 ebf_curtoken_error("action (or fake action) name");
                 continue;


### PR DESCRIPTION
Fix for https://github.com/DavidKinder/Inform6/issues/323 .

If we're calling get_next_token() for action_of_name(), we want to set `dont_enter_into_symbol_table` for that call. We do this in other places.
