### PR TITLE
Consistent indentation

### DIFF
--- a/arrays.c
+++ b/arrays.c
@@ -95,69 +95,69 @@ int zcode_highest_allowed_global;
 */
 extern void finish_array(int32 i, int is_static)
 {
-  uchar *area;
-  int area_size;
+    uchar *area;
+    int area_size;
   
-  if (!is_static) {
-      ensure_memory_list_available(&dynamic_array_area_memlist, dynamic_array_area_size+array_base+1*array_entry_size);
-      area = dynamic_array_area;
-      area_size = dynamic_array_area_size;
-  }
-  else {
-      ensure_memory_list_available(&static_array_area_memlist, static_array_area_size+array_base+1*array_entry_size);
-      area = static_array_area;
-      area_size = static_array_area_size;
-  }
+    if (!is_static) {
+        ensure_memory_list_available(&dynamic_array_area_memlist, dynamic_array_area_size+array_base+1*array_entry_size);
+        area = dynamic_array_area;
+        area_size = dynamic_array_area_size;
+    }
+    else {
+        ensure_memory_list_available(&static_array_area_memlist, static_array_area_size+array_base+1*array_entry_size);
+        area = static_array_area;
+        area_size = static_array_area_size;
+    }
 
-  if (i == 0) {
-      error("An array must have at least one entry");
-  }
+    if (i == 0) {
+        error("An array must have at least one entry");
+    }
   
     /*  Write the array size into the 0th byte/word of the array, if it's
         a "table" or "string" array                                          */
-  if (!glulx_mode) {
+    if (!glulx_mode) {
 
-    if (array_base != area_size)
-    {   if (area_size-array_base==2)
-        {   area[array_base]   = i/256;
-            area[array_base+1] = i%256;
+        if (array_base != area_size)
+        {   if (area_size-array_base==2)
+            {   area[array_base]   = i/256;
+                area[array_base+1] = i%256;
+            }
+            else
+            {   if (i>=256)
+                    error("A 'string' array can have at most 256 entries");
+                area[array_base] = i;
+            }
         }
-        else
-        {   if (i>=256)
-                error("A 'string' array can have at most 256 entries");
-            area[array_base] = i;
+        
+    }
+    else {
+        if (array_base != area_size)
+        {   if (area_size-array_base==4)
+            {   
+                area[array_base]   = (i >> 24) & 0xFF;
+                area[array_base+1] = (i >> 16) & 0xFF;
+                area[array_base+2] = (i >> 8) & 0xFF;
+                area[array_base+3] = (i) & 0xFF;
+            }
+            else
+            {   if (i>=256)
+                    error("A 'string' array can have at most 256 entries");
+                area[array_base] = i;
+            }
         }
+        
     }
 
-  }
-  else {
-    if (array_base != area_size)
-    {   if (area_size-array_base==4)
-        {   
-            area[array_base]   = (i >> 24) & 0xFF;
-            area[array_base+1] = (i >> 16) & 0xFF;
-            area[array_base+2] = (i >> 8) & 0xFF;
-            area[array_base+3] = (i) & 0xFF;
-        }
-        else
-        {   if (i>=256)
-                error("A 'string' array can have at most 256 entries");
-            area[array_base] = i;
-        }
+    /*  Move on the static/dynamic array size so that it now points to the
+        next available free space  */
+    
+    if (!is_static) {
+        dynamic_array_area_size += i*array_entry_size;
+    }
+    else {
+        static_array_area_size += i*array_entry_size;
     }
     
-  }
-
-  /*  Move on the static/dynamic array size so that it now points to the
-      next available free space                                              */
-
-  if (!is_static) {
-      dynamic_array_area_size += i*array_entry_size;
-  }
-  else {
-      static_array_area_size += i*array_entry_size;
-  }
-
 }
 
 /* Fill in array entry i (in either the static or dynamic area).
@@ -166,98 +166,98 @@ extern void finish_array(int32 i, int is_static)
 */
 extern void array_entry(int32 i, int is_static, assembly_operand VAL)
 {
-  uchar *area;
-  int area_size;
+    uchar *area;
+    int area_size;
   
-  if (!is_static) {
-      ensure_memory_list_available(&dynamic_array_area_memlist, dynamic_array_area_size+(i+1)*array_entry_size);
-      area = dynamic_array_area;
-      area_size = dynamic_array_area_size;
-  }
-  else {
-      ensure_memory_list_available(&static_array_area_memlist, static_array_area_size+(i+1)*array_entry_size);
-      area = static_array_area;
-      area_size = static_array_area_size;
-  }
-  
-  if (!glulx_mode) {
-    /*  Array entry i (initial entry has i=0) is set to Z-machine value j    */
-
-    if (array_entry_size==1)
-    {   area[area_size+i] = (VAL.value)%256;
-
-        if (VAL.marker != 0)
-           error("Entries in byte arrays and strings must be known constants");
-
-        /*  If the entry is too large for a byte array, issue a warning
-            and truncate the value                                           */
-        else
-        if (VAL.value >= 256)
-            warning("Entry in '->', 'string' or 'buffer' array not in range 0 to 255");
+    if (!is_static) {
+        ensure_memory_list_available(&dynamic_array_area_memlist, dynamic_array_area_size+(i+1)*array_entry_size);
+        area = dynamic_array_area;
+        area_size = dynamic_array_area_size;
     }
-    else
-    {
-        int32 addr = area_size + 2*i;
-        area[addr]   = (VAL.value)/256;
-        area[addr+1] = (VAL.value)%256;
-        if (VAL.marker != 0) {
-            if (!is_static) {
-                backpatch_zmachine(VAL.marker, DYNAMIC_ARRAY_ZA,
-                    addr);
-            }
-            else {
-                backpatch_zmachine(VAL.marker, STATIC_ARRAY_ZA,
-                    addr);
+    else {
+        ensure_memory_list_available(&static_array_area_memlist, static_array_area_size+(i+1)*array_entry_size);
+        area = static_array_area;
+        area_size = static_array_area_size;
+    }
+  
+    if (!glulx_mode) {
+        /* Array entry i (initial entry has i=0) is set to Z-machine value j */
+
+        if (array_entry_size==1)
+        {   area[area_size+i] = (VAL.value)%256;
+            
+            if (VAL.marker != 0)
+                error("Entries in byte arrays and strings must be known constants");
+            
+            /*  If the entry is too large for a byte array, issue a warning
+                and truncate the value */
+            else
+                if (VAL.value >= 256)
+                    warning("Entry in '->', 'string' or 'buffer' array not in range 0 to 255");
+        }
+        else
+        {
+            int32 addr = area_size + 2*i;
+            area[addr]   = (VAL.value)/256;
+            area[addr+1] = (VAL.value)%256;
+            if (VAL.marker != 0) {
+                if (!is_static) {
+                    backpatch_zmachine(VAL.marker, DYNAMIC_ARRAY_ZA,
+                                       addr);
+                }
+                else {
+                    backpatch_zmachine(VAL.marker, STATIC_ARRAY_ZA,
+                                       addr);
+                }
             }
         }
     }
-  }
-  else {
-    /*  Array entry i (initial entry has i=0) is set to value j              */
-
-    if (array_entry_size==1)
-    {   area[area_size+i] = (VAL.value) & 0xFF;
-
-        if (VAL.marker != 0)
-           error("Entries in byte arrays and strings must be known constants");
-
-        /*  If the entry is too large for a byte array, issue a warning
-            and truncate the value                                           */
-        else
-        if (VAL.value >= 256)
-            warning("Entry in '->', 'string' or 'buffer' array not in range 0 to 255");
-    }
-    else if (array_entry_size==4)
-    {
-        int32 addr = area_size + 4*i;
-        area[addr]   = (VAL.value >> 24) & 0xFF;
-        area[addr+1] = (VAL.value >> 16) & 0xFF;
-        area[addr+2] = (VAL.value >> 8) & 0xFF;
-        area[addr+3] = (VAL.value) & 0xFF;
-        if (VAL.marker != 0) {
-            if (!is_static) {
-                backpatch_zmachine(VAL.marker, DYNAMIC_ARRAY_ZA,
-                    addr);
-            }
-            else {
-                /* We can't use backpatch_zmachine() because that only applies to RAM. Instead we add an entry to staticarray_backpatch_table.
-                   A backpatch entry is five bytes: *_MV followed by the array offset (in static array area). */
-                if (bpatch_trace_setting >= 2)
-                    printf("BP added: MV %d staticarray %04x\n", VAL.marker, addr);
-                ensure_memory_list_available(&staticarray_backpatch_table_memlist, staticarray_backpatch_size+5);
-                staticarray_backpatch_table[staticarray_backpatch_size++] = VAL.marker;
-                staticarray_backpatch_table[staticarray_backpatch_size++] = ((addr >> 24) & 0xFF);
-                staticarray_backpatch_table[staticarray_backpatch_size++] = ((addr >> 16) & 0xFF);
-                staticarray_backpatch_table[staticarray_backpatch_size++] = ((addr >> 8) & 0xFF);
-                staticarray_backpatch_table[staticarray_backpatch_size++] = (addr & 0xFF);
+    else {
+        /*  Array entry i (initial entry has i=0) is set to value j  */
+        
+        if (array_entry_size==1)
+        {   area[area_size+i] = (VAL.value) & 0xFF;
+            
+            if (VAL.marker != 0)
+                error("Entries in byte arrays and strings must be known constants");
+            
+            /*  If the entry is too large for a byte array, issue a warning
+                and truncate the value  */
+            else
+                if (VAL.value >= 256)
+                    warning("Entry in '->', 'string' or 'buffer' array not in range 0 to 255");
+        }
+        else if (array_entry_size==4)
+        {
+            int32 addr = area_size + 4*i;
+            area[addr]   = (VAL.value >> 24) & 0xFF;
+            area[addr+1] = (VAL.value >> 16) & 0xFF;
+            area[addr+2] = (VAL.value >> 8) & 0xFF;
+            area[addr+3] = (VAL.value) & 0xFF;
+            if (VAL.marker != 0) {
+                if (!is_static) {
+                    backpatch_zmachine(VAL.marker, DYNAMIC_ARRAY_ZA,
+                                       addr);
+                }
+                else {
+                    /* We can't use backpatch_zmachine() because that only applies to RAM. Instead we add an entry to staticarray_backpatch_table.
+                       A backpatch entry is five bytes: *_MV followed by the array offset (in static array area). */
+                    if (bpatch_trace_setting >= 2)
+                        printf("BP added: MV %d staticarray %04x\n", VAL.marker, addr);
+                    ensure_memory_list_available(&staticarray_backpatch_table_memlist, staticarray_backpatch_size+5);
+                    staticarray_backpatch_table[staticarray_backpatch_size++] = VAL.marker;
+                    staticarray_backpatch_table[staticarray_backpatch_size++] = ((addr >> 24) & 0xFF);
+                    staticarray_backpatch_table[staticarray_backpatch_size++] = ((addr >> 16) & 0xFF);
+                    staticarray_backpatch_table[staticarray_backpatch_size++] = ((addr >> 8) & 0xFF);
+                    staticarray_backpatch_table[staticarray_backpatch_size++] = (addr & 0xFF);
+                }
             }
         }
+        else
+        {
+            error("Somehow created an array of shorts");
+        }
     }
-    else
-    {
-        error("Somehow created an array of shorts");
-    }
-  }
 }
 
 /* ------------------------------------------------------------------------- */

--- a/asm.c
+++ b/asm.c
@@ -2539,53 +2539,53 @@ static void transfer_routine_g(void)
                 zcode_holding_area[i+3] = (addr) & 0xFF;
             }
             zcode_area[adjusted_pc++] = zcode_holding_area[i]; new_pc++;
-      }
-      else if (zcode_markers[i] == LABEL_MV) {
-          error("*** No LABEL opcodes in Glulx ***");
-      }
-      else if (zcode_markers[i] == DELETED_MV) {
-        /* skip it */
-      }
-      else {
-        switch(zcode_markers[i] & 0x7f) {
-        case NULL_MV: 
-            break;
-        case ERROR_MV:
-            break;
-        case IDENT_MV:
-            break;
-        case ACTION_MV:
-            if (!GRAMMAR_META_FLAG) break;
-            /* Actions are backpatchable if GRAMMAR_META_FLAG; fall
-               through and create entry */
-            /* Fall through */
-        case OBJECT_MV:
-        case VARIABLE_MV:
-        default:
-            if ((zcode_markers[i] & 0x7f) > LARGEST_BPATCH_MV) {
-                error("*** Illegal code backpatch value ***");
-                printf("Illegal value of %02x at PC = %04x\n",
-                zcode_markers[i] & 0x7f, new_pc);
+        }
+        else if (zcode_markers[i] == LABEL_MV) {
+            error("*** No LABEL opcodes in Glulx ***");
+        }
+        else if (zcode_markers[i] == DELETED_MV) {
+            /* skip it */
+        }
+        else {
+            switch(zcode_markers[i] & 0x7f) {
+            case NULL_MV: 
+                break;
+            case ERROR_MV:
+                break;
+            case IDENT_MV:
+                break;
+            case ACTION_MV:
+                if (!GRAMMAR_META_FLAG) break;
+                /* Actions are backpatchable if GRAMMAR_META_FLAG; fall
+                   through and create entry */
+                /* Fall through */
+            case OBJECT_MV:
+            case VARIABLE_MV:
+            default:
+                if ((zcode_markers[i] & 0x7f) > LARGEST_BPATCH_MV) {
+                    error("*** Illegal code backpatch value ***");
+                    printf("Illegal value of %02x at PC = %04x\n",
+                           zcode_markers[i] & 0x7f, new_pc);
+                    break;
+                }
+                /* The backpatch table format for Glulx:
+                   First, the marker byte (0..LARGEST_BPATCH_MV).
+                   Then a byte indicating the data size to be patched (1, 2, 4).
+                   Then the four-byte address (new_pc).
+                */
+                if (bpatch_trace_setting >= 2)
+                    printf("BP added: MV %d size %d PC %04x\n", zcode_markers[i], 4, new_pc);
+                ensure_memory_list_available(&zcode_backpatch_table_memlist, zcode_backpatch_size+6);
+                zcode_backpatch_table[zcode_backpatch_size++] = zcode_markers[i];
+                zcode_backpatch_table[zcode_backpatch_size++] = 4;
+                zcode_backpatch_table[zcode_backpatch_size++] = ((new_pc >> 24) & 0xFF);
+                zcode_backpatch_table[zcode_backpatch_size++] = ((new_pc >> 16) & 0xFF);
+                zcode_backpatch_table[zcode_backpatch_size++] = ((new_pc >> 8) & 0xFF);
+                zcode_backpatch_table[zcode_backpatch_size++] = (new_pc & 0xFF);
                 break;
             }
-          /* The backpatch table format for Glulx:
-             First, the marker byte (0..LARGEST_BPATCH_MV).
-             Then a byte indicating the data size to be patched (1, 2, 4).
-             Then the four-byte address (new_pc).
-          */
-          if (bpatch_trace_setting >= 2)
-              printf("BP added: MV %d size %d PC %04x\n", zcode_markers[i], 4, new_pc);
-          ensure_memory_list_available(&zcode_backpatch_table_memlist, zcode_backpatch_size+6);
-          zcode_backpatch_table[zcode_backpatch_size++] = zcode_markers[i];
-          zcode_backpatch_table[zcode_backpatch_size++] = 4;
-          zcode_backpatch_table[zcode_backpatch_size++] = ((new_pc >> 24) & 0xFF);
-          zcode_backpatch_table[zcode_backpatch_size++] = ((new_pc >> 16) & 0xFF);
-          zcode_backpatch_table[zcode_backpatch_size++] = ((new_pc >> 8) & 0xFF);
-          zcode_backpatch_table[zcode_backpatch_size++] = (new_pc & 0xFF);
-          break;
+            zcode_area[adjusted_pc++] = zcode_holding_area[i]; new_pc++;
         }
-        zcode_area[adjusted_pc++] = zcode_holding_area[i]; new_pc++;
-      }
     }
 
     /* Consistency check */

--- a/asm.c
+++ b/asm.c
@@ -263,47 +263,47 @@ extern void set_constant_otv(assembly_operand *AO, int32 val)
 
 extern void set_constant_ot(assembly_operand *AO)
 {
-  if (!glulx_mode) {
-    if (AO->value >= 0 && AO->value <= 255)
-      AO->type = SHORT_CONSTANT_OT;
-    else
-      AO->type = LONG_CONSTANT_OT;
-  }
-  else {
-    if (AO->value == 0)
-      AO->type = ZEROCONSTANT_OT;
-    else if (AO->value >= -0x80 && AO->value < 0x80)
-      AO->type = BYTECONSTANT_OT;
-    else if (AO->value >= -0x8000 && AO->value < 0x8000) 
-      AO->type = HALFCONSTANT_OT;
-    else
-      AO->type = CONSTANT_OT;
-  }
+    if (!glulx_mode) {
+        if (AO->value >= 0 && AO->value <= 255)
+            AO->type = SHORT_CONSTANT_OT;
+        else
+            AO->type = LONG_CONSTANT_OT;
+    }
+    else {
+        if (AO->value == 0)
+            AO->type = ZEROCONSTANT_OT;
+        else if (AO->value >= -0x80 && AO->value < 0x80)
+            AO->type = BYTECONSTANT_OT;
+        else if (AO->value >= -0x8000 && AO->value < 0x8000) 
+            AO->type = HALFCONSTANT_OT;
+        else
+            AO->type = CONSTANT_OT;
+    }
 }
 
 extern int is_constant_ot(int otval)
 {
-  if (!glulx_mode) {
-    return ((otval == LONG_CONSTANT_OT) 
-      || (otval == SHORT_CONSTANT_OT));
-  }
-  else {
-    return ((otval == CONSTANT_OT)
-      || (otval == HALFCONSTANT_OT)
-      || (otval == BYTECONSTANT_OT)
-      || (otval == ZEROCONSTANT_OT));
-  }
+    if (!glulx_mode) {
+        return ((otval == LONG_CONSTANT_OT) 
+                || (otval == SHORT_CONSTANT_OT));
+    }
+    else {
+        return ((otval == CONSTANT_OT)
+                || (otval == HALFCONSTANT_OT)
+                || (otval == BYTECONSTANT_OT)
+                || (otval == ZEROCONSTANT_OT));
+    }
 }
 
 extern int is_variable_ot(int otval)
 {
-  if (!glulx_mode) {
-    return (otval == VARIABLE_OT);
-  }
-  else {
-    return ((otval == LOCALVAR_OT)
-      || (otval == GLOBALVAR_OT));
-  }
+    if (!glulx_mode) {
+        return (otval == VARIABLE_OT);
+    }
+    else {
+        return ((otval == LOCALVAR_OT)
+                || (otval == GLOBALVAR_OT));
+    }
 }
 
 extern int operands_identical(const assembly_operand *AO1, const assembly_operand *AO2)
@@ -324,32 +324,32 @@ extern char *variable_name(int32 i)
     if (i<MAX_LOCAL_VARIABLES) return get_local_variable_name(i-1);
 
     if (!glulx_mode) {
-      if (i == globalv_z_temp_var1) return("TEMP1");
-      if (i == globalv_z_temp_var2) return("TEMP2");
-      if (i == globalv_z_temp_var3) return("TEMP3");
-      if (i == globalv_z_temp_var4) return("TEMP4");
-      if (i == globalv_z_self) return("self");
-      if (i == globalv_z_sender) return("sender");
-      if (i == globalv_z_sw__var) return("sw__var");
-      if (i >= 256 && i < 286)
-      {   if (i - 256 < NUMBER_SYSTEM_FUNCTIONS) return system_functions.keywords[i - 256];
-          return "<unnamed system function>";
-      }
+        if (i == globalv_z_temp_var1) return("TEMP1");
+        if (i == globalv_z_temp_var2) return("TEMP2");
+        if (i == globalv_z_temp_var3) return("TEMP3");
+        if (i == globalv_z_temp_var4) return("TEMP4");
+        if (i == globalv_z_self) return("self");
+        if (i == globalv_z_sender) return("sender");
+        if (i == globalv_z_sw__var) return("sw__var");
+        if (i >= 256 && i < 286)
+            {   if (i - 256 < NUMBER_SYSTEM_FUNCTIONS) return system_functions.keywords[i - 256];
+                return "<unnamed system function>";
+            }
     }
     else {
-      switch (i - MAX_LOCAL_VARIABLES) {
-      case 0: return "temp_global";
-      case 1: return "temp__global2";
-      case 2: return "temp__global3";
-      case 3: return "temp__global4";
-      case 4: return "self";
-      case 5: return "sender";
-      case 6: return "sw__var";
-      case 7: return "sys__glob0";
-      case 8: return "sys__glob1";
-      case 9: return "sys__glob2";
-      case 10: return "sys_statusline_flag";
-      }
+        switch (i - MAX_LOCAL_VARIABLES) {
+        case 0: return "temp_global";
+        case 1: return "temp__global2";
+        case 2: return "temp__global3";
+        case 3: return "temp__global4";
+        case 4: return "self";
+        case 5: return "sender";
+        case 6: return "sw__var";
+        case 7: return "sys__glob0";
+        case 8: return "sys__glob1";
+        case 9: return "sys__glob2";
+        case 10: return "sys_statusline_flag";
+        }
     }
 
     return (symbols[variables[i].token].name);
@@ -402,42 +402,42 @@ static void print_operand_z(const assembly_operand *o, int annotate)
 
 static void print_operand_g(const assembly_operand *o, int annotate)
 {
-  switch (o->type) {
-  case EXPRESSION_OT: printf("expr_"); break;
-  case CONSTANT_OT: printf("long_"); break;
-  case HALFCONSTANT_OT: printf("short_"); break;
-  case BYTECONSTANT_OT: printf("byte_"); break;
-  case ZEROCONSTANT_OT: printf("zero_"); return;
-  case DEREFERENCE_OT: printf("*"); break;
-  case GLOBALVAR_OT: 
-    printf("global_%d (%s)", o->value, variable_name(o->value)); 
-    return;
-  case LOCALVAR_OT: 
-    if (o->value == 0)
-      printf("stackptr"); 
-    else
-      printf("local_%d (%s)", o->value-1, variable_name(o->value)); 
-    return;
-  case SYSFUN_OT:
-    if (o->value >= 0 && o->value < NUMBER_SYSTEM_FUNCTIONS)
-      printf("%s", system_functions.keywords[o->value]);
-    else
-      printf("<unnamed system function>");
-    return;
-  case OMITTED_OT: printf("<no value>"); return;
-  default: printf("???_"); break; 
-  }
-  printf("%d", o->value);
-  if (annotate)
-    print_operand_annotation(o);
+    switch (o->type) {
+    case EXPRESSION_OT: printf("expr_"); break;
+    case CONSTANT_OT: printf("long_"); break;
+    case HALFCONSTANT_OT: printf("short_"); break;
+    case BYTECONSTANT_OT: printf("byte_"); break;
+    case ZEROCONSTANT_OT: printf("zero_"); return;
+    case DEREFERENCE_OT: printf("*"); break;
+    case GLOBALVAR_OT: 
+        printf("global_%d (%s)", o->value, variable_name(o->value)); 
+        return;
+    case LOCALVAR_OT: 
+        if (o->value == 0)
+            printf("stackptr"); 
+        else
+            printf("local_%d (%s)", o->value-1, variable_name(o->value)); 
+        return;
+    case SYSFUN_OT:
+        if (o->value >= 0 && o->value < NUMBER_SYSTEM_FUNCTIONS)
+            printf("%s", system_functions.keywords[o->value]);
+        else
+            printf("<unnamed system function>");
+        return;
+    case OMITTED_OT: printf("<no value>"); return;
+    default: printf("???_"); break; 
+    }
+    printf("%d", o->value);
+    if (annotate)
+        print_operand_annotation(o);
 }
 
 extern void print_operand(const assembly_operand *o, int annotate)
 {
-  if (!glulx_mode)
-    print_operand_z(o, annotate);
-  else
-    print_operand_g(o, annotate);
+    if (!glulx_mode)
+        print_operand_z(o, annotate);
+    else
+        print_operand_g(o, annotate);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -694,165 +694,165 @@ static opcodez custom_opcode_z;
 */
 
 static opcodeg opcodes_table_g[] = {
-  { (uchar *) "nop",        0x00,  0, 0, 0 },
-  { (uchar *) "add",        0x10, St, 0, 3 },
-  { (uchar *) "sub",        0x11, St, 0, 3 },
-  { (uchar *) "mul",        0x12, St, 0, 3 },
-  { (uchar *) "div",        0x13, St, 0, 3 },
-  { (uchar *) "mod",        0x14, St, 0, 3 },
-  { (uchar *) "neg",        0x15, St, 0, 2 },
-  { (uchar *) "bitand",     0x18, St, 0, 3 },
-  { (uchar *) "bitor",      0x19, St, 0, 3 },
-  { (uchar *) "bitxor",     0x1A, St, 0, 3 },
-  { (uchar *) "bitnot",     0x1B, St, 0, 2 },
-  { (uchar *) "shiftl",     0x1C, St, 0, 3 },
-  { (uchar *) "sshiftr",    0x1D, St, 0, 3 },
-  { (uchar *) "ushiftr",    0x1E, St, 0, 3 },
-  { (uchar *) "jump",       0x20, Br|Rf, 0, 1 },
-  { (uchar *) "jz",     0x22, Br, 0, 2 },
-  { (uchar *) "jnz",        0x23, Br, 0, 2 },
-  { (uchar *) "jeq",        0x24, Br, 0, 3 },
-  { (uchar *) "jne",        0x25, Br, 0, 3 },
-  { (uchar *) "jlt",        0x26, Br, 0, 3 },
-  { (uchar *) "jge",        0x27, Br, 0, 3 },
-  { (uchar *) "jgt",        0x28, Br, 0, 3 },
-  { (uchar *) "jle",        0x29, Br, 0, 3 },
-  { (uchar *) "jltu",       0x2A, Br, 0, 3 },
-  { (uchar *) "jgeu",       0x2B, Br, 0, 3 },
-  { (uchar *) "jgtu",       0x2C, Br, 0, 3 },
-  { (uchar *) "jleu",       0x2D, Br, 0, 3 },
-  { (uchar *) "call",       0x30, St, 0, 3 },
-  { (uchar *) "return",     0x31, Rf, 0, 1 },
-  { (uchar *) "catch",      0x32, Br|St, 0, 2 },
-  { (uchar *) "throw",      0x33, Rf, 0, 2 },
-  { (uchar *) "tailcall",   0x34, Rf, 0, 2 },
-  { (uchar *) "copy",       0x40, St, 0, 2 },
-  { (uchar *) "copys",      0x41, St, 0, 2 },
-  { (uchar *) "copyb",      0x42, St, 0, 2 },
-  { (uchar *) "sexs",       0x44, St, 0, 2 },
-  { (uchar *) "sexb",       0x45, St, 0, 2 },
-  { (uchar *) "aload",      0x48, St, 0, 3 },
-  { (uchar *) "aloads",     0x49, St, 0, 3 },
-  { (uchar *) "aloadb",     0x4A, St, 0, 3 },
-  { (uchar *) "aloadbit",   0x4B, St, 0, 3 },
-  { (uchar *) "astore",     0x4C,  0, 0, 3 },
-  { (uchar *) "astores",    0x4D,  0, 0, 3 },
-  { (uchar *) "astoreb",    0x4E,  0, 0, 3 },
-  { (uchar *) "astorebit",  0x4F,  0, 0, 3 },
-  { (uchar *) "stkcount",   0x50, St, 0, 1 },
-  { (uchar *) "stkpeek",    0x51, St, 0, 2 },
-  { (uchar *) "stkswap",    0x52,  0, 0, 0 },
-  { (uchar *) "stkroll",    0x53,  0, 0, 2 },
-  { (uchar *) "stkcopy",    0x54,  0, 0, 1 },
-  { (uchar *) "streamchar", 0x70,  0, 0, 1 },
-  { (uchar *) "streamnum",  0x71,  0, 0, 1 },
-  { (uchar *) "streamstr",  0x72,  0, 0, 1 },
-  { (uchar *) "gestalt",    0x0100, St, 0, 3 },
-  { (uchar *) "debugtrap",  0x0101, 0, 0, 1 },
-  { (uchar *) "getmemsize",     0x0102, St, 0, 1 },
-  { (uchar *) "setmemsize",     0x0103, St, 0, 2 },
-  { (uchar *) "jumpabs",    0x0104, Rf, 0, 1 },
-  { (uchar *) "random",     0x0110, St, 0, 2 },
-  { (uchar *) "setrandom",  0x0111,  0, 0, 1 },
-  { (uchar *) "quit",       0x0120, Rf, 0, 0 },
-  { (uchar *) "verify",     0x0121, St, 0, 1 },
-  { (uchar *) "restart",    0x0122,  0, 0, 0 },
-  { (uchar *) "save",       0x0123, St, 0, 2 },
-  { (uchar *) "restore",    0x0124, St, 0, 2 },
-  { (uchar *) "saveundo",   0x0125, St, 0, 1 },
-  { (uchar *) "restoreundo",    0x0126, St, 0, 1 },
-  { (uchar *) "protect",    0x0127,  0, 0, 2 },
-  { (uchar *) "glk",        0x0130, St, 0, 3 },
-  { (uchar *) "getstringtbl",   0x0140, St, 0, 1 },
-  { (uchar *) "setstringtbl",   0x0141, 0, 0, 1 },
-  { (uchar *) "getiosys",   0x0148, St|St2, 0, 2 },
-  { (uchar *) "setiosys",   0x0149, 0, 0, 2 },
-  { (uchar *) "linearsearch",   0x0150, St, 0, 8 },
-  { (uchar *) "binarysearch",   0x0151, St, 0, 8 },
-  { (uchar *) "linkedsearch",   0x0152, St, 0, 7 },
-  { (uchar *) "callf",      0x0160, St, 0, 2 },
-  { (uchar *) "callfi",     0x0161, St, 0, 3 },
-  { (uchar *) "callfii",    0x0162, St, 0, 4 },
-  { (uchar *) "callfiii",   0x0163, St, 0, 5 },
-  { (uchar *) "streamunichar", 0x73,  0, GOP_Unicode, 1 },
-  { (uchar *) "mzero",      0x170,  0, GOP_MemHeap, 2 },
-  { (uchar *) "mcopy",      0x171,  0, GOP_MemHeap, 3 },
-  { (uchar *) "malloc",     0x178,  St, GOP_MemHeap, 2 },
-  { (uchar *) "mfree",      0x179,  0, GOP_MemHeap, 1 },
-  { (uchar *) "accelfunc",  0x180,  0, GOP_Acceleration, 2 },
-  { (uchar *) "accelparam", 0x181,  0, GOP_Acceleration, 2 },
-  { (uchar *) "hasundo",    0x128,  St, GOP_ExtUndo, 1 },
-  { (uchar *) "discardundo",0x129,   0, GOP_ExtUndo, 0 },
-  { (uchar *) "numtof",     0x190,  St, GOP_Float, 2 },
-  { (uchar *) "ftonumz",    0x191,  St, GOP_Float, 2 },
-  { (uchar *) "ftonumn",    0x192,  St, GOP_Float, 2 },
-  { (uchar *) "ceil",       0x198,  St, GOP_Float, 2 },
-  { (uchar *) "floor",      0x199,  St, GOP_Float, 2 },
-  { (uchar *) "fadd",       0x1A0,  St, GOP_Float, 3 },
-  { (uchar *) "fsub",       0x1A1,  St, GOP_Float, 3 },
-  { (uchar *) "fmul",       0x1A2,  St, GOP_Float, 3 },
-  { (uchar *) "fdiv",       0x1A3,  St, GOP_Float, 3 },
-  { (uchar *) "fmod",       0x1A4,  St|St2, GOP_Float, 4 },
-  { (uchar *) "sqrt",       0x1A8,  St, GOP_Float, 2 },
-  { (uchar *) "exp",        0x1A9,  St, GOP_Float, 2 },
-  { (uchar *) "log",        0x1AA,  St, GOP_Float, 2 },
-  { (uchar *) "pow",        0x1AB,  St, GOP_Float, 3 },
-  { (uchar *) "sin",        0x1B0,  St, GOP_Float, 2 },
-  { (uchar *) "cos",        0x1B1,  St, GOP_Float, 2 },
-  { (uchar *) "tan",        0x1B2,  St, GOP_Float, 2 },
-  { (uchar *) "asin",       0x1B3,  St, GOP_Float, 2 },
-  { (uchar *) "acos",       0x1B4,  St, GOP_Float, 2 },
-  { (uchar *) "atan",       0x1B5,  St, GOP_Float, 2 },
-  { (uchar *) "atan2",      0x1B6,  St, GOP_Float, 3 },
-  { (uchar *) "jfeq",       0x1C0,  Br, GOP_Float, 4 },
-  { (uchar *) "jfne",       0x1C1,  Br, GOP_Float, 4 },
-  { (uchar *) "jflt",       0x1C2,  Br, GOP_Float, 3 },
-  { (uchar *) "jfle",       0x1C3,  Br, GOP_Float, 3 },
-  { (uchar *) "jfgt",       0x1C4,  Br, GOP_Float, 3 },
-  { (uchar *) "jfge",       0x1C5,  Br, GOP_Float, 3 },
-  { (uchar *) "jisnan",     0x1C8,  Br, GOP_Float, 2 },
-  { (uchar *) "jisinf",     0x1C9,  Br, GOP_Float, 2 },
-  { (uchar *) "numtod",     0x200,  St|St2, GOP_Double, 3 },
-  { (uchar *) "dtonumz",    0x201,  St, GOP_Double, 3 },
-  { (uchar *) "dtonumn",    0x202,  St, GOP_Double, 3 },
-  { (uchar *) "ftod",       0x203,  St|St2, GOP_Double, 3 },
-  { (uchar *) "dtof",       0x204,  St, GOP_Double, 3 },
-  { (uchar *) "dceil",      0x208,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dfloor",     0x209,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dadd",       0x210,  St|St2, GOP_Double, 6 },
-  { (uchar *) "dsub",       0x211,  St|St2, GOP_Double, 6 },
-  { (uchar *) "dmul",       0x212,  St|St2, GOP_Double, 6 },
-  { (uchar *) "ddiv",       0x213,  St|St2, GOP_Double, 6 },
-  { (uchar *) "dmodr",      0x214,  St|St2, GOP_Double, 6 },
-  { (uchar *) "dmodq",      0x215,  St|St2, GOP_Double, 6 },
-  { (uchar *) "dsqrt",      0x218,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dexp",       0x219,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dlog",       0x21A,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dpow",       0x21B,  St|St2, GOP_Double, 6 },
-  { (uchar *) "dsin",       0x220,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dcos",       0x221,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dtan",       0x222,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dasin",      0x223,  St|St2, GOP_Double, 4 },
-  { (uchar *) "dacos",      0x224,  St|St2, GOP_Double, 4 },
-  { (uchar *) "datan",      0x225,  St|St2, GOP_Double, 4 },
-  { (uchar *) "datan2",     0x226,  St|St2, GOP_Double, 6 },
-  { (uchar *) "jdeq",       0x230,  Br, GOP_Double, 7 },
-  { (uchar *) "jdne",       0x231,  Br, GOP_Double, 7 },
-  { (uchar *) "jdlt",       0x232,  Br, GOP_Double, 5 },
-  { (uchar *) "jdle",       0x233,  Br, GOP_Double, 5 },
-  { (uchar *) "jdgt",       0x234,  Br, GOP_Double, 5 },
-  { (uchar *) "jdge",       0x235,  Br, GOP_Double, 5 },
-  { (uchar *) "jdisnan",    0x238,  Br, GOP_Double, 3 },
-  { (uchar *) "jdisinf",    0x239,  Br, GOP_Double, 3 },
+    { (uchar *) "nop",        0x00,  0, 0, 0 },
+    { (uchar *) "add",        0x10, St, 0, 3 },
+    { (uchar *) "sub",        0x11, St, 0, 3 },
+    { (uchar *) "mul",        0x12, St, 0, 3 },
+    { (uchar *) "div",        0x13, St, 0, 3 },
+    { (uchar *) "mod",        0x14, St, 0, 3 },
+    { (uchar *) "neg",        0x15, St, 0, 2 },
+    { (uchar *) "bitand",     0x18, St, 0, 3 },
+    { (uchar *) "bitor",      0x19, St, 0, 3 },
+    { (uchar *) "bitxor",     0x1A, St, 0, 3 },
+    { (uchar *) "bitnot",     0x1B, St, 0, 2 },
+    { (uchar *) "shiftl",     0x1C, St, 0, 3 },
+    { (uchar *) "sshiftr",    0x1D, St, 0, 3 },
+    { (uchar *) "ushiftr",    0x1E, St, 0, 3 },
+    { (uchar *) "jump",       0x20, Br|Rf, 0, 1 },
+    { (uchar *) "jz",     0x22, Br, 0, 2 },
+    { (uchar *) "jnz",        0x23, Br, 0, 2 },
+    { (uchar *) "jeq",        0x24, Br, 0, 3 },
+    { (uchar *) "jne",        0x25, Br, 0, 3 },
+    { (uchar *) "jlt",        0x26, Br, 0, 3 },
+    { (uchar *) "jge",        0x27, Br, 0, 3 },
+    { (uchar *) "jgt",        0x28, Br, 0, 3 },
+    { (uchar *) "jle",        0x29, Br, 0, 3 },
+    { (uchar *) "jltu",       0x2A, Br, 0, 3 },
+    { (uchar *) "jgeu",       0x2B, Br, 0, 3 },
+    { (uchar *) "jgtu",       0x2C, Br, 0, 3 },
+    { (uchar *) "jleu",       0x2D, Br, 0, 3 },
+    { (uchar *) "call",       0x30, St, 0, 3 },
+    { (uchar *) "return",     0x31, Rf, 0, 1 },
+    { (uchar *) "catch",      0x32, Br|St, 0, 2 },
+    { (uchar *) "throw",      0x33, Rf, 0, 2 },
+    { (uchar *) "tailcall",   0x34, Rf, 0, 2 },
+    { (uchar *) "copy",       0x40, St, 0, 2 },
+    { (uchar *) "copys",      0x41, St, 0, 2 },
+    { (uchar *) "copyb",      0x42, St, 0, 2 },
+    { (uchar *) "sexs",       0x44, St, 0, 2 },
+    { (uchar *) "sexb",       0x45, St, 0, 2 },
+    { (uchar *) "aload",      0x48, St, 0, 3 },
+    { (uchar *) "aloads",     0x49, St, 0, 3 },
+    { (uchar *) "aloadb",     0x4A, St, 0, 3 },
+    { (uchar *) "aloadbit",   0x4B, St, 0, 3 },
+    { (uchar *) "astore",     0x4C,  0, 0, 3 },
+    { (uchar *) "astores",    0x4D,  0, 0, 3 },
+    { (uchar *) "astoreb",    0x4E,  0, 0, 3 },
+    { (uchar *) "astorebit",  0x4F,  0, 0, 3 },
+    { (uchar *) "stkcount",   0x50, St, 0, 1 },
+    { (uchar *) "stkpeek",    0x51, St, 0, 2 },
+    { (uchar *) "stkswap",    0x52,  0, 0, 0 },
+    { (uchar *) "stkroll",    0x53,  0, 0, 2 },
+    { (uchar *) "stkcopy",    0x54,  0, 0, 1 },
+    { (uchar *) "streamchar", 0x70,  0, 0, 1 },
+    { (uchar *) "streamnum",  0x71,  0, 0, 1 },
+    { (uchar *) "streamstr",  0x72,  0, 0, 1 },
+    { (uchar *) "gestalt",    0x0100, St, 0, 3 },
+    { (uchar *) "debugtrap",  0x0101, 0, 0, 1 },
+    { (uchar *) "getmemsize",     0x0102, St, 0, 1 },
+    { (uchar *) "setmemsize",     0x0103, St, 0, 2 },
+    { (uchar *) "jumpabs",    0x0104, Rf, 0, 1 },
+    { (uchar *) "random",     0x0110, St, 0, 2 },
+    { (uchar *) "setrandom",  0x0111,  0, 0, 1 },
+    { (uchar *) "quit",       0x0120, Rf, 0, 0 },
+    { (uchar *) "verify",     0x0121, St, 0, 1 },
+    { (uchar *) "restart",    0x0122,  0, 0, 0 },
+    { (uchar *) "save",       0x0123, St, 0, 2 },
+    { (uchar *) "restore",    0x0124, St, 0, 2 },
+    { (uchar *) "saveundo",   0x0125, St, 0, 1 },
+    { (uchar *) "restoreundo",    0x0126, St, 0, 1 },
+    { (uchar *) "protect",    0x0127,  0, 0, 2 },
+    { (uchar *) "glk",        0x0130, St, 0, 3 },
+    { (uchar *) "getstringtbl",   0x0140, St, 0, 1 },
+    { (uchar *) "setstringtbl",   0x0141, 0, 0, 1 },
+    { (uchar *) "getiosys",   0x0148, St|St2, 0, 2 },
+    { (uchar *) "setiosys",   0x0149, 0, 0, 2 },
+    { (uchar *) "linearsearch",   0x0150, St, 0, 8 },
+    { (uchar *) "binarysearch",   0x0151, St, 0, 8 },
+    { (uchar *) "linkedsearch",   0x0152, St, 0, 7 },
+    { (uchar *) "callf",      0x0160, St, 0, 2 },
+    { (uchar *) "callfi",     0x0161, St, 0, 3 },
+    { (uchar *) "callfii",    0x0162, St, 0, 4 },
+    { (uchar *) "callfiii",   0x0163, St, 0, 5 },
+    { (uchar *) "streamunichar", 0x73,  0, GOP_Unicode, 1 },
+    { (uchar *) "mzero",      0x170,  0, GOP_MemHeap, 2 },
+    { (uchar *) "mcopy",      0x171,  0, GOP_MemHeap, 3 },
+    { (uchar *) "malloc",     0x178,  St, GOP_MemHeap, 2 },
+    { (uchar *) "mfree",      0x179,  0, GOP_MemHeap, 1 },
+    { (uchar *) "accelfunc",  0x180,  0, GOP_Acceleration, 2 },
+    { (uchar *) "accelparam", 0x181,  0, GOP_Acceleration, 2 },
+    { (uchar *) "hasundo",    0x128,  St, GOP_ExtUndo, 1 },
+    { (uchar *) "discardundo",0x129,   0, GOP_ExtUndo, 0 },
+    { (uchar *) "numtof",     0x190,  St, GOP_Float, 2 },
+    { (uchar *) "ftonumz",    0x191,  St, GOP_Float, 2 },
+    { (uchar *) "ftonumn",    0x192,  St, GOP_Float, 2 },
+    { (uchar *) "ceil",       0x198,  St, GOP_Float, 2 },
+    { (uchar *) "floor",      0x199,  St, GOP_Float, 2 },
+    { (uchar *) "fadd",       0x1A0,  St, GOP_Float, 3 },
+    { (uchar *) "fsub",       0x1A1,  St, GOP_Float, 3 },
+    { (uchar *) "fmul",       0x1A2,  St, GOP_Float, 3 },
+    { (uchar *) "fdiv",       0x1A3,  St, GOP_Float, 3 },
+    { (uchar *) "fmod",       0x1A4,  St|St2, GOP_Float, 4 },
+    { (uchar *) "sqrt",       0x1A8,  St, GOP_Float, 2 },
+    { (uchar *) "exp",        0x1A9,  St, GOP_Float, 2 },
+    { (uchar *) "log",        0x1AA,  St, GOP_Float, 2 },
+    { (uchar *) "pow",        0x1AB,  St, GOP_Float, 3 },
+    { (uchar *) "sin",        0x1B0,  St, GOP_Float, 2 },
+    { (uchar *) "cos",        0x1B1,  St, GOP_Float, 2 },
+    { (uchar *) "tan",        0x1B2,  St, GOP_Float, 2 },
+    { (uchar *) "asin",       0x1B3,  St, GOP_Float, 2 },
+    { (uchar *) "acos",       0x1B4,  St, GOP_Float, 2 },
+    { (uchar *) "atan",       0x1B5,  St, GOP_Float, 2 },
+    { (uchar *) "atan2",      0x1B6,  St, GOP_Float, 3 },
+    { (uchar *) "jfeq",       0x1C0,  Br, GOP_Float, 4 },
+    { (uchar *) "jfne",       0x1C1,  Br, GOP_Float, 4 },
+    { (uchar *) "jflt",       0x1C2,  Br, GOP_Float, 3 },
+    { (uchar *) "jfle",       0x1C3,  Br, GOP_Float, 3 },
+    { (uchar *) "jfgt",       0x1C4,  Br, GOP_Float, 3 },
+    { (uchar *) "jfge",       0x1C5,  Br, GOP_Float, 3 },
+    { (uchar *) "jisnan",     0x1C8,  Br, GOP_Float, 2 },
+    { (uchar *) "jisinf",     0x1C9,  Br, GOP_Float, 2 },
+    { (uchar *) "numtod",     0x200,  St|St2, GOP_Double, 3 },
+    { (uchar *) "dtonumz",    0x201,  St, GOP_Double, 3 },
+    { (uchar *) "dtonumn",    0x202,  St, GOP_Double, 3 },
+    { (uchar *) "ftod",       0x203,  St|St2, GOP_Double, 3 },
+    { (uchar *) "dtof",       0x204,  St, GOP_Double, 3 },
+    { (uchar *) "dceil",      0x208,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dfloor",     0x209,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dadd",       0x210,  St|St2, GOP_Double, 6 },
+    { (uchar *) "dsub",       0x211,  St|St2, GOP_Double, 6 },
+    { (uchar *) "dmul",       0x212,  St|St2, GOP_Double, 6 },
+    { (uchar *) "ddiv",       0x213,  St|St2, GOP_Double, 6 },
+    { (uchar *) "dmodr",      0x214,  St|St2, GOP_Double, 6 },
+    { (uchar *) "dmodq",      0x215,  St|St2, GOP_Double, 6 },
+    { (uchar *) "dsqrt",      0x218,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dexp",       0x219,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dlog",       0x21A,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dpow",       0x21B,  St|St2, GOP_Double, 6 },
+    { (uchar *) "dsin",       0x220,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dcos",       0x221,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dtan",       0x222,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dasin",      0x223,  St|St2, GOP_Double, 4 },
+    { (uchar *) "dacos",      0x224,  St|St2, GOP_Double, 4 },
+    { (uchar *) "datan",      0x225,  St|St2, GOP_Double, 4 },
+    { (uchar *) "datan2",     0x226,  St|St2, GOP_Double, 6 },
+    { (uchar *) "jdeq",       0x230,  Br, GOP_Double, 7 },
+    { (uchar *) "jdne",       0x231,  Br, GOP_Double, 7 },
+    { (uchar *) "jdlt",       0x232,  Br, GOP_Double, 5 },
+    { (uchar *) "jdle",       0x233,  Br, GOP_Double, 5 },
+    { (uchar *) "jdgt",       0x234,  Br, GOP_Double, 5 },
+    { (uchar *) "jdge",       0x235,  Br, GOP_Double, 5 },
+    { (uchar *) "jdisnan",    0x238,  Br, GOP_Double, 3 },
+    { (uchar *) "jdisinf",    0x239,  Br, GOP_Double, 3 },
 };
 
 /* The opmacros table is used for fake opcodes. The opcode numbers are
    ignored; this table is only used for argument parsing. */
 static opcodeg opmacros_table_g[] = {
-  { (uchar *) "pull",   pull_gm,       St, 0, 1 },
-  { (uchar *) "push",   push_gm,        0, 0, 1 },
-  { (uchar *) "dload",  dload_gm,  St|St2, 0, 3 },
-  { (uchar *) "dstore", dstore_gm,      0, 0, 3 },
+    { (uchar *) "pull",   pull_gm,       St, 0, 1 },
+    { (uchar *) "push",   push_gm,        0, 0, 1 },
+    { (uchar *) "dload",  dload_gm,  St|St2, 0, 3 },
+    { (uchar *) "dstore", dstore_gm,      0, 0, 3 },
 };
 
 static opcodeg custom_opcode_g;
@@ -1459,17 +1459,17 @@ extern void assembleg_instruction(const assembly_instruction *AI)
     start_pc = zcode_ha_size; 
 
     if (opco.code < 0x80) {
-      byteout(opco.code, 0);
+        byteout(opco.code, 0);
     }
     else if (opco.code < 0x4000) {
-      byteout(((opco.code >> 8) & 0xFF) | 0x80, 0);
-      byteout((opco.code & 0xFF), 0);
+        byteout(((opco.code >> 8) & 0xFF) | 0x80, 0);
+        byteout((opco.code & 0xFF), 0);
     }
     else {
-      byteout(((opco.code >> 24) & 0xFF) | 0xC0, 0);
-      byteout(((opco.code >> 16) & 0xFF), 0);
-      byteout(((opco.code >> 8) & 0xFF), 0);
-      byteout(((opco.code) & 0xFF), 0);
+        byteout(((opco.code >> 24) & 0xFF) | 0xC0, 0);
+        byteout(((opco.code >> 16) & 0xFF), 0);
+        byteout(((opco.code >> 8) & 0xFF), 0);
+        byteout(((opco.code) & 0xFF), 0);
     }
 
     /* ... and the operand addressing modes. There's one byte for
@@ -1479,7 +1479,7 @@ extern void assembleg_instruction(const assembly_instruction *AI)
     opmodes_pc = zcode_ha_size;
 
     for (ix=0; ix<opco.no; ix+=2) {
-      byteout(0, 0);
+        byteout(0, 0);
     }
 
     /* 2. Dispose of the special rules */
@@ -1488,7 +1488,7 @@ extern void assembleg_instruction(const assembly_instruction *AI)
     /* 3. Sort out the operands */
 
     if (no_operands_given != opco.no) {
-      goto OpcodeSyntaxError;
+        goto OpcodeSyntaxError;
     }
 
     for (ix=0; ix<no_operands_given; ix++) {
@@ -1528,167 +1528,167 @@ extern void assembleg_instruction(const assembly_instruction *AI)
                 }
             }
         }
-    if ((opco.flags & St) 
-      && ((!(opco.flags & Br) && (ix == no_operands_given-1))
-      || ((opco.flags & Br) && (ix == no_operands_given-2)))) {
-        if (type == BYTECONSTANT_OT || type == HALFCONSTANT_OT
-            || type == CONSTANT_OT) {
-            error("*** instruction tried to store to a constant ***");
-            goto OpcodeSyntaxError; 
+        if ((opco.flags & St) 
+            && ((!(opco.flags & Br) && (ix == no_operands_given-1))
+                || ((opco.flags & Br) && (ix == no_operands_given-2)))) {
+            if (type == BYTECONSTANT_OT || type == HALFCONSTANT_OT
+                || type == CONSTANT_OT) {
+                error("*** instruction tried to store to a constant ***");
+                goto OpcodeSyntaxError; 
+            }
         }
-    }
-    if ((opco.flags & St2) 
-        && (ix == no_operands_given-2)) {
-        if (type == BYTECONSTANT_OT || type == HALFCONSTANT_OT
-          || type == CONSTANT_OT) {
-          error("*** instruction tried to store to a constant ***");
-          goto OpcodeSyntaxError; 
-        }
-    }
-
-      if (marker && (type == HALFCONSTANT_OT 
-        || type == BYTECONSTANT_OT
-        || type == ZEROCONSTANT_OT)) {
-        compiler_error("Assembling marker in less than 32-bit constant.");
-        /* Actually we should store marker|0x80 for a byte constant,
-           but let's hold off on that. */
+        if ((opco.flags & St2) 
+            && (ix == no_operands_given-2)) {
+            if (type == BYTECONSTANT_OT || type == HALFCONSTANT_OT
+                || type == CONSTANT_OT) {
+                error("*** instruction tried to store to a constant ***");
+                goto OpcodeSyntaxError; 
+            }
         }
 
-      switch (type) {
-      case LONG_CONSTANT_OT:
-      case SHORT_CONSTANT_OT:
-      case VARIABLE_OT:
-        j = 0;
-        compiler_error("Z-code OT in Glulx assembly operand.");
-        break;
-      case CONSTANT_OT:
-        j = 3;
-        byteout((k >> 24) & 0xFF, marker);
-        byteout((k >> 16) & 0xFF, 0);
-        byteout((k >> 8) & 0xFF, 0);
-        byteout((k & 0xFF), 0);
-        break;
-      case HALFCONSTANT_OT:
-        j = 2;
-        byteout((k >> 8) & 0xFF, marker);
-        byteout((k & 0xFF), 0);
-        break;
-      case BYTECONSTANT_OT:
-        j = 1;
-        byteout((k & 0xFF), marker);
-        break;
-      case ZEROCONSTANT_OT:
-        j = 0;
-        break;
-      case DEREFERENCE_OT:
-        j = 7;
-        byteout((k >> 24) & 0xFF, marker);
-        byteout((k >> 16) & 0xFF, 0);
-        byteout((k >> 8) & 0xFF, 0);
-        byteout((k & 0xFF), 0);
-        break;
-      case GLOBALVAR_OT:
-        /* Global variable -- a constant address. */
-        k -= MAX_LOCAL_VARIABLES;
-        if (/* DISABLES CODE */ (0)) {
-            /* We could write the value as a marker and patch it later... */
+        if (marker && (type == HALFCONSTANT_OT 
+                       || type == BYTECONSTANT_OT
+                       || type == ZEROCONSTANT_OT)) {
+            compiler_error("Assembling marker in less than 32-bit constant.");
+            /* Actually we should store marker|0x80 for a byte constant,
+               but let's hold off on that. */
+        }
+
+        switch (type) {
+        case LONG_CONSTANT_OT:
+        case SHORT_CONSTANT_OT:
+        case VARIABLE_OT:
+            j = 0;
+            compiler_error("Z-code OT in Glulx assembly operand.");
+            break;
+        case CONSTANT_OT:
+            j = 3;
+            byteout((k >> 24) & 0xFF, marker);
+            byteout((k >> 16) & 0xFF, 0);
+            byteout((k >> 8) & 0xFF, 0);
+            byteout((k & 0xFF), 0);
+            break;
+        case HALFCONSTANT_OT:
+            j = 2;
+            byteout((k >> 8) & 0xFF, marker);
+            byteout((k & 0xFF), 0);
+            break;
+        case BYTECONSTANT_OT:
+            j = 1;
+            byteout((k & 0xFF), marker);
+            break;
+        case ZEROCONSTANT_OT:
+            j = 0;
+            break;
+        case DEREFERENCE_OT:
             j = 7;
-            byteout(((k) >> 24) & 0xFF, VARIABLE_MV);
-            byteout(((k) >> 16) & 0xFF, 0);
-            byteout(((k) >> 8) & 0xFF, 0);
-            byteout(((k) & 0xFF), 0);
-        }
-        else {
-            /* ...but it's more efficient to write it as a RAM operand,
-                  which can be 1, 2, or 4 bytes. Remember that global variables
-                  are the very first thing in RAM. */
-            k = k * 4; /* each variable is four bytes */
-            if (k <= 255) {
-                j = 13;
-                byteout(((k) & 0xFF), 0);
-            }
-            else if (k <= 65535) {
-                j = 14;
-                byteout(((k) >> 8) & 0xFF, 0);
-                byteout(((k) & 0xFF), 0);
-            }
-            else {
-                j = 15;
-                byteout(((k) >> 24) & 0xFF, 0);
+            byteout((k >> 24) & 0xFF, marker);
+            byteout((k >> 16) & 0xFF, 0);
+            byteout((k >> 8) & 0xFF, 0);
+            byteout((k & 0xFF), 0);
+            break;
+        case GLOBALVAR_OT:
+            /* Global variable -- a constant address. */
+            k -= MAX_LOCAL_VARIABLES;
+            if (/* DISABLES CODE */ (0)) {
+                /* We could write the value as a marker and patch it later... */
+                j = 7;
+                byteout(((k) >> 24) & 0xFF, VARIABLE_MV);
                 byteout(((k) >> 16) & 0xFF, 0);
                 byteout(((k) >> 8) & 0xFF, 0);
-                byteout(((k) & 0xFF), 0);       
-            }
-        }
-        break;
-      case LOCALVAR_OT:
-        if (k == 0) {
-            /* Stack-pointer magic variable */
-            j = 8; 
-        }
-        else {
-            /* Local variable -- a byte or short offset from the
-               frame pointer. It's an unsigned offset, so we can
-               fit up to long 63 (offset 4*63) in a byte. */
-            if ((k-1) < 64) {
-                j = 9;
-                byteout((k-1)*4, 0);
+                byteout(((k) & 0xFF), 0);
             }
             else {
-                j = 10;
-                byteout((((k-1)*4) >> 8) & 0xFF, 0);
-                byteout(((k-1)*4) & 0xFF, 0);
+                /* ...but it's more efficient to write it as a RAM operand,
+                   which can be 1, 2, or 4 bytes. Remember that global variables
+                   are the very first thing in RAM. */
+                k = k * 4; /* each variable is four bytes */
+                if (k <= 255) {
+                    j = 13;
+                    byteout(((k) & 0xFF), 0);
+                }
+                else if (k <= 65535) {
+                    j = 14;
+                    byteout(((k) >> 8) & 0xFF, 0);
+                    byteout(((k) & 0xFF), 0);
+                }
+                else {
+                    j = 15;
+                    byteout(((k) >> 24) & 0xFF, 0);
+                    byteout(((k) >> 16) & 0xFF, 0);
+                    byteout(((k) >> 8) & 0xFF, 0);
+                    byteout(((k) & 0xFF), 0);       
+                }
             }
+            break;
+        case LOCALVAR_OT:
+            if (k == 0) {
+                /* Stack-pointer magic variable */
+                j = 8; 
+            }
+            else {
+                /* Local variable -- a byte or short offset from the
+                   frame pointer. It's an unsigned offset, so we can
+                   fit up to long 63 (offset 4*63) in a byte. */
+                if ((k-1) < 64) {
+                    j = 9;
+                    byteout((k-1)*4, 0);
+                }
+                else {
+                    j = 10;
+                    byteout((((k-1)*4) >> 8) & 0xFF, 0);
+                    byteout(((k-1)*4) & 0xFF, 0);
+                }
+            }
+            break;
+        default:
+            j = 0;
+            break;
         }
-        break;
-      default:
-        j = 0;
-        break;
-      }
 
-      if (ix & 1)
-          j = (j << 4);
-      zcode_holding_area[opmodes_pc+ix/2] |= j;
+        if (ix & 1)
+            j = (j << 4);
+        zcode_holding_area[opmodes_pc+ix/2] |= j;
     }
 
     /* Print assembly trace. */
     if (asm_trace_level > 0) {
-      int i;
-      printf("%5d  +%05lx %3s %-12s ", ErrorReport.line_number,
-        ((long int) offset),
-        (at_seq_point)?"<*>":"   ", opco.name);
-      for (i=0; i<AI->operand_count; i++) {
-          if ((opco.flags & Br) && (i == opco.no-1)) {
-            if (AI->operand[i].value == -4)
-                printf("to rtrue");
-            else if (AI->operand[i].value == -3)
-                printf("to rfalse");
-            else
-                printf("to L%d", AI->operand[i].value);
-            }
-          else {
-            print_operand_g(&AI->operand[i], TRUE);
-          }
-          printf(" ");
-      }
-
-      if (asm_trace_level>=2) {
-        for (j=0;
-            start_pc<zcode_ha_size;
-            j++, start_pc++) {
-            if (j%16==0) printf("\n                               ");
-            if (/* DISABLES CODE */ (0)) {
-                printf("%02x ", zcode_holding_area[start_pc]);
+        int i;
+        printf("%5d  +%05lx %3s %-12s ", ErrorReport.line_number,
+               ((long int) offset),
+               (at_seq_point)?"<*>":"   ", opco.name);
+        for (i=0; i<AI->operand_count; i++) {
+            if ((opco.flags & Br) && (i == opco.no-1)) {
+                if (AI->operand[i].value == -4)
+                    printf("to rtrue");
+                else if (AI->operand[i].value == -3)
+                    printf("to rfalse");
+                else
+                    printf("to L%d", AI->operand[i].value);
             }
             else {
-                if (zcode_markers[start_pc])
-                    printf("{%s}", describe_mv_short(zcode_markers[start_pc]));
-                printf("%02x", zcode_holding_area[start_pc]);
-                printf(" ");
+                print_operand_g(&AI->operand[i], TRUE);
+            }
+            printf(" ");
+        }
+
+        if (asm_trace_level>=2) {
+            for (j=0;
+                 start_pc<zcode_ha_size;
+                 j++, start_pc++) {
+                if (j%16==0) printf("\n                               ");
+                if (/* DISABLES CODE */ (0)) {
+                    printf("%02x ", zcode_holding_area[start_pc]);
+                }
+                else {
+                    if (zcode_markers[start_pc])
+                        printf("{%s}", describe_mv_short(zcode_markers[start_pc]));
+                    printf("%02x", zcode_holding_area[start_pc]);
+                    printf(" ");
+                }
             }
         }
-      }
-      printf("\n");
+        printf("\n");
     }
 
     return;
@@ -1813,186 +1813,186 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
     /*  provide the possibility in any case.)                                */
 
     if (!glulx_mode) {
+        
+        if (stackargs) 
+            warning("Z-code does not support stack-argument function definitions.");
 
-      if (stackargs) 
-        warning("Z-code does not support stack-argument function definitions.");
+        byteout(no_locals, 0);
 
-      byteout(no_locals, 0);
+        /*  Not the packed address, but the scaled offset from code area start:  */
 
-      /*  Not the packed address, but the scaled offset from code area start:  */
+        rv = zmachine_pc/scale_factor;
 
-      rv = zmachine_pc/scale_factor;
+        if (instruction_set_number<5)
+            for (i=0; i<no_locals; i++) { byteout(0,0); byteout(0,0); }
 
-      if (instruction_set_number<5)
-          for (i=0; i<no_locals; i++) { byteout(0,0); byteout(0,0); }
+        next_label = 0; next_sequence_point = 0; last_label = -1;
+        labeluse_size = 0;
 
-      next_label = 0; next_sequence_point = 0; last_label = -1;
-      labeluse_size = 0;
+        /*  Compile code to print out text like "a=3, b=4, c=5" when the     */
+        /*  function is called, if it's required.                            */
 
-      /*  Compile code to print out text like "a=3, b=4, c=5" when the       */
-      /*  function is called, if it's required.                              */
-
-      if ((routine_asterisked) || (define_INFIX_switch))
-      {   char fnt[256]; assembly_operand PV, RFA, CON, STP, SLF; int ln, ln2;
-          /* TODO: fnt[256] is unsafe */
+        if ((routine_asterisked) || (define_INFIX_switch))
+        {   char fnt[256]; assembly_operand PV, RFA, CON, STP, SLF; int ln, ln2;
+            /* TODO: fnt[256] is unsafe */
           
-          ln = next_label++;
-          ln2 = next_label++;
-
-          if (define_INFIX_switch)
-          {
-            if (embedded_flag)
+            ln = next_label++;
+            ln2 = next_label++;
+          
+            if (define_INFIX_switch)
             {
-                INITAOTV(&SLF, VARIABLE_OT, globalv_z_self);
-                INITAOTV(&CON, SHORT_CONSTANT_OT, 0);
-                assemblez_2_branch(test_attr_zc, SLF, CON, ln2, FALSE);
+                if (embedded_flag)
+                {
+                    INITAOTV(&SLF, VARIABLE_OT, globalv_z_self);
+                    INITAOTV(&CON, SHORT_CONSTANT_OT, 0);
+                    assemblez_2_branch(test_attr_zc, SLF, CON, ln2, FALSE);
+                }
+                else
+                {   i = no_named_routines++;
+                    ensure_memory_list_available(&named_routine_symbols_memlist, no_named_routines);
+                    named_routine_symbols[i] = the_symbol;
+                    INITAOTV(&CON, LONG_CONSTANT_OT, i/8);
+                    INITAOTV(&RFA, LONG_CONSTANT_OT, routine_flags_array_SC);
+                    RFA.marker = INCON_MV;
+                    INITAOTV(&STP, VARIABLE_OT, 0);
+                    assemblez_2_to(loadb_zc, RFA, CON, STP);
+                    INITAOTV(&CON, SHORT_CONSTANT_OT, (1 << (i%8)));
+                    assemblez_2_to(and_zc, STP, CON, STP);
+                    assemblez_1_branch(jz_zc, STP, ln2, TRUE);
+                }
             }
-            else
-            {   i = no_named_routines++;
-                ensure_memory_list_available(&named_routine_symbols_memlist, no_named_routines);
-                named_routine_symbols[i] = the_symbol;
-                INITAOTV(&CON, LONG_CONSTANT_OT, i/8);
-                INITAOTV(&RFA, LONG_CONSTANT_OT, routine_flags_array_SC);
-                RFA.marker = INCON_MV;
-                INITAOTV(&STP, VARIABLE_OT, 0);
-                assemblez_2_to(loadb_zc, RFA, CON, STP);
-                INITAOTV(&CON, SHORT_CONSTANT_OT, (1 << (i%8)));
-                assemblez_2_to(and_zc, STP, CON, STP);
-                assemblez_1_branch(jz_zc, STP, ln2, TRUE);
-            }
-        }
-        sprintf(fnt, "[ %s(", name);
-        AI.text = fnt; assemblez_0(print_zc);
-        for (i=1; (i<=7)&&(i<=no_locals); i++)
-        {   if (version_number >= 5)
-            {
-                INITAOTV(&PV, SHORT_CONSTANT_OT, i);
-                assemblez_1_branch(check_arg_count_zc, PV, ln, FALSE);
-            }
-            sprintf(fnt, "%s%s = ", (i==1)?"":", ", variable_name(i));
+            sprintf(fnt, "[ %s(", name);
             AI.text = fnt; assemblez_0(print_zc);
-            INITAOTV(&PV, VARIABLE_OT, i);
-            assemblez_1(print_num_zc, PV);
+            for (i=1; (i<=7)&&(i<=no_locals); i++)
+            {   if (version_number >= 5)
+                {
+                    INITAOTV(&PV, SHORT_CONSTANT_OT, i);
+                    assemblez_1_branch(check_arg_count_zc, PV, ln, FALSE);
+                }
+                sprintf(fnt, "%s%s = ", (i==1)?"":", ", variable_name(i));
+                AI.text = fnt; assemblez_0(print_zc);
+                INITAOTV(&PV, VARIABLE_OT, i);
+                assemblez_1(print_num_zc, PV);
+            }
+            assemble_label_no(ln);
+            sprintf(fnt, ") ]^"); AI.text = fnt;
+            assemblez_0(print_zc);
+            AI.text = NULL;
+            assemble_label_no(ln2);
         }
-        assemble_label_no(ln);
-        sprintf(fnt, ") ]^"); AI.text = fnt;
-        assemblez_0(print_zc);
-        AI.text = NULL;
-        assemble_label_no(ln2);
-      }
-
+        
     }
     else {
-      rv = zmachine_pc;
+        rv = zmachine_pc;
 
-      if (stackargs)
-        byteout(0xC0, 0); /* Glulx type byte for function */
-      else
-        byteout(0xC1, 0); /* Glulx type byte for function */
+        if (stackargs)
+            byteout(0xC0, 0); /* Glulx type byte for function */
+        else
+            byteout(0xC1, 0); /* Glulx type byte for function */
 
-      /* Now the locals format list. This is simple; we only use
-        four-byte locals. That's a single pair, unless we have more
-        than 255 locals, or none at all. */
-      i = no_locals;
-      while (i) {
-        int j = i;
-        if (j > 255)
-          j = 255;
-        byteout(4, 0); 
-        byteout(j, 0);
-        i -= j;
-      }
-      /* Terminate the list with a (0, 0) pair. */
-      byteout(0, 0);
-      byteout(0, 0);
-
-      if (stackargs) {
-        /* The top stack value is the number of function arguments. Let's
-           move that into the first local, which is _vararg_count. */
-        /* @copy sp _vararg_count; */
-        byteout(0x40, 0); byteout(0x98, 0); byteout(0x00, 0);
-      }
-
-      next_label = 0; next_sequence_point = 0; last_label = -1; 
-      labeluse_size = 0;
-
-      if ((routine_asterisked) || (define_INFIX_switch)) {
-        int ix;
-        char fnt[256];
-        assembly_operand AO, AO2;
-        if (define_INFIX_switch) {
-          /* This isn't supported */
-          if (embedded_flag) {
-          }
-          else {
-            i = no_named_routines++;
-            ensure_memory_list_available(&named_routine_symbols_memlist, no_named_routines);
-            named_routine_symbols[i] = the_symbol;
-          }
+        /* Now the locals format list. This is simple; we only use
+           four-byte locals. That's a single pair, unless we have more
+           than 255 locals, or none at all. */
+        i = no_locals;
+        while (i) {
+            int j = i;
+            if (j > 255)
+                j = 255;
+            byteout(4, 0); 
+            byteout(j, 0);
+            i -= j;
         }
-        INITAO(&AO);
-        INITAO(&AO2);
-        sprintf(fnt, "[ %s(", name);
-        AO.marker = STRING_MV;
-        AO.type   = CONSTANT_OT;
-        AO.value  = compile_string(fnt, STRCTX_INFIX);
-        assembleg_1(streamstr_gc, AO);
+        /* Terminate the list with a (0, 0) pair. */
+        byteout(0, 0);
+        byteout(0, 0);
 
-        if (!stackargs) {
-          for (ix=1; ix<=no_locals; ix++) {
-            sprintf(fnt, "%s%s = ", (ix==1)?"":", ", variable_name(ix));
+        if (stackargs) {
+            /* The top stack value is the number of function arguments. Let's
+               move that into the first local, which is _vararg_count. */
+            /* @copy sp _vararg_count; */
+            byteout(0x40, 0); byteout(0x98, 0); byteout(0x00, 0);
+        }
+
+        next_label = 0; next_sequence_point = 0; last_label = -1; 
+        labeluse_size = 0;
+
+        if ((routine_asterisked) || (define_INFIX_switch)) {
+            int ix;
+            char fnt[256];
+            assembly_operand AO, AO2;
+            if (define_INFIX_switch) {
+                /* This isn't supported */
+                if (embedded_flag) {
+                }
+                else {
+                    i = no_named_routines++;
+                    ensure_memory_list_available(&named_routine_symbols_memlist, no_named_routines);
+                    named_routine_symbols[i] = the_symbol;
+                }
+            }
+            INITAO(&AO);
+            INITAO(&AO2);
+            sprintf(fnt, "[ %s(", name);
             AO.marker = STRING_MV;
             AO.type   = CONSTANT_OT;
             AO.value  = compile_string(fnt, STRCTX_INFIX);
             assembleg_1(streamstr_gc, AO);
-            AO.marker = 0;
-            AO.type = LOCALVAR_OT;
-            AO.value = ix;
-            assembleg_1(streamnum_gc, AO);
-          }
-        }
-        else {
-          int lntop, lnbottom;
-          sprintf(fnt, "%s = ", variable_name(1));
-          AO.marker = STRING_MV;
-          AO.type   = CONSTANT_OT;
-          AO.value  = compile_string(fnt, STRCTX_INFIX);
-          assembleg_1(streamstr_gc, AO);
-          AO.marker = 0;
-          AO.type = LOCALVAR_OT;
-          AO.value = 1;
-          assembleg_1(streamnum_gc, AO);
-          AO2.type = BYTECONSTANT_OT;
-          AO2.marker = 0;
-          AO2.value = ':';
-          assembleg_1(streamchar_gc, AO2);
-          AO2.type = BYTECONSTANT_OT;
-          AO2.marker = 0;
-          AO2.value = ' ';
-          /* for (temp_var4=0 : temp_var4<_vararg_count : temp_var4++) {
-               @streamchar ' ';
-               @stkpeek temp_var4 sp;
-               @stream_num sp;
-             }
-          */
-          assembleg_store(temp_var4, zero_operand);
-          lntop = next_label++;
-          lnbottom = next_label++;
-          assemble_label_no(lntop);
-          assembleg_2_branch(jge_gc, temp_var4, AO, lnbottom); /* AO is _vararg_count */
-          assembleg_1(streamchar_gc, AO2); /* AO2 is space */
-          assembleg_2(stkpeek_gc, temp_var4, stack_pointer);
-          assembleg_1(streamnum_gc, stack_pointer);
-          assembleg_3(add_gc, temp_var4, one_operand, temp_var4);
-          assembleg_0_branch(jump_gc, lntop);
-          assemble_label_no(lnbottom);
-        }
 
-        AO.marker = STRING_MV;
-        AO.type   = CONSTANT_OT;
-        AO.value  = compile_string(") ]^", STRCTX_INFIX);
-        assembleg_1(streamstr_gc, AO);
-      }
+            if (!stackargs) {
+                for (ix=1; ix<=no_locals; ix++) {
+                    sprintf(fnt, "%s%s = ", (ix==1)?"":", ", variable_name(ix));
+                    AO.marker = STRING_MV;
+                    AO.type   = CONSTANT_OT;
+                    AO.value  = compile_string(fnt, STRCTX_INFIX);
+                    assembleg_1(streamstr_gc, AO);
+                    AO.marker = 0;
+                    AO.type = LOCALVAR_OT;
+                    AO.value = ix;
+                    assembleg_1(streamnum_gc, AO);
+                }
+            }
+            else {
+                int lntop, lnbottom;
+                sprintf(fnt, "%s = ", variable_name(1));
+                AO.marker = STRING_MV;
+                AO.type   = CONSTANT_OT;
+                AO.value  = compile_string(fnt, STRCTX_INFIX);
+                assembleg_1(streamstr_gc, AO);
+                AO.marker = 0;
+                AO.type = LOCALVAR_OT;
+                AO.value = 1;
+                assembleg_1(streamnum_gc, AO);
+                AO2.type = BYTECONSTANT_OT;
+                AO2.marker = 0;
+                AO2.value = ':';
+                assembleg_1(streamchar_gc, AO2);
+                AO2.type = BYTECONSTANT_OT;
+                AO2.marker = 0;
+                AO2.value = ' ';
+                /* for (temp_var4=0 : temp_var4<_vararg_count : temp_var4++) {
+                   @streamchar ' ';
+                   @stkpeek temp_var4 sp;
+                   @stream_num sp;
+                   }
+                */
+                assembleg_store(temp_var4, zero_operand);
+                lntop = next_label++;
+                lnbottom = next_label++;
+                assemble_label_no(lntop);
+                assembleg_2_branch(jge_gc, temp_var4, AO, lnbottom); /* AO is _vararg_count */
+                assembleg_1(streamchar_gc, AO2); /* AO2 is space */
+                assembleg_2(stkpeek_gc, temp_var4, stack_pointer);
+                assembleg_1(streamnum_gc, stack_pointer);
+                assembleg_3(add_gc, temp_var4, one_operand, temp_var4);
+                assembleg_0_branch(jump_gc, lntop);
+                assemble_label_no(lnbottom);
+            }
+
+            AO.marker = STRING_MV;
+            AO.type   = CONSTANT_OT;
+            AO.value  = compile_string(") ]^", STRCTX_INFIX);
+            assembleg_1(streamstr_gc, AO);
+        }
     }
 
     return rv;
@@ -2010,27 +2010,27 @@ void assemble_routine_end(int embedded_flag, debug_locations locations)
 
     if (!execution_never_reaches_here)
     {   
-      if (!glulx_mode) {
-        if (embedded_flag) assemblez_0(rfalse_zc);
-                      else assemblez_0(rtrue_zc);
-      }
-      else {
-        assembly_operand AO;
-        if (embedded_flag) 
-            AO = zero_operand;
-        else 
-            AO = one_operand;
-        assembleg_1(return_gc, AO);
-      }
+        if (!glulx_mode) {
+            if (embedded_flag) assemblez_0(rfalse_zc);
+            else assemblez_0(rtrue_zc);
+        }
+        else {
+            assembly_operand AO;
+            if (embedded_flag) 
+                AO = zero_operand;
+            else 
+                AO = one_operand;
+            assembleg_1(return_gc, AO);
+        }
     }
-
+    
     /* Dump the contents of the current routine into longer-term Z-code
        storage                                                               */
 
     if (!glulx_mode)
-      transfer_routine_z();
+        transfer_routine_z();
     else
-      transfer_routine_g();
+        transfer_routine_g();
 
     if (track_unused_routines)
         df_note_function_end(zmachine_pc);
@@ -2455,26 +2455,26 @@ static void transfer_routine_g(void)
             (if two labels move inside the "short" range as a result of
             a previous optimisation).  However, this is acceptably uncommon. */
     if (next_label > 0) {
-      if (asm_trace_level >= 4) {
-        printf("Opening label: %d\n", first_label);
-        for (i=0;i<next_label;i++)
-            printf("Label %d offset %04x next -> %d previous -> %d\n",
-                i, labels[i].offset, labels[i].next, labels[i].prev);
-      }
-
-      /* label will advance through the linked list as pc increases. */
-      for (i=0, pc=adjusted_pc, new_pc=adjusted_pc, label = first_label;
-        i<zcode_ha_size; 
-        i++, pc++) {
-        while ((label != -1) && (labels[label].offset == pc)) {
-            if (asm_trace_level >= 4)
-                printf("Position of L%d corrected from %04x to %04x\n",
-                label, labels[label].offset, new_pc);
-            labels[label].offset = new_pc;
-            label = labels[label].next;
+        if (asm_trace_level >= 4) {
+            printf("Opening label: %d\n", first_label);
+            for (i=0;i<next_label;i++)
+                printf("Label %d offset %04x next -> %d previous -> %d\n",
+                       i, labels[i].offset, labels[i].next, labels[i].prev);
         }
-        if (zcode_markers[i] != DELETED_MV) new_pc++;
-      }
+
+        /* label will advance through the linked list as pc increases. */
+        for (i=0, pc=adjusted_pc, new_pc=adjusted_pc, label = first_label;
+             i<zcode_ha_size; 
+             i++, pc++) {
+            while ((label != -1) && (labels[label].offset == pc)) {
+                if (asm_trace_level >= 4)
+                    printf("Position of L%d corrected from %04x to %04x\n",
+                           label, labels[label].offset, new_pc);
+                labels[label].offset = new_pc;
+                label = labels[label].next;
+            }
+            if (zcode_markers[i] != DELETED_MV) new_pc++;
+        }
     }
 
     /*  (3) As we are transferring, replace the label numbers in branch
@@ -3059,41 +3059,41 @@ void assembleg_2_branch(int internal_number,
 }
 
 void assembleg_call_1(assembly_operand oaddr, assembly_operand o1, 
-  assembly_operand odest)
+    assembly_operand odest)
 {
-  assembleg_3(callfi_gc, oaddr, o1, odest);
+    assembleg_3(callfi_gc, oaddr, o1, odest);
 }
 
 void assembleg_call_2(assembly_operand oaddr, assembly_operand o1, 
-  assembly_operand o2, assembly_operand odest)
+    assembly_operand o2, assembly_operand odest)
 {
-  assembleg_4(callfii_gc, oaddr, o1, o2, odest);
+    assembleg_4(callfii_gc, oaddr, o1, o2, odest);
 }
 
 void assembleg_call_3(assembly_operand oaddr, assembly_operand o1, 
-  assembly_operand o2, assembly_operand o3, assembly_operand odest)
+    assembly_operand o2, assembly_operand o3, assembly_operand odest)
 {
-  assembleg_5(callfiii_gc, oaddr, o1, o2, o3, odest);
+    assembleg_5(callfiii_gc, oaddr, o1, o2, o3, odest);
 }
 
 void assembleg_inc(assembly_operand o1)
 {
-  AI.internal_number = add_gc;
-  AI.operand_count = 3;
-  AI.operand[0] = o1;
-  AI.operand[1] = one_operand;
-  AI.operand[2] = o1;
-  assembleg_instruction(&AI);
+    AI.internal_number = add_gc;
+    AI.operand_count = 3;
+    AI.operand[0] = o1;
+    AI.operand[1] = one_operand;
+    AI.operand[2] = o1;
+    assembleg_instruction(&AI);
 }
 
 void assembleg_dec(assembly_operand o1)
 {
-  AI.internal_number = sub_gc;
-  AI.operand_count = 3;
-  AI.operand[0] = o1;
-  AI.operand[1] = one_operand;
-  AI.operand[2] = o1;
-  assembleg_instruction(&AI);
+    AI.internal_number = sub_gc;
+    AI.operand_count = 3;
+    AI.operand[0] = o1;
+    AI.operand[1] = one_operand;
+    AI.operand[2] = o1;
+    assembleg_instruction(&AI);
 }
 
 void assembleg_store(assembly_operand o1, assembly_operand o2)
@@ -3104,15 +3104,15 @@ void assembleg_store(assembly_operand o1, assembly_operand o2)
 
 void assembleg_jump(int n)
 {
-  if (n==-4) {
-      assembleg_1(return_gc, one_operand);
-  }
-  else if (n==-3) {
-      assembleg_1(return_gc, zero_operand); 
-  }
-  else {
-      assembleg_0_branch(jump_gc, n);
-  }
+    if (n==-4) {
+        assembleg_1(return_gc, one_operand);
+    }
+    else if (n==-3) {
+        assembleg_1(return_gc, zero_operand); 
+    }
+    else {
+        assembleg_0_branch(jump_gc, n);
+    }
 }
 
 /* ========================================================================= */
@@ -3709,10 +3709,10 @@ S (store), SS (two stores), R (execution never continues)");
 
 extern void parse_assembly(void)
 {
-  if (!glulx_mode)
-    parse_assembly_z();
-  else
-    parse_assembly_g();
+    if (!glulx_mode)
+        parse_assembly_z();
+    else
+        parse_assembly_g();
 }
 
 /* ========================================================================= */

--- a/asm.c
+++ b/asm.c
@@ -1315,8 +1315,8 @@ static void assembleg_macro(const assembly_instruction *AI)
     for (ix = 0; ix < no_operands_given; ix++) {
         int type = AI->operand[ix].type;
         if ((opco.flags & St) 
-          && ((!(opco.flags & Br) && (ix == no_operands_given-1))
-          || ((opco.flags & Br) && (ix == no_operands_given-2)))) {
+            && ((!(opco.flags & Br) && (ix == no_operands_given-1))
+            || ((opco.flags & Br) && (ix == no_operands_given-2)))) {
             if (is_constant_ot(type)) {
                 error("*** assembly macro tried to store to a constant ***");
                 goto OpcodeSyntaxError; 
@@ -3026,12 +3026,12 @@ void assembleg_1_branch(int internal_number,
        to zero. */
     if (o1.marker == 0 && is_constant_ot(o1.type)) {
         if ((internal_number == jz_gc && o1.value == 0)
-          || (internal_number == jnz_gc && o1.value != 0)) {
+            || (internal_number == jnz_gc && o1.value != 0)) {
             assembleg_0_branch(jump_gc, label);
             return;
         }
         if ((internal_number == jz_gc && o1.value != 0)
-          || (internal_number == jnz_gc && o1.value == 0)) {
+            || (internal_number == jnz_gc && o1.value == 0)) {
             /* assemble nothing at all! */
             return;
         }

--- a/asm.c
+++ b/asm.c
@@ -2397,54 +2397,54 @@ static void transfer_routine_g(void)
             lengths is too much work.) */
 
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++) {
-      if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV) {
-        int opmodeoffset = (zcode_markers[i] - BRANCH_MV);
-        int32 opmodebyte;
-        if (asm_trace_level >= 4)
-            printf("Branch detected at offset %04x\n", pc);
-        j = ((zcode_holding_area[i] << 24) 
-            | (zcode_holding_area[i+1] << 16)
-            | (zcode_holding_area[i+2] << 8)
-            | (zcode_holding_area[i+3]));
-        offset_of_next = pc + 4;
-        addr = (labels[j].offset - offset_of_next) + 2;
-        opmodebyte = i - ((opmodeoffset+1)/2);
-        if (asm_trace_level >= 4)
-            printf("...To label %d, which is (%d-2) = %d from here\n",
-                j, addr, labels[j].offset - offset_of_next);
-        if (addr == 2 && i >= 2 && opmodeoffset == 2 && zcode_holding_area[opmodebyte-1] == opcodes_table_g[jump_gc].code) {
-            if (asm_trace_level >= 4) printf("...Deleting branch\n");
-            zcode_markers[i-2] = DELETED_MV;
-            zcode_markers[i-1] = DELETED_MV;
-            zcode_markers[i] = DELETED_MV;
-            zcode_markers[i+1] = DELETED_MV;
-            zcode_markers[i+2] = DELETED_MV;
-            zcode_markers[i+3] = DELETED_MV;
+        if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV) {
+            int opmodeoffset = (zcode_markers[i] - BRANCH_MV);
+            int32 opmodebyte;
+            if (asm_trace_level >= 4)
+                printf("Branch detected at offset %04x\n", pc);
+            j = ((zcode_holding_area[i] << 24) 
+                 | (zcode_holding_area[i+1] << 16)
+                 | (zcode_holding_area[i+2] << 8)
+                 | (zcode_holding_area[i+3]));
+            offset_of_next = pc + 4;
+            addr = (labels[j].offset - offset_of_next) + 2;
+            opmodebyte = i - ((opmodeoffset+1)/2);
+            if (asm_trace_level >= 4)
+                printf("...To label %d, which is (%d-2) = %d from here\n",
+                       j, addr, labels[j].offset - offset_of_next);
+            if (addr == 2 && i >= 2 && opmodeoffset == 2 && zcode_holding_area[opmodebyte-1] == opcodes_table_g[jump_gc].code) {
+                if (asm_trace_level >= 4) printf("...Deleting branch\n");
+                zcode_markers[i-2] = DELETED_MV;
+                zcode_markers[i-1] = DELETED_MV;
+                zcode_markers[i] = DELETED_MV;
+                zcode_markers[i+1] = DELETED_MV;
+                zcode_markers[i+2] = DELETED_MV;
+                zcode_markers[i+3] = DELETED_MV;
+            }
+            else if (addr >= -0x80 && addr < 0x80) {
+                if (asm_trace_level >= 4) printf("...Byte form\n");
+                zcode_markers[i+1] = DELETED_MV;
+                zcode_markers[i+2] = DELETED_MV;
+                zcode_markers[i+3] = DELETED_MV;
+                if ((opmodeoffset & 1) == 0)
+                    zcode_holding_area[opmodebyte] = 
+                        (zcode_holding_area[opmodebyte] & 0xF0) | 0x01;
+                else
+                    zcode_holding_area[opmodebyte] = 
+                        (zcode_holding_area[opmodebyte] & 0x0F) | 0x10;
+            }
+            else if (addr >= -0x8000 && addr < 0x8000) {
+                if (asm_trace_level >= 4) printf("...Short form\n");
+                zcode_markers[i+2] = DELETED_MV;
+                zcode_markers[i+3] = DELETED_MV;
+                if ((opmodeoffset & 1) == 0)
+                    zcode_holding_area[opmodebyte] = 
+                        (zcode_holding_area[opmodebyte] & 0xF0) | 0x02;
+                else
+                    zcode_holding_area[opmodebyte] = 
+                        (zcode_holding_area[opmodebyte] & 0x0F) | 0x20;
+            }
         }
-        else if (addr >= -0x80 && addr < 0x80) {
-            if (asm_trace_level >= 4) printf("...Byte form\n");
-            zcode_markers[i+1] = DELETED_MV;
-            zcode_markers[i+2] = DELETED_MV;
-            zcode_markers[i+3] = DELETED_MV;
-            if ((opmodeoffset & 1) == 0)
-                zcode_holding_area[opmodebyte] = 
-                    (zcode_holding_area[opmodebyte] & 0xF0) | 0x01;
-            else
-                zcode_holding_area[opmodebyte] = 
-                    (zcode_holding_area[opmodebyte] & 0x0F) | 0x10;
-        }
-        else if (addr >= -0x8000 && addr < 0x8000) {
-            if (asm_trace_level >= 4) printf("...Short form\n");
-            zcode_markers[i+2] = DELETED_MV;
-            zcode_markers[i+3] = DELETED_MV;
-            if ((opmodeoffset & 1) == 0)
-                zcode_holding_area[opmodebyte] = 
-                    (zcode_holding_area[opmodebyte] & 0xF0) | 0x02;
-            else
-                zcode_holding_area[opmodebyte] = 
-                    (zcode_holding_area[opmodebyte] & 0x0F) | 0x20;
-        }
-      }
     }
 
     /*  (2) Calculate the new positions of the labels.  Note that since the
@@ -2485,60 +2485,60 @@ static void transfer_routine_g(void)
     
     for (i=0, new_pc=adjusted_pc; i<zcode_ha_size; i++) {
 
-      if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV) {
-        form_len = 4;
-        if (zcode_markers[i+1] == DELETED_MV) {
-            form_len = 1;
-        }
-        else {
-            if (zcode_markers[i+2] == DELETED_MV)
-                form_len = 2;
-        }
-        j = ((zcode_holding_area[i] << 24) 
-            | (zcode_holding_area[i+1] << 16)
-            | (zcode_holding_area[i+2] << 8)
-            | (zcode_holding_area[i+3]));
-
-        /* At the moment, we can safely assume that the branch operand
-           is the end of the opcode, so the next opcode starts right
-           after it. */
-        offset_of_next = new_pc + form_len;
-
-        if (labels[j].offset < 0) {
-            char *lname = "(anon)";
-            if (labels[j].symbol >= 0 && labels[j].symbol < no_symbols)
-                lname = symbols[labels[j].symbol].name;
-            error_named("Attempt to jump to an unreachable label", lname);
-            addr = 0;
-        }
-        else {
-            addr = (labels[j].offset - offset_of_next) + 2;
-        }
-        if (asm_trace_level >= 4) {
-            printf("Branch at offset %04x: %04x (%s)\n",
-                new_pc, addr, ((form_len == 1) ? "byte" :
-                ((form_len == 2) ? "short" : "long")));
-        }
-        if (form_len == 1) {
-            if (addr < -0x80 || addr >= 0x80) {
-                error("*** Label out of range for byte branch ***");
+        if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV) {
+            form_len = 4;
+            if (zcode_markers[i+1] == DELETED_MV) {
+                form_len = 1;
             }
-            zcode_holding_area[i] = (addr) & 0xFF;
-        }
-        else if (form_len == 2) {
-            if (addr < -0x8000 || addr >= 0x8000) {
-                error("*** Label out of range for short branch ***");
+            else {
+                if (zcode_markers[i+2] == DELETED_MV)
+                    form_len = 2;
             }
-            zcode_holding_area[i] = (addr >> 8) & 0xFF;
-            zcode_holding_area[i+1] = (addr) & 0xFF;
-        }
-        else {
-            zcode_holding_area[i] = (addr >> 24) & 0xFF;
-            zcode_holding_area[i+1] = (addr >> 16) & 0xFF;
-            zcode_holding_area[i+2] = (addr >> 8) & 0xFF;
-            zcode_holding_area[i+3] = (addr) & 0xFF;
-        }
-        zcode_area[adjusted_pc++] = zcode_holding_area[i]; new_pc++;
+            j = ((zcode_holding_area[i] << 24) 
+                 | (zcode_holding_area[i+1] << 16)
+                 | (zcode_holding_area[i+2] << 8)
+                 | (zcode_holding_area[i+3]));
+
+            /* At the moment, we can safely assume that the branch operand
+               is the end of the opcode, so the next opcode starts right
+               after it. */
+            offset_of_next = new_pc + form_len;
+
+            if (labels[j].offset < 0) {
+                char *lname = "(anon)";
+                if (labels[j].symbol >= 0 && labels[j].symbol < no_symbols)
+                    lname = symbols[labels[j].symbol].name;
+                error_named("Attempt to jump to an unreachable label", lname);
+                addr = 0;
+            }
+            else {
+                addr = (labels[j].offset - offset_of_next) + 2;
+            }
+            if (asm_trace_level >= 4) {
+                printf("Branch at offset %04x: %04x (%s)\n",
+                    new_pc, addr, ((form_len == 1) ? "byte" :
+                                   ((form_len == 2) ? "short" : "long")));
+            }
+            if (form_len == 1) {
+                if (addr < -0x80 || addr >= 0x80) {
+                    error("*** Label out of range for byte branch ***");
+                }
+                zcode_holding_area[i] = (addr) & 0xFF;
+            }
+            else if (form_len == 2) {
+                if (addr < -0x8000 || addr >= 0x8000) {
+                    error("*** Label out of range for short branch ***");
+                }
+                zcode_holding_area[i] = (addr >> 8) & 0xFF;
+                zcode_holding_area[i+1] = (addr) & 0xFF;
+            }
+            else {
+                zcode_holding_area[i] = (addr >> 24) & 0xFF;
+                zcode_holding_area[i+1] = (addr >> 16) & 0xFF;
+                zcode_holding_area[i+2] = (addr >> 8) & 0xFF;
+                zcode_holding_area[i+3] = (addr) & 0xFF;
+            }
+            zcode_area[adjusted_pc++] = zcode_holding_area[i]; new_pc++;
       }
       else if (zcode_markers[i] == LABEL_MV) {
           error("*** No LABEL opcodes in Glulx ***");

--- a/asm.c
+++ b/asm.c
@@ -2965,7 +2965,7 @@ void assembleg_1(int internal_number, assembly_operand o1)
 }
 
 void assembleg_2(int internal_number, assembly_operand o1,
-  assembly_operand o2)
+    assembly_operand o2)
 {   AI.internal_number = internal_number;
     AI.operand_count = 2;
     AI.operand[0] = o1;
@@ -2974,7 +2974,7 @@ void assembleg_2(int internal_number, assembly_operand o1,
 }
 
 void assembleg_3(int internal_number, assembly_operand o1,
-  assembly_operand o2, assembly_operand o3)
+    assembly_operand o2, assembly_operand o3)
 {   AI.internal_number = internal_number;
     AI.operand_count = 3;
     AI.operand[0] = o1;
@@ -2984,8 +2984,8 @@ void assembleg_3(int internal_number, assembly_operand o1,
 }
 
 void assembleg_4(int internal_number, assembly_operand o1,
-  assembly_operand o2, assembly_operand o3,
-  assembly_operand o4)
+    assembly_operand o2, assembly_operand o3,
+    assembly_operand o4)
 {   AI.internal_number = internal_number;
     AI.operand_count = 4;
     AI.operand[0] = o1;
@@ -2996,8 +2996,8 @@ void assembleg_4(int internal_number, assembly_operand o1,
 }
 
 void assembleg_5(int internal_number, assembly_operand o1,
-  assembly_operand o2, assembly_operand o3,
-  assembly_operand o4, assembly_operand o5)
+    assembly_operand o2, assembly_operand o3,
+    assembly_operand o4, assembly_operand o5)
 {   AI.internal_number = internal_number;
     AI.operand_count = 5;
     AI.operand[0] = o1;

--- a/bpatch.c
+++ b/bpatch.c
@@ -431,10 +431,10 @@ symbol");
 
 extern int32 backpatch_value(int32 value)
 {
-  if (!glulx_mode)
-    return backpatch_value_z(value);
-  else
-    return backpatch_value_g(value);
+    if (!glulx_mode)
+        return backpatch_value_z(value);
+    else
+        return backpatch_value_g(value);
 }
 
 static void backpatch_zmachine_z(int mv, int zmachine_area, int32 offset)
@@ -478,10 +478,10 @@ static void backpatch_zmachine_g(int mv, int zmachine_area, int32 offset)
 
 extern void backpatch_zmachine(int mv, int zmachine_area, int32 offset)
 {
-  if (!glulx_mode)
-    backpatch_zmachine_z(mv, zmachine_area, offset);
-  else
-    backpatch_zmachine_g(mv, zmachine_area, offset);
+    if (!glulx_mode)
+        backpatch_zmachine_z(mv, zmachine_area, offset);
+    else
+        backpatch_zmachine_g(mv, zmachine_area, offset);
 }
 
 extern void backpatch_zmachine_image_z(void)

--- a/bpatch.c
+++ b/bpatch.c
@@ -494,8 +494,8 @@ extern void backpatch_zmachine_image_z(void)
         zmachine_area
             = zmachine_backpatch_table[bm+1];
         offset
-          = 256*zmachine_backpatch_table[bm+2]
-            + zmachine_backpatch_table[bm+3];
+            = 256*zmachine_backpatch_table[bm+2]
+                + zmachine_backpatch_table[bm+3];
         bm += 4;
 
         switch(zmachine_area)
@@ -539,14 +539,14 @@ extern void backpatch_zmachine_image_g(void)
             = zmachine_backpatch_table[bm+1];
         offset = zmachine_backpatch_table[bm+2];
         offset = (offset << 8) |
-          zmachine_backpatch_table[bm+3];
+            zmachine_backpatch_table[bm+3];
         offset = (offset << 8) |
-          zmachine_backpatch_table[bm+4];
+            zmachine_backpatch_table[bm+4];
         offset = (offset << 8) |
-          zmachine_backpatch_table[bm+5];
+            zmachine_backpatch_table[bm+5];
         bm += 6;
 
-            switch(zmachine_area) {   
+        switch(zmachine_area) {   
         case PROP_DEFAULTS_ZA:   addr = prop_defaults_offset+4; break;
         case PROP_ZA:            addr = prop_values_offset; break;
         case INDIVIDUAL_PROP_ZA: addr = individuals_offset; break;

--- a/errors.c
+++ b/errors.c
@@ -570,8 +570,8 @@ extern int compiler_error_named(char *s1, char *s2)
 #include "kernel.h"
 
 extern void throwback_start(void)
-{    _kernel_swi_regs regs;
-     if (throwback_switch)
+{   _kernel_swi_regs regs;
+    if (throwback_switch)
          _kernel_swi(DDEUtils_ThrowbackStart, &regs, &regs);
 }
 

--- a/expressc.c
+++ b/expressc.c
@@ -24,32 +24,32 @@ assembly_operand stack_pointer, temp_var1, temp_var2, temp_var3,
 
 static void make_operands(void)
 {
-  if (!glulx_mode) {
-    INITAOTV(&stack_pointer, VARIABLE_OT, 0);
-    INITAOTV(&temp_var1, VARIABLE_OT, globalv_z_temp_var1);
-    INITAOTV(&temp_var2, VARIABLE_OT, globalv_z_temp_var2);
-    INITAOTV(&temp_var3, VARIABLE_OT, globalv_z_temp_var3);
-    INITAOTV(&temp_var4, VARIABLE_OT, globalv_z_temp_var4);
-    INITAOTV(&zero_operand, SHORT_CONSTANT_OT, 0);
-    INITAOTV(&one_operand, SHORT_CONSTANT_OT, 1);
-    INITAOTV(&two_operand, SHORT_CONSTANT_OT, 2);
-    INITAOTV(&three_operand, SHORT_CONSTANT_OT, 3);
-    INITAOTV(&four_operand, SHORT_CONSTANT_OT, 4);
-    INITAOTV(&valueless_operand, OMITTED_OT, 0);
-  }
-  else {
-    INITAOTV(&stack_pointer, LOCALVAR_OT, 0);
-    INITAOTV(&temp_var1, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+0);
-    INITAOTV(&temp_var2, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+1);
-    INITAOTV(&temp_var3, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+2);
-    INITAOTV(&temp_var4, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+3);
-    INITAOTV(&zero_operand, ZEROCONSTANT_OT, 0);
-    INITAOTV(&one_operand, BYTECONSTANT_OT, 1);
-    INITAOTV(&two_operand, BYTECONSTANT_OT, 2);
-    INITAOTV(&three_operand, BYTECONSTANT_OT, 3);
-    INITAOTV(&four_operand, BYTECONSTANT_OT, 4);
-    INITAOTV(&valueless_operand, OMITTED_OT, 0);
-  }
+    if (!glulx_mode) {
+        INITAOTV(&stack_pointer, VARIABLE_OT, 0);
+        INITAOTV(&temp_var1, VARIABLE_OT, globalv_z_temp_var1);
+        INITAOTV(&temp_var2, VARIABLE_OT, globalv_z_temp_var2);
+        INITAOTV(&temp_var3, VARIABLE_OT, globalv_z_temp_var3);
+        INITAOTV(&temp_var4, VARIABLE_OT, globalv_z_temp_var4);
+        INITAOTV(&zero_operand, SHORT_CONSTANT_OT, 0);
+        INITAOTV(&one_operand, SHORT_CONSTANT_OT, 1);
+        INITAOTV(&two_operand, SHORT_CONSTANT_OT, 2);
+        INITAOTV(&three_operand, SHORT_CONSTANT_OT, 3);
+        INITAOTV(&four_operand, SHORT_CONSTANT_OT, 4);
+        INITAOTV(&valueless_operand, OMITTED_OT, 0);
+    }
+    else {
+        INITAOTV(&stack_pointer, LOCALVAR_OT, 0);
+        INITAOTV(&temp_var1, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+0);
+        INITAOTV(&temp_var2, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+1);
+        INITAOTV(&temp_var3, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+2);
+        INITAOTV(&temp_var4, GLOBALVAR_OT, MAX_LOCAL_VARIABLES+3);
+        INITAOTV(&zero_operand, ZEROCONSTANT_OT, 0);
+        INITAOTV(&one_operand, BYTECONSTANT_OT, 1);
+        INITAOTV(&two_operand, BYTECONSTANT_OT, 2);
+        INITAOTV(&three_operand, BYTECONSTANT_OT, 3);
+        INITAOTV(&four_operand, BYTECONSTANT_OT, 4);
+        INITAOTV(&valueless_operand, OMITTED_OT, 0);
+    }
 }
 
 /* ------------------------------------------------------------------------- */
@@ -68,19 +68,19 @@ static void make_operands(void)
 #define LAST_CC (515)
 
 typedef struct condclass_s {
-  int32 posform; /* Opcode for the conditional in its positive form. */
-  int32 negform; /* Opcode for the conditional in its negated form. */
+    int32 posform; /* Opcode for the conditional in its positive form. */
+    int32 negform; /* Opcode for the conditional in its negated form. */
 } condclass;
 
 condclass condclasses[] = {
-  { jz_gc, jnz_gc },
-  { jeq_gc, jne_gc },
-  { jlt_gc, jge_gc },
-  { jgt_gc, jle_gc },
-  { -1, -1 },
-  { -1, -1 },
-  { -1, -1 },
-  { -1, -1 }
+    { jz_gc, jnz_gc },
+    { jeq_gc, jne_gc },
+    { jlt_gc, jge_gc },
+    { jgt_gc, jle_gc },
+    { -1, -1 },
+    { -1, -1 },
+    { -1, -1 },
+    { -1, -1 }
 };
 
 /* ------------------------------------------------------------------------- */
@@ -1184,141 +1184,141 @@ static void access_memory_g(int oc, assembly_operand AO1, assembly_operand AO2,
     }
 
     if ((oc == aloadb_gc) || (oc == aload_gc)) 
-      assembleg_call_2(veneer_routine(vr), AO1, AO2, AO3);
+        assembleg_call_2(veneer_routine(vr), AO1, AO2, AO3);
     else
-      assembleg_call_3(veneer_routine(vr), AO1, AO2, AO3, zero_operand);
+        assembleg_call_3(veneer_routine(vr), AO1, AO2, AO3, zero_operand);
 }
 
 static assembly_operand check_nonzero_at_runtime_g(assembly_operand AO1,
-        int error_label, int rte_number)
+                                                   int error_label, int rte_number)
 {
-  assembly_operand AO, AO2, AO3;
-  int ln;
-  int check_sp = FALSE, passed_label, failed_label, last_label;
-  int pre_unreach;
+    assembly_operand AO, AO2, AO3;
+    int ln;
+    int check_sp = FALSE, passed_label, failed_label, last_label;
+    int pre_unreach;
   
-  if (veneer_mode) 
-    return AO1;
+    if (veneer_mode) 
+        return AO1;
 
-  /*  Assemble to code to check that the operand AO1 is ofclass Object:
-      if it is, execution should continue and the stack should be
-      unchanged.  Otherwise, call the veneer's run-time-error routine
-      with the given error number, and then: if the label isn't -1,
-      switch execution to this label, with the value popped from
-      the stack if it was on the stack in the first place;
-      if the label is -1, either replace the top of the stack with
-      the constant symbol (class-object) Object.
+    /*  Assemble to code to check that the operand AO1 is ofclass Object:
+        if it is, execution should continue and the stack should be
+        unchanged.  Otherwise, call the veneer's run-time-error routine
+        with the given error number, and then: if the label isn't -1,
+        switch execution to this label, with the value popped from
+        the stack if it was on the stack in the first place;
+        if the label is -1, either replace the top of the stack with
+        the constant symbol (class-object) Object.
 
-      The Object has no parent, child or sibling, so that the
-      built-in tree functions will safely return 0 on this object. */
+        The Object has no parent, child or sibling, so that the
+        built-in tree functions will safely return 0 on this object. */
 
-  /*  Sometimes we can already see that the object number is valid. */
-  if (AO1.marker == OBJECT_MV && 
-    ((AO1.value >= 1) && (AO1.value <= no_objects))) {
-    return AO1;
-  }
+    /*  Sometimes we can already see that the object number is valid. */
+    if (AO1.marker == OBJECT_MV && 
+        ((AO1.value >= 1) && (AO1.value <= no_objects))) {
+        return AO1;
+    }
 
-  pre_unreach = execution_never_reaches_here;
+    pre_unreach = execution_never_reaches_here;
   
-  passed_label = next_label++;
-  failed_label = next_label++;  
+    passed_label = next_label++;
+    failed_label = next_label++;  
 
-  if ((AO1.type == LOCALVAR_OT) && (AO1.value == 0) && (AO1.marker == 0)) {
-    /* That is, if AO1 is the stack pointer */
-    check_sp = TRUE;
-    assembleg_store(temp_var2, stack_pointer);
-    assembleg_store(stack_pointer, temp_var2);
-    AO = temp_var2;
-  }
-  else {
-    AO = AO1;
-  }
-  
-  if ((rte_number == IN_RTE) || (rte_number == HAS_RTE)
-    || (rte_number == PROPERTY_RTE) || (rte_number == PROP_NUM_RTE)
-    || (rte_number == PROP_ADD_RTE)) {   
-    /* Allow classes */
-    /* Test if zero... */
-    assembleg_1_branch(jz_gc, AO, failed_label);
-    if (!pre_unreach && execution_never_reaches_here)
-        execution_never_reaches_here |= EXECSTATE_NOWARN;
-    /* Test if first byte is 0x70... */
-    assembleg_3(aloadb_gc, AO, zero_operand, stack_pointer);
-    INITAO(&AO3);
-    AO3.value = 0x70; /* type byte -- object */
-    set_constant_ot(&AO3);
-    assembleg_2_branch(jeq_gc, stack_pointer, AO3, passed_label);
-  }
-  else {
-    /* Test if zero... */
-    assembleg_1_branch(jz_gc, AO, failed_label);
-    if (!pre_unreach && execution_never_reaches_here)
-        execution_never_reaches_here |= EXECSTATE_NOWARN;
-    /* Test if first byte is 0x70... */
-    assembleg_3(aloadb_gc, AO, zero_operand, stack_pointer);
-    INITAO(&AO3);
-    AO3.value = 0x70; /* type byte -- object */
-    set_constant_ot(&AO3);
-    assembleg_2_branch(jne_gc, stack_pointer, AO3, failed_label);
-    /* Test if inside the "Class" object... */
-    INITAOTV(&AO3, BYTECONSTANT_OT, GOBJFIELD_PARENT());
-    assembleg_3(aload_gc, AO, AO3, stack_pointer);
-    ln = get_symbol_index("Class");
-    if (ln < 0) {
-        error("No 'Class' object found");
-        AO3 = zero_operand;
+    if ((AO1.type == LOCALVAR_OT) && (AO1.value == 0) && (AO1.marker == 0)) {
+        /* That is, if AO1 is the stack pointer */
+        check_sp = TRUE;
+        assembleg_store(temp_var2, stack_pointer);
+        assembleg_store(stack_pointer, temp_var2);
+        AO = temp_var2;
     }
     else {
-        AO3.value = symbols[ln].value;
-        AO3.marker = OBJECT_MV;
-        AO3.type = CONSTANT_OT;
+        AO = AO1;
     }
-    assembleg_2_branch(jne_gc, stack_pointer, AO3, passed_label);
-  }
   
-  assemble_label_no(failed_label);
-  INITAO(&AO2);
-  AO2.value = rte_number; 
-  set_constant_ot(&AO2);
-  assembleg_call_2(veneer_routine(RT__Err_VR), AO2, AO1, zero_operand);
-  
-  if (error_label != -1) {
-    /* Jump to the error label */
-    if (error_label == -3) assembleg_1(return_gc, zero_operand);
-    else if (error_label == -4) assembleg_1(return_gc, one_operand);
-    else assembleg_jump(error_label);
-  }
-  else {
-    /* Build the symbol for "Object" */
-    ln = get_symbol_index("Object");
-    if (ln < 0) {
-        error("No 'Object' object found");
-        AO2 = zero_operand;
+    if ((rte_number == IN_RTE) || (rte_number == HAS_RTE)
+        || (rte_number == PROPERTY_RTE) || (rte_number == PROP_NUM_RTE)
+        || (rte_number == PROP_ADD_RTE)) {   
+        /* Allow classes */
+        /* Test if zero... */
+        assembleg_1_branch(jz_gc, AO, failed_label);
+        if (!pre_unreach && execution_never_reaches_here)
+            execution_never_reaches_here |= EXECSTATE_NOWARN;
+        /* Test if first byte is 0x70... */
+        assembleg_3(aloadb_gc, AO, zero_operand, stack_pointer);
+        INITAO(&AO3);
+        AO3.value = 0x70; /* type byte -- object */
+        set_constant_ot(&AO3);
+        assembleg_2_branch(jeq_gc, stack_pointer, AO3, passed_label);
     }
     else {
-        AO2.value = symbols[ln].value;
-        AO2.marker = OBJECT_MV;
-        AO2.type = CONSTANT_OT;
+        /* Test if zero... */
+        assembleg_1_branch(jz_gc, AO, failed_label);
+        if (!pre_unreach && execution_never_reaches_here)
+            execution_never_reaches_here |= EXECSTATE_NOWARN;
+        /* Test if first byte is 0x70... */
+        assembleg_3(aloadb_gc, AO, zero_operand, stack_pointer);
+        INITAO(&AO3);
+        AO3.value = 0x70; /* type byte -- object */
+        set_constant_ot(&AO3);
+        assembleg_2_branch(jne_gc, stack_pointer, AO3, failed_label);
+        /* Test if inside the "Class" object... */
+        INITAOTV(&AO3, BYTECONSTANT_OT, GOBJFIELD_PARENT());
+        assembleg_3(aload_gc, AO, AO3, stack_pointer);
+        ln = get_symbol_index("Class");
+        if (ln < 0) {
+            error("No 'Class' object found");
+            AO3 = zero_operand;
+        }
+        else {
+            AO3.value = symbols[ln].value;
+            AO3.marker = OBJECT_MV;
+            AO3.type = CONSTANT_OT;
+        }
+        assembleg_2_branch(jne_gc, stack_pointer, AO3, passed_label);
     }
-    if (check_sp) {
-      /* Push "Object" */
-      assembleg_store(AO1, AO2);
+  
+    assemble_label_no(failed_label);
+    INITAO(&AO2);
+    AO2.value = rte_number; 
+    set_constant_ot(&AO2);
+    assembleg_call_2(veneer_routine(RT__Err_VR), AO2, AO1, zero_operand);
+  
+    if (error_label != -1) {
+        /* Jump to the error label */
+        if (error_label == -3) assembleg_1(return_gc, zero_operand);
+        else if (error_label == -4) assembleg_1(return_gc, one_operand);
+        else assembleg_jump(error_label);
     }
     else {
-      /* Store either "Object" or the operand's value in the temporary
-         variable. */
-      assembleg_store(temp_var2, AO2);
-      last_label = next_label++;
-      assembleg_jump(last_label);
-      assemble_label_no(passed_label);
-      assembleg_store(temp_var2, AO1);
-      assemble_label_no(last_label);
-      return temp_var2;
+        /* Build the symbol for "Object" */
+        ln = get_symbol_index("Object");
+        if (ln < 0) {
+            error("No 'Object' object found");
+            AO2 = zero_operand;
+        }
+        else {
+            AO2.value = symbols[ln].value;
+            AO2.marker = OBJECT_MV;
+            AO2.type = CONSTANT_OT;
+        }
+        if (check_sp) {
+            /* Push "Object" */
+            assembleg_store(AO1, AO2);
+        }
+        else {
+            /* Store either "Object" or the operand's value in the temporary
+               variable. */
+            assembleg_store(temp_var2, AO2);
+            last_label = next_label++;
+            assembleg_jump(last_label);
+            assemble_label_no(passed_label);
+            assembleg_store(temp_var2, AO1);
+            assemble_label_no(last_label);
+            return temp_var2;
+        }
     }
-  }
     
-  assemble_label_no(passed_label);
-  return AO1;
+    assemble_label_no(passed_label);
+    return AO1;
 }
 
 static void compile_conditional_g(condclass *cc,
@@ -1462,20 +1462,20 @@ static void compile_conditional_g(condclass *cc,
 
 static void value_in_void_context(assembly_operand AO)
 {
-  if (!glulx_mode)
-    value_in_void_context_z(AO);
-  else
-    value_in_void_context_g(AO);
+    if (!glulx_mode)
+        value_in_void_context_z(AO);
+    else
+        value_in_void_context_g(AO);
 }
 
 
 extern assembly_operand check_nonzero_at_runtime(assembly_operand AO1,
-  int error_label, int rte_number)
+    int error_label, int rte_number)
 {
-  if (!glulx_mode)
-    return check_nonzero_at_runtime_z(AO1, error_label, rte_number);
-  else
-    return check_nonzero_at_runtime_g(AO1, error_label, rte_number);
+    if (!glulx_mode)
+        return check_nonzero_at_runtime_z(AO1, error_label, rte_number);
+    else
+        return check_nonzero_at_runtime_g(AO1, error_label, rte_number);
 }
 
 static void generate_code_from(int n, int void_flag)

--- a/expressc.c
+++ b/expressc.c
@@ -19,8 +19,8 @@ int vivc_flag;                      /*  TRUE if the last code-generated
 /* These data structures are global, because they're too useful to be
    static. */
 assembly_operand stack_pointer, temp_var1, temp_var2, temp_var3,
-  temp_var4, zero_operand, one_operand, two_operand, three_operand,
-  four_operand, valueless_operand;
+    temp_var4, zero_operand, one_operand, two_operand, three_operand,
+    four_operand, valueless_operand;
 
 static void make_operands(void)
 {

--- a/expressc.c
+++ b/expressc.c
@@ -1560,292 +1560,292 @@ static void generate_code_from(int n, int void_flag)
     {   ET[n].down = -1; return;
     }
 
-  if (!glulx_mode) {
+    if (!glulx_mode) {
 
-    if (operators[opnum].opcode_number_z >= 400)
-    {
-        /*  Conditional terms such as '==': */
-
-        int a = ET[n].true_label, b = ET[n].false_label,
-            branch_away, branch_other,
-            make_jump_away = FALSE, make_branch_label = FALSE;
-        int oc = operators[opnum].opcode_number_z-400, flag = TRUE;
-
-        if (oc >= 400) { oc = oc - 400; flag = FALSE; }
-
-        /*  A condition comparing to constant zero can be converted
-            to jz.
-            
-            The marker check is *almost* redundant. Most backpatchable
-            values (DWORD_MV, etc) are stored as LONG_CONSTANT_OT
-            and thus fail the check against zero_operand.type. (This
-            was probably deliberate but it was never documented.)
-            
-            ACTION_MV is stored as SHORT_CONSTANT_OT, so we check the
-            marker value to catch that case. But actions are only
-            backpatchable if GRAMMAR_META_FLAG is set. Thus the special
-            case.
-        */
-        if ((oc == je_zc) && (arity == 2))
-        {   i = ET[ET[n].down].right;
-            if ((ET[i].value.value == zero_operand.value)
-                && (ET[i].value.type == zero_operand.type)) {
-                if (ET[i].value.marker == 0 || (ET[i].value.marker == ACTION_MV && !GRAMMAR_META_FLAG))
-                    oc = jz_zc;
-            }
-        }
-
-        /*  If the condition has truth state flag, branch to
-            label a, and if not, to label b.  Possibly one of a, b
-            equals -1, meaning "continue from this instruction".
-
-            branch_away is the label which is a branch away (the one
-            which isn't immediately after) and flag is the truth
-            state to branch there.
-
-            Note that when multiple instructions are needed (because
-            of the use of the 'or' operator) the branch_other label
-            is created if need be.
-        */
-
-        /*  Reduce to the case where the branch_away label does exist:  */
-
-        if (a == -1) { a = b; b = -1; flag = !flag; }
-
-        branch_away = a; branch_other = b;
-        if (branch_other != -1) make_jump_away = TRUE;
-
-        if ((((oc != je_zc)&&(arity > 2)) || (arity > 4)) && (flag == FALSE))
+        if (operators[opnum].opcode_number_z >= 400)
         {
-            /*  In this case, we have an 'or' situation where multiple
-                instructions are needed and where the overall condition
-                is negated.  That is, we have, e.g.
-
-                   if not (A cond B or C or D) then branch_away
-
-                which we transform into
-
-                   if (A cond B) then branch_other
-                   if (A cond C) then branch_other
-                   if not (A cond D) then branch_away
-                  .branch_other                                          */
-
-            if (branch_other == -1)
-            {   branch_other = next_label++; make_branch_label = TRUE;
-            }
-        }
-
-        if (oc == jz_zc)
-            assemblez_1_branch(jz_zc, ET[below].value, branch_away, flag);
-        else
-        {   assembly_operand left_operand;
-
-            if (arity == 2)
-                compile_conditional_z(oc, ET[below].value,
-                    ET[ET[below].right].value, branch_away, flag);
-            else
-            {   /*  The case of a condition using "or".
-                    First: if the condition tests the stack pointer,
-                    and it can't always be done in a single test, move
-                    the value off the stack and into temporary variable
-                    storage.  */
-
-                if (((ET[below].value.type == VARIABLE_OT)
-                     && (ET[below].value.value == 0))
-                    && ((oc != je_zc) || (arity>4)) )
-                {   INITAOTV(&left_operand, VARIABLE_OT, globalv_z_temp_var1);
-                    assemblez_store(left_operand, ET[below].value);
+            /*  Conditional terms such as '==': */
+    
+            int a = ET[n].true_label, b = ET[n].false_label,
+                branch_away, branch_other,
+                make_jump_away = FALSE, make_branch_label = FALSE;
+            int oc = operators[opnum].opcode_number_z-400, flag = TRUE;
+    
+            if (oc >= 400) { oc = oc - 400; flag = FALSE; }
+    
+            /*  A condition comparing to constant zero can be converted
+                to jz.
+                
+                The marker check is *almost* redundant. Most backpatchable
+                values (DWORD_MV, etc) are stored as LONG_CONSTANT_OT
+                and thus fail the check against zero_operand.type. (This
+                was probably deliberate but it was never documented.)
+                
+                ACTION_MV is stored as SHORT_CONSTANT_OT, so we check the
+                marker value to catch that case. But actions are only
+                backpatchable if GRAMMAR_META_FLAG is set. Thus the special
+                case.
+            */
+            if ((oc == je_zc) && (arity == 2))
+            {   i = ET[ET[n].down].right;
+                if ((ET[i].value.value == zero_operand.value)
+                    && (ET[i].value.type == zero_operand.type)) {
+                    if (ET[i].value.marker == 0 || (ET[i].value.marker == ACTION_MV && !GRAMMAR_META_FLAG))
+                        oc = jz_zc;
                 }
-                else left_operand = ET[below].value;
-                i = ET[below].right; arity--;
-
-                /*  "left_operand" now holds the quantity to be tested;
-                    "i" holds the right operand reached so far;
-                    "arity" the number of right operands.  */
-
-                while (i != -1)
-                {   if ((oc == je_zc) && (arity>1))
-                    {
-                        /*  je_zc is an especially good case since the
-                            Z-machine implements "or" for up to three
-                            right operands automatically, though it's an
-                            especially bad case to generate code for!  */
-
-                        if (arity == 2)
-                        {   assemblez_3_branch(je_zc,
-                              left_operand, ET[i].value,
-                              ET[ET[i].right].value, branch_away, flag);
-                            i = ET[i].right; arity--;
+            }
+    
+            /*  If the condition has truth state flag, branch to
+                label a, and if not, to label b.  Possibly one of a, b
+                equals -1, meaning "continue from this instruction".
+    
+                branch_away is the label which is a branch away (the one
+                which isn't immediately after) and flag is the truth
+                state to branch there.
+    
+                Note that when multiple instructions are needed (because
+                of the use of the 'or' operator) the branch_other label
+                is created if need be.
+            */
+    
+            /*  Reduce to the case where the branch_away label does exist:  */
+    
+            if (a == -1) { a = b; b = -1; flag = !flag; }
+    
+            branch_away = a; branch_other = b;
+            if (branch_other != -1) make_jump_away = TRUE;
+    
+            if ((((oc != je_zc)&&(arity > 2)) || (arity > 4)) && (flag == FALSE))
+            {
+                /*  In this case, we have an 'or' situation where multiple
+                    instructions are needed and where the overall condition
+                    is negated.  That is, we have, e.g.
+    
+                       if not (A cond B or C or D) then branch_away
+    
+                    which we transform into
+    
+                       if (A cond B) then branch_other
+                       if (A cond C) then branch_other
+                       if not (A cond D) then branch_away
+                      .branch_other                                          */
+    
+                if (branch_other == -1)
+                {   branch_other = next_label++; make_branch_label = TRUE;
+                }
+            }
+    
+            if (oc == jz_zc)
+                assemblez_1_branch(jz_zc, ET[below].value, branch_away, flag);
+            else
+            {   assembly_operand left_operand;
+    
+                if (arity == 2)
+                    compile_conditional_z(oc, ET[below].value,
+                        ET[ET[below].right].value, branch_away, flag);
+                else
+                {   /*  The case of a condition using "or".
+                        First: if the condition tests the stack pointer,
+                        and it can't always be done in a single test, move
+                        the value off the stack and into temporary variable
+                        storage.  */
+    
+                    if (((ET[below].value.type == VARIABLE_OT)
+                         && (ET[below].value.value == 0))
+                        && ((oc != je_zc) || (arity>4)) )
+                    {   INITAOTV(&left_operand, VARIABLE_OT, globalv_z_temp_var1);
+                        assemblez_store(left_operand, ET[below].value);
+                    }
+                    else left_operand = ET[below].value;
+                    i = ET[below].right; arity--;
+    
+                    /*  "left_operand" now holds the quantity to be tested;
+                        "i" holds the right operand reached so far;
+                        "arity" the number of right operands.  */
+    
+                    while (i != -1)
+                    {   if ((oc == je_zc) && (arity>1))
+                        {
+                            /*  je_zc is an especially good case since the
+                                Z-machine implements "or" for up to three
+                                right operands automatically, though it's an
+                                especially bad case to generate code for!  */
+    
+                            if (arity == 2)
+                            {   assemblez_3_branch(je_zc,
+                                  left_operand, ET[i].value,
+                                  ET[ET[i].right].value, branch_away, flag);
+                                i = ET[i].right; arity--;
+                            }
+                            else
+                            {   if ((arity == 3) || flag)
+                                  assemblez_4_branch(je_zc, left_operand,
+                                    ET[i].value,
+                                    ET[ET[i].right].value,
+                                    ET[ET[ET[i].right].right].value,
+                                    branch_away, flag);
+                                else
+                                  assemblez_4_branch(je_zc, left_operand,
+                                    ET[i].value,
+                                    ET[ET[i].right].value,
+                                    ET[ET[ET[i].right].right].value,
+                                    branch_other, !flag);
+                                i = ET[ET[i].right].right; arity -= 2;
+                            }
                         }
                         else
-                        {   if ((arity == 3) || flag)
-                              assemblez_4_branch(je_zc, left_operand,
-                                ET[i].value,
-                                ET[ET[i].right].value,
-                                ET[ET[ET[i].right].right].value,
-                                branch_away, flag);
+                        {   /*  Otherwise we can compare the left_operand with
+                                only one right operand at the time.  There are
+                                two cases: it's the last right operand, or it
+                                isn't.  */
+    
+                            if ((arity == 1) || flag)
+                                compile_conditional_z(oc, left_operand,
+                                    ET[i].value, branch_away, flag);
                             else
-                              assemblez_4_branch(je_zc, left_operand,
-                                ET[i].value,
-                                ET[ET[i].right].value,
-                                ET[ET[ET[i].right].right].value,
-                                branch_other, !flag);
-                            i = ET[ET[i].right].right; arity -= 2;
+                                compile_conditional_z(oc, left_operand,
+                                    ET[i].value, branch_other, !flag);
                         }
+                        i = ET[i].right; arity--;
                     }
-                    else
-                    {   /*  Otherwise we can compare the left_operand with
+    
+                }
+            }
+    
+            /*  NB: These two conditions cannot both occur, fortunately!  */
+    
+            if (make_branch_label) assemble_label_no(branch_other);
+            if (make_jump_away) assemblez_jump(branch_other);
+    
+            goto OperatorGenerated;
+        }
+
+    }
+    else {
+        if (operators[opnum].opcode_number_g >= FIRST_CC 
+            && operators[opnum].opcode_number_g <= LAST_CC) {
+            /*  Conditional terms such as '==': */
+
+            int a = ET[n].true_label, b = ET[n].false_label;
+            int branch_away, branch_other, flag,
+                make_jump_away = FALSE, make_branch_label = FALSE;
+            int ccode = operators[opnum].opcode_number_g;
+            condclass *cc = &condclasses[(ccode-FIRST_CC) / 2];
+            flag = (ccode & 1) ? 0 : 1;
+
+            /*  If the comparison is "equal to (constant) 0", change it
+                to the simple "zero" test. Unfortunately, this doesn't
+                work for the commutative form "(constant) 0 is equal to". 
+                At least I don't think it does. */
+
+            if ((cc == &condclasses[1]) && (arity == 2)) {
+                i = ET[ET[n].down].right;
+                if ((ET[i].value.value == 0)
+                    && (ET[i].value.marker == 0) 
+                    && is_constant_ot(ET[i].value.type)) {
+                    cc = &condclasses[0];
+                }
+            }
+
+            /*  If the condition has truth state flag, branch to
+                label a, and if not, to label b.  Possibly one of a, b
+                equals -1, meaning "continue from this instruction".
+          
+                branch_away is the label which is a branch away (the one
+                which isn't immediately after) and flag is the truth
+                state to branch there.
+
+                Note that when multiple instructions are needed (because
+                of the use of the 'or' operator) the branch_other label
+                is created if need be.
+            */
+      
+            /*  Reduce to the case where the branch_away label does exist:  */
+
+            if (a == -1) { a = b; b = -1; flag = !flag; }
+
+            branch_away = a; branch_other = b;
+            if (branch_other != -1) make_jump_away = TRUE;
+      
+            if ((arity > 2) && (flag == FALSE)) {
+                /*  In this case, we have an 'or' situation where multiple
+                    instructions are needed and where the overall condition
+                    is negated.  That is, we have, e.g.
+            
+                    if not (A cond B or C or D) then branch_away
+            
+                    which we transform into
+            
+                    if (A cond B) then branch_other
+                    if (A cond C) then branch_other
+                    if not (A cond D) then branch_away
+                    .branch_other                                          */
+        
+                if (branch_other == -1) {
+                    branch_other = next_label++; make_branch_label = TRUE;
+                }
+            }
+
+            if (cc == &condclasses[0]) {
+                assembleg_1_branch((flag ? cc->posform : cc->negform), 
+                    ET[below].value, branch_away);
+            }
+            else {
+                if (arity == 2) {
+                    compile_conditional_g(cc, ET[below].value,
+                        ET[ET[below].right].value, branch_away, flag);
+                }
+                else {
+                    /*  The case of a condition using "or".
+                        First: if the condition tests the stack pointer,
+                        and it can't always be done in a single test, move
+                        the value off the stack and into temporary variable
+                        storage.  */
+
+                    assembly_operand left_operand;
+                    if (((ET[below].value.type == LOCALVAR_OT)
+                         && (ET[below].value.value == 0))) {
+                        assembleg_store(temp_var1, ET[below].value);
+                        left_operand = temp_var1;
+                    }
+                    else {
+                        left_operand = ET[below].value;
+                    }
+                    i = ET[below].right; 
+                    arity--;
+
+                    /*  "left_operand" now holds the quantity to be tested;
+                        "i" holds the right operand reached so far;
+                        "arity" the number of right operands.  */
+
+                    while (i != -1) {
+                        /*  We can compare the left_operand with
                             only one right operand at the time.  There are
                             two cases: it's the last right operand, or it
                             isn't.  */
 
                         if ((arity == 1) || flag)
-                            compile_conditional_z(oc, left_operand,
+                            compile_conditional_g(cc, left_operand,
                                 ET[i].value, branch_away, flag);
                         else
-                            compile_conditional_z(oc, left_operand,
+                            compile_conditional_g(cc, left_operand,
                                 ET[i].value, branch_other, !flag);
+
+                        i = ET[i].right; 
+                        arity--;
                     }
-                    i = ET[i].right; arity--;
                 }
-
             }
+      
+            /*  NB: These two conditions cannot both occur, fortunately!  */
+      
+            if (make_branch_label) assemble_label_no(branch_other);
+            if (make_jump_away) assembleg_jump(branch_other);
+      
+            goto OperatorGenerated;
         }
 
-        /*  NB: These two conditions cannot both occur, fortunately!  */
-
-        if (make_branch_label) assemble_label_no(branch_other);
-        if (make_jump_away) assemblez_jump(branch_other);
-
-        goto OperatorGenerated;
     }
-
-  }
-  else {
-    if (operators[opnum].opcode_number_g >= FIRST_CC 
-      && operators[opnum].opcode_number_g <= LAST_CC) {
-      /*  Conditional terms such as '==': */
-
-      int a = ET[n].true_label, b = ET[n].false_label;
-      int branch_away, branch_other, flag,
-        make_jump_away = FALSE, make_branch_label = FALSE;
-      int ccode = operators[opnum].opcode_number_g;
-      condclass *cc = &condclasses[(ccode-FIRST_CC) / 2];
-      flag = (ccode & 1) ? 0 : 1;
-
-      /*  If the comparison is "equal to (constant) 0", change it
-          to the simple "zero" test. Unfortunately, this doesn't
-          work for the commutative form "(constant) 0 is equal to". 
-          At least I don't think it does. */
-
-      if ((cc == &condclasses[1]) && (arity == 2)) {
-        i = ET[ET[n].down].right;
-        if ((ET[i].value.value == 0)
-          && (ET[i].value.marker == 0) 
-          && is_constant_ot(ET[i].value.type)) {
-          cc = &condclasses[0];
-        }
-      }
-
-      /*  If the condition has truth state flag, branch to
-          label a, and if not, to label b.  Possibly one of a, b
-          equals -1, meaning "continue from this instruction".
-          
-          branch_away is the label which is a branch away (the one
-          which isn't immediately after) and flag is the truth
-          state to branch there.
-
-          Note that when multiple instructions are needed (because
-          of the use of the 'or' operator) the branch_other label
-          is created if need be.
-      */
-      
-      /*  Reduce to the case where the branch_away label does exist:  */
-
-      if (a == -1) { a = b; b = -1; flag = !flag; }
-
-      branch_away = a; branch_other = b;
-      if (branch_other != -1) make_jump_away = TRUE;
-      
-      if ((arity > 2) && (flag == FALSE)) {
-        /*  In this case, we have an 'or' situation where multiple
-            instructions are needed and where the overall condition
-            is negated.  That is, we have, e.g.
-            
-            if not (A cond B or C or D) then branch_away
-            
-            which we transform into
-            
-            if (A cond B) then branch_other
-            if (A cond C) then branch_other
-            if not (A cond D) then branch_away
-            .branch_other                                          */
-        
-        if (branch_other == -1) {
-          branch_other = next_label++; make_branch_label = TRUE;
-        }
-      }
-
-      if (cc == &condclasses[0]) {
-        assembleg_1_branch((flag ? cc->posform : cc->negform), 
-          ET[below].value, branch_away);
-      }
-      else {
-        if (arity == 2) {
-          compile_conditional_g(cc, ET[below].value,
-            ET[ET[below].right].value, branch_away, flag);
-        }
-        else {
-          /*  The case of a condition using "or".
-              First: if the condition tests the stack pointer,
-              and it can't always be done in a single test, move
-              the value off the stack and into temporary variable
-              storage.  */
-
-          assembly_operand left_operand;
-          if (((ET[below].value.type == LOCALVAR_OT)
-            && (ET[below].value.value == 0))) {
-            assembleg_store(temp_var1, ET[below].value);
-            left_operand = temp_var1;
-          }
-          else {
-            left_operand = ET[below].value;
-          }
-          i = ET[below].right; 
-          arity--;
-
-          /*  "left_operand" now holds the quantity to be tested;
-              "i" holds the right operand reached so far;
-              "arity" the number of right operands.  */
-
-          while (i != -1) {
-            /*  We can compare the left_operand with
-            only one right operand at the time.  There are
-            two cases: it's the last right operand, or it
-            isn't.  */
-
-            if ((arity == 1) || flag)
-              compile_conditional_g(cc, left_operand,
-            ET[i].value, branch_away, flag);
-            else
-              compile_conditional_g(cc, left_operand,
-            ET[i].value, branch_other, !flag);
-
-            i = ET[i].right; 
-            arity--;
-          }
-        }
-      }
-      
-      /*  NB: These two conditions cannot both occur, fortunately!  */
-      
-      if (make_branch_label) assemble_label_no(branch_other);
-      if (make_jump_away) assembleg_jump(branch_other);
-      
-      goto OperatorGenerated;
-    }
-
-  }
 
     /*  The operator is now definitely one which produces a value  */
 
@@ -1872,1273 +1872,1273 @@ static void generate_code_from(int n, int void_flag)
         else Result = stack_pointer;  /*  Otherwise, put it on the stack  */
     }
 
-  if (!glulx_mode) {
+    if (!glulx_mode) {
 
-    if (operators[opnum].opcode_number_z != -1)
-    {
-        /*  Operators directly translatable into Z-code opcodes: infix ops
-            take two operands whereas pre/postfix operators take only one */
-
-        if (operators[opnum].usage == IN_U)
-        {   int o_n = operators[opnum].opcode_number_z;
-            if (runtime_error_checking_switch && (!veneer_mode)
-                && ((o_n == div_zc) || (o_n == mod_zc)))
-            {   assembly_operand by_ao, error_ao; int ln;
-                by_ao = ET[ET[below].right].value;
-                if ((by_ao.value != 0) && (by_ao.marker == 0)
-                    && ((by_ao.type == SHORT_CONSTANT_OT)
-                        || (by_ao.type == LONG_CONSTANT_OT)))
+        if (operators[opnum].opcode_number_z != -1)
+        {
+            /*  Operators directly translatable into Z-code opcodes: infix ops
+                take two operands whereas pre/postfix operators take only one */
+    
+            if (operators[opnum].usage == IN_U)
+            {   int o_n = operators[opnum].opcode_number_z;
+                if (runtime_error_checking_switch && (!veneer_mode)
+                    && ((o_n == div_zc) || (o_n == mod_zc)))
+                {   assembly_operand by_ao, error_ao; int ln;
+                    by_ao = ET[ET[below].right].value;
+                    if ((by_ao.value != 0) && (by_ao.marker == 0)
+                        && ((by_ao.type == SHORT_CONSTANT_OT)
+                            || (by_ao.type == LONG_CONSTANT_OT)))
+                        assemblez_2_to(o_n, ET[below].value,
+                            by_ao, Result);
+                    else
+                    {
+                        assemblez_store(temp_var1, ET[below].value);
+                        assemblez_store(temp_var2, by_ao);
+                        ln = next_label++;
+                        assemblez_1_branch(jz_zc, temp_var2, ln, FALSE);
+                        INITAOT(&error_ao, SHORT_CONSTANT_OT);
+                        error_ao.value = DBYZERO_RTE;
+                        assemblez_2(call_vn_zc, veneer_routine(RT__Err_VR),
+                            error_ao);
+                        assemblez_inc(temp_var2);
+                        assemble_label_no(ln);
+                        assemblez_2_to(o_n, temp_var1, temp_var2, Result);
+                    }
+                }
+                else if (try_optimize_expr_z(o_n, ET[below].value,
+                    ET[ET[below].right].value, Result)) {
+                    /* generated simplified code */
+                }
+                else {
                     assemblez_2_to(o_n, ET[below].value,
-                        by_ao, Result);
-                else
-                {
-                    assemblez_store(temp_var1, ET[below].value);
-                    assemblez_store(temp_var2, by_ao);
-                    ln = next_label++;
-                    assemblez_1_branch(jz_zc, temp_var2, ln, FALSE);
-                    INITAOT(&error_ao, SHORT_CONSTANT_OT);
-                    error_ao.value = DBYZERO_RTE;
-                    assemblez_2(call_vn_zc, veneer_routine(RT__Err_VR),
-                        error_ao);
-                    assemblez_inc(temp_var2);
-                    assemble_label_no(ln);
-                    assemblez_2_to(o_n, temp_var1, temp_var2, Result);
+                        ET[ET[below].right].value, Result);
                 }
             }
-            else if (try_optimize_expr_z(o_n, ET[below].value,
-                ET[ET[below].right].value, Result)) {
-                /* generated simplified code */
-            }
             else {
-                assemblez_2_to(o_n, ET[below].value,
-                    ET[ET[below].right].value, Result);
+                assemblez_1_to(operators[opnum].opcode_number_z, ET[below].value,
+                    Result);
             }
         }
-        else {
-            assemblez_1_to(operators[opnum].opcode_number_z, ET[below].value,
-                Result);
-        }
-    }
-    else
-    switch(opnum)
-    {   case ARROW_OP:
-             access_memory_z(loadb_zc, ET[below].value,
-                                     ET[ET[below].right].value, Result);
-             break;
-        case DARROW_OP:
-             access_memory_z(loadw_zc, ET[below].value,
-                                     ET[ET[below].right].value, Result);
-             break;
-        case UNARY_MINUS_OP:
-             assemblez_2_to(sub_zc, zero_operand, ET[below].value, Result);
-             break;
-        case ARTNOT_OP:
-             assemblez_1_to(not_zc, ET[below].value, Result);
-             break;
-
-        case PROP_ADD_OP:
-             {   assembly_operand AO = ET[below].value;
-                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".&\" expression");
-                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
-                 if (runtime_error_checking_switch && (!veneer_mode))
-                     AO = check_nonzero_at_runtime(AO, -1, PROP_ADD_RTE);
-                 if ((!void_flag) && Result.type == VARIABLE_OT) {
-                     /* store directly to variable */
-                     assemblez_2_to(get_prop_addr_zc, AO,
-                         ET[ET[below].right].value, Result);
-                 }
-                 else {
-                     assemblez_2_to(get_prop_addr_zc, AO,
-                         ET[ET[below].right].value, temp_var1);
-                     if (!void_flag) write_result_z(Result, temp_var1);
-                 }
-             }
-             break;
-
-        case PROP_NUM_OP:
-             {   assembly_operand AO = ET[below].value;
-                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".#\" expression");
-                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".#\" expression");
-                 if (runtime_error_checking_switch && (!veneer_mode))
-                     AO = check_nonzero_at_runtime(AO, -1, PROP_NUM_RTE);
-                 assemblez_2_to(get_prop_addr_zc, AO,
-                     ET[ET[below].right].value, temp_var1);
-                 assemblez_1_branch(jz_zc, temp_var1, next_label++, TRUE);
-                 assemblez_1_to(get_prop_len_zc, temp_var1, temp_var1);
-                 assemble_label_no(next_label-1);
-                 if (!void_flag) write_result_z(Result, temp_var1);
-             }
-             break;
-
-        case PROPERTY_OP:
-             {
-                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
-                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-                 if (runtime_error_checking_switch && (!veneer_mode)) {
-                     assemblez_3_to(call_vs_zc, veneer_routine(RT__ChPR_VR),
-                         ET[below].value, ET[ET[below].right].value, temp_var1);
-                     if (!void_flag) write_result_z(Result, temp_var1);
-                 }
-                 else {
+        else
+        switch(opnum)
+        {   case ARROW_OP:
+                 access_memory_z(loadb_zc, ET[below].value,
+                                         ET[ET[below].right].value, Result);
+                 break;
+            case DARROW_OP:
+                 access_memory_z(loadw_zc, ET[below].value,
+                                         ET[ET[below].right].value, Result);
+                 break;
+            case UNARY_MINUS_OP:
+                 assemblez_2_to(sub_zc, zero_operand, ET[below].value, Result);
+                 break;
+            case ARTNOT_OP:
+                 assemblez_1_to(not_zc, ET[below].value, Result);
+                 break;
+    
+            case PROP_ADD_OP:
+                 {   assembly_operand AO = ET[below].value;
+                     check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".&\" expression");
+                     check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
+                     if (runtime_error_checking_switch && (!veneer_mode))
+                         AO = check_nonzero_at_runtime(AO, -1, PROP_ADD_RTE);
                      if ((!void_flag) && Result.type == VARIABLE_OT) {
                          /* store directly to variable */
-                         assemblez_2_to(get_prop_zc, ET[below].value,
+                         assemblez_2_to(get_prop_addr_zc, AO,
                              ET[ET[below].right].value, Result);
                      }
                      else {
-                         assemblez_2_to(get_prop_zc, ET[below].value,
+                         assemblez_2_to(get_prop_addr_zc, AO,
                              ET[ET[below].right].value, temp_var1);
                          if (!void_flag) write_result_z(Result, temp_var1);
                      }
                  }
-             }
-             break;
-
-        case MESSAGE_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-             j=1; AI.operand[0] = veneer_routine(RV__Pr_VR);
-             goto GenFunctionCallZ;
-        case MPROP_ADD_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".&\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
-             j=1; AI.operand[0] = veneer_routine(RA__Pr_VR);
-             goto GenFunctionCallZ;
-        case MPROP_NUM_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".#\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".#\" expression");
-             j=1; AI.operand[0] = veneer_routine(RL__Pr_VR);
-             goto GenFunctionCallZ;
-        case MESSAGE_SETEQUALS_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-             j=1; AI.operand[0] = veneer_routine(WV__Pr_VR);
-             goto GenFunctionCallZ;
-        case MESSAGE_INC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"++.\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"++.\" expression");
-             j=1; AI.operand[0] = veneer_routine(IB__Pr_VR);
-             goto GenFunctionCallZ;
-        case MESSAGE_DEC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"--.\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"--.\" expression");
-             j=1; AI.operand[0] = veneer_routine(DB__Pr_VR);
-             goto GenFunctionCallZ;
-        case MESSAGE_POST_INC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".++\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".++\" expression");
-             j=1; AI.operand[0] = veneer_routine(IA__Pr_VR);
-             goto GenFunctionCallZ;
-        case MESSAGE_POST_DEC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".--\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".--\" expression");
-             j=1; AI.operand[0] = veneer_routine(DA__Pr_VR);
-             goto GenFunctionCallZ;
-        case SUPERCLASS_OP:
-             j=1; AI.operand[0] = veneer_routine(RA__Sc_VR);
-             goto GenFunctionCallZ;
-        case PROP_CALL_OP:
-             check_warn_symbol_has_metaclass(&ET[below].value, "\".()\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".()\" expression");
-             j=1; AI.operand[0] = veneer_routine(CA__Pr_VR);
-             goto GenFunctionCallZ;
-        case MESSAGE_CALL_OP:
-             check_warn_symbol_has_metaclass(&ET[below].value, "\".()\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".()\" expression");
-             j=1; AI.operand[0] = veneer_routine(CA__Pr_VR);
-             goto GenFunctionCallZ;
-
-
-        case FCALL_OP:
-             j = 0;
-
-             if ((ET[below].value.type == VARIABLE_OT)
-                 && (ET[below].value.value >= 256))
-             {   int sf_number = ET[below].value.value - 256;
-
-                 i = ET[below].right;
-                 if (i == -1)
-                 {   error("Argument to system function missing");
-                     AI.operand[0] = one_operand;
-                     AI.operand_count = 1;
-                 }
-                 else
-                 {   j=0;
-                     while (i != -1) { j++; i = ET[i].right; }
-
-                     if (((sf_number != INDIRECT_SYSF) &&
-                         (sf_number != RANDOM_SYSF) && (j > 1))
-                         || ((sf_number == INDIRECT_SYSF) && (j>7)))
-                     {   j=1;
-                         error("System function given with too many arguments");
-                     }
-                     if (sf_number != RANDOM_SYSF)
-                     {   int jcount;
-                         i = ET[below].right;
-                         for (jcount = 0; jcount < j; jcount++)
-                         {   AI.operand[jcount] = ET[i].value;
-                             i = ET[i].right;
-                         }
-                         AI.operand_count = j;
-                     }
-                 }
-                 AI.store_variable_number = Result.value;
-                 AI.branch_label_number = -1;
-
-                 switch(sf_number)
-                 {   case RANDOM_SYSF:
-                         if (j>1)
-                         {  assembly_operand AO, AO2; int arg_c, arg_et;
-                            INITAOTV(&AO, SHORT_CONSTANT_OT, j);
-                            INITAOT(&AO2, LONG_CONSTANT_OT);
-                            AO2.value = begin_word_array();
-                            AO2.marker = ARRAY_MV;
-
-                            for (arg_c=0, arg_et = ET[below].right;arg_c<j;
-                                 arg_c++, arg_et = ET[arg_et].right)
-                            {   if (ET[arg_et].value.type == VARIABLE_OT)
-              error("Only constants can be used as possible 'random' results");
-                                array_entry(arg_c, FALSE, ET[arg_et].value);
-                            }
-                            finish_array(arg_c, FALSE);
-
-                            assemblez_1_to(random_zc, AO, temp_var1);
-                            assemblez_dec(temp_var1);
-                            assemblez_2_to(loadw_zc, AO2, temp_var1, Result);
-                         }
-                         else
-                         assemblez_1_to(random_zc,
-                             ET[ET[below].right].value, Result);
-                         break;
-
-                     case PARENT_SYSF:
-                         {  assembly_operand AO;
-                            AO = ET[ET[below].right].value;
-                            if (runtime_error_checking_switch)
-                                AO = check_nonzero_at_runtime(AO, -1,
-                                    PARENT_RTE);
-                            assemblez_1_to(get_parent_zc, AO, Result);
-                         }
-                         break;
-
-                     case ELDEST_SYSF:
-                     case CHILD_SYSF:
-                         {  assembly_operand AO;
-                            AO = ET[ET[below].right].value;
-                            if (runtime_error_checking_switch)
-                               AO = check_nonzero_at_runtime(AO, -1,
-                               (sf_number==CHILD_SYSF)?CHILD_RTE:ELDEST_RTE);
-                            assemblez_objcode(get_child_zc,
-                               AO, Result, -2, TRUE);
-                         }
-                         break;
-
-                     case YOUNGER_SYSF:
-                     case SIBLING_SYSF:
-                         {  assembly_operand AO;
-                            AO = ET[ET[below].right].value;
-                            if (runtime_error_checking_switch)
-                               AO = check_nonzero_at_runtime(AO, -1,
-                               (sf_number==SIBLING_SYSF)
-                                   ?SIBLING_RTE:YOUNGER_RTE);
-                            assemblez_objcode(get_sibling_zc,
-                               AO, Result, -2, TRUE);
-                         }
-                         break;
-
-                     case INDIRECT_SYSF:
-                         j=0; i = ET[below].right;
-                         check_warn_symbol_type(&ET[i].value, ROUTINE_T, 0, "indirect function call");
-                         goto IndirectFunctionCallZ;
-
-                     case CHILDREN_SYSF:
-                         {  assembly_operand AO;
-                             AO = ET[ET[below].right].value;
-                             if (runtime_error_checking_switch)
-                                 AO = check_nonzero_at_runtime(AO, -1,
-                                     CHILDREN_RTE);
-                             assemblez_store(temp_var1, zero_operand);
-                             assemblez_objcode(get_child_zc,
-                                 AO, stack_pointer, next_label+1, FALSE);
-                             assemble_label_no(next_label);
-                             assemblez_inc(temp_var1);
-                             assemblez_objcode(get_sibling_zc,
-                                 stack_pointer, stack_pointer,
-                                 next_label, TRUE);
-                             assemble_label_no(next_label+1);
-                             assemblez_store(temp_var2, stack_pointer);
-                             if (!void_flag) write_result_z(Result, temp_var1);
-                             next_label += 2;
-                         }
-                         break;
-
-                     case YOUNGEST_SYSF:
-                         {  assembly_operand AO;
-                             AO = ET[ET[below].right].value;
-                             if (runtime_error_checking_switch)
-                                 AO = check_nonzero_at_runtime(AO, -1,
-                                     YOUNGEST_RTE);
-                             assemblez_objcode(get_child_zc,
-                                 AO, temp_var1, next_label+1, FALSE);
-                             assemblez_1(push_zc, temp_var1);
-                             assemble_label_no(next_label);
-                             assemblez_store(temp_var1, stack_pointer);
-                             assemblez_objcode(get_sibling_zc,
-                                 temp_var1, stack_pointer, next_label, TRUE);
-                             assemble_label_no(next_label+1);
-                             if (!void_flag) write_result_z(Result, temp_var1);
-                             next_label += 2;
-                         }
-                         break;
-
-                     case ELDER_SYSF:
-                         assemblez_store(temp_var1, ET[ET[below].right].value);
-                         if (runtime_error_checking_switch)
-                             check_nonzero_at_runtime(temp_var1, -1,
-                                 ELDER_RTE);
-                         assemblez_1_to(get_parent_zc, temp_var1, temp_var3);
-                         assemblez_1_branch(jz_zc, temp_var3,next_label+1,TRUE);
-                         assemblez_store(temp_var2, temp_var3);
-                         assemblez_store(temp_var3, zero_operand);
-                         assemblez_objcode(get_child_zc,
-                             temp_var2, temp_var2, next_label, TRUE);
-                         assemble_label_no(next_label++);
-                         assemblez_2_branch(je_zc, temp_var1, temp_var2,
-                             next_label, TRUE);
-                         assemblez_store(temp_var3, temp_var2);
-                         assemblez_objcode(get_sibling_zc,
-                             temp_var2, temp_var2, next_label - 1, TRUE);
-                         assemble_label_no(next_label++);
-                         if (!void_flag) write_result_z(Result, temp_var3);
-                         break;
-
-                     case METACLASS_SYSF:
-                         assemblez_2_to((version_number==3)?call_zc:call_vs_zc,
-                             veneer_routine(Metaclass_VR),
-                             ET[ET[below].right].value, Result);
-                         break;
-
-                     case GLK_SYSF: 
-                         error("The glk() system function does not exist in Z-code");
-                         break;
+                 break;
+    
+            case PROP_NUM_OP:
+                 {   assembly_operand AO = ET[below].value;
+                     check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".#\" expression");
+                     check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".#\" expression");
+                     if (runtime_error_checking_switch && (!veneer_mode))
+                         AO = check_nonzero_at_runtime(AO, -1, PROP_NUM_RTE);
+                     assemblez_2_to(get_prop_addr_zc, AO,
+                         ET[ET[below].right].value, temp_var1);
+                     assemblez_1_branch(jz_zc, temp_var1, next_label++, TRUE);
+                     assemblez_1_to(get_prop_len_zc, temp_var1, temp_var1);
+                     assemble_label_no(next_label-1);
+                     if (!void_flag) write_result_z(Result, temp_var1);
                  }
                  break;
-             }
-             check_warn_symbol_type(&ET[below].value, ROUTINE_T, 0, "function call");
-
-             GenFunctionCallZ:
-
-             i = below;
-
-             IndirectFunctionCallZ:
-
-             while ((i != -1) && (j<8))
-             {   AI.operand[j++] = ET[i].value;
-                 i = ET[i].right;
-             }
-
-             if ((j > 4) && (version_number == 3))
-             {   error("A function may be called with at most 3 arguments");
-                 j = 4;
-             }
-             if ((j==8) && (i != -1))
-             {   error("A function may be called with at most 7 arguments");
-             }
-
-             AI.operand_count = j;
-
-             if ((void_flag) && (version_number >= 5))
-             {   AI.store_variable_number = -1;
-                 switch(j)
-                 {   case 1: AI.internal_number = call_1n_zc; break;
-                     case 2: AI.internal_number = call_2n_zc; break;
-                     case 3: case 4: AI.internal_number = call_vn_zc; break;
-                     case 5: case 6: case 7: case 8:
-                         AI.internal_number = call_vn2_zc; break;
+    
+            case PROPERTY_OP:
+                 {
+                     check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
+                     check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
+                     if (runtime_error_checking_switch && (!veneer_mode)) {
+                         assemblez_3_to(call_vs_zc, veneer_routine(RT__ChPR_VR),
+                             ET[below].value, ET[ET[below].right].value, temp_var1);
+                         if (!void_flag) write_result_z(Result, temp_var1);
+                     }
+                     else {
+                         if ((!void_flag) && Result.type == VARIABLE_OT) {
+                             /* store directly to variable */
+                             assemblez_2_to(get_prop_zc, ET[below].value,
+                                 ET[ET[below].right].value, Result);
+                         }
+                         else {
+                             assemblez_2_to(get_prop_zc, ET[below].value,
+                                 ET[ET[below].right].value, temp_var1);
+                             if (!void_flag) write_result_z(Result, temp_var1);
+                         }
+                     }
                  }
-             }
-             else
-             {   AI.store_variable_number = Result.value;
-                 if (version_number == 3)
-                     AI.internal_number = call_zc;
-                 else
-                 switch(j)
-                 {   case 1: AI.internal_number = call_1s_zc; break;
-                     case 2: AI.internal_number = call_2s_zc; break;
-                     case 3: case 4: AI.internal_number = call_vs_zc; break;
-                     case 5: case 6: case 7: case 8:
-                         AI.internal_number = call_vs2_zc; break;
+                 break;
+    
+            case MESSAGE_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
+                 j=1; AI.operand[0] = veneer_routine(RV__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MPROP_ADD_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".&\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
+                 j=1; AI.operand[0] = veneer_routine(RA__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MPROP_NUM_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".#\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".#\" expression");
+                 j=1; AI.operand[0] = veneer_routine(RL__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MESSAGE_SETEQUALS_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
+                 j=1; AI.operand[0] = veneer_routine(WV__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MESSAGE_INC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"++.\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"++.\" expression");
+                 j=1; AI.operand[0] = veneer_routine(IB__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MESSAGE_DEC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"--.\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"--.\" expression");
+                 j=1; AI.operand[0] = veneer_routine(DB__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MESSAGE_POST_INC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".++\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".++\" expression");
+                 j=1; AI.operand[0] = veneer_routine(IA__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MESSAGE_POST_DEC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".--\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".--\" expression");
+                 j=1; AI.operand[0] = veneer_routine(DA__Pr_VR);
+                 goto GenFunctionCallZ;
+            case SUPERCLASS_OP:
+                 j=1; AI.operand[0] = veneer_routine(RA__Sc_VR);
+                 goto GenFunctionCallZ;
+            case PROP_CALL_OP:
+                 check_warn_symbol_has_metaclass(&ET[below].value, "\".()\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".()\" expression");
+                 j=1; AI.operand[0] = veneer_routine(CA__Pr_VR);
+                 goto GenFunctionCallZ;
+            case MESSAGE_CALL_OP:
+                 check_warn_symbol_has_metaclass(&ET[below].value, "\".()\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".()\" expression");
+                 j=1; AI.operand[0] = veneer_routine(CA__Pr_VR);
+                 goto GenFunctionCallZ;
+    
+    
+            case FCALL_OP:
+                 j = 0;
+    
+                 if ((ET[below].value.type == VARIABLE_OT)
+                     && (ET[below].value.value >= 256))
+                 {   int sf_number = ET[below].value.value - 256;
+    
+                     i = ET[below].right;
+                     if (i == -1)
+                     {   error("Argument to system function missing");
+                         AI.operand[0] = one_operand;
+                         AI.operand_count = 1;
+                     }
+                     else
+                     {   j=0;
+                         while (i != -1) { j++; i = ET[i].right; }
+    
+                         if (((sf_number != INDIRECT_SYSF) &&
+                             (sf_number != RANDOM_SYSF) && (j > 1))
+                             || ((sf_number == INDIRECT_SYSF) && (j>7)))
+                         {   j=1;
+                             error("System function given with too many arguments");
+                         }
+                         if (sf_number != RANDOM_SYSF)
+                         {   int jcount;
+                             i = ET[below].right;
+                             for (jcount = 0; jcount < j; jcount++)
+                             {   AI.operand[jcount] = ET[i].value;
+                                 i = ET[i].right;
+                             }
+                             AI.operand_count = j;
+                         }
+                     }
+                     AI.store_variable_number = Result.value;
+                     AI.branch_label_number = -1;
+    
+                     switch(sf_number)
+                     {   case RANDOM_SYSF:
+                             if (j>1)
+                             {  assembly_operand AO, AO2; int arg_c, arg_et;
+                                INITAOTV(&AO, SHORT_CONSTANT_OT, j);
+                                INITAOT(&AO2, LONG_CONSTANT_OT);
+                                AO2.value = begin_word_array();
+                                AO2.marker = ARRAY_MV;
+    
+                                for (arg_c=0, arg_et = ET[below].right;arg_c<j;
+                                     arg_c++, arg_et = ET[arg_et].right)
+                                {   if (ET[arg_et].value.type == VARIABLE_OT)
+                  error("Only constants can be used as possible 'random' results");
+                                    array_entry(arg_c, FALSE, ET[arg_et].value);
+                                }
+                                finish_array(arg_c, FALSE);
+    
+                                assemblez_1_to(random_zc, AO, temp_var1);
+                                assemblez_dec(temp_var1);
+                                assemblez_2_to(loadw_zc, AO2, temp_var1, Result);
+                             }
+                             else
+                             assemblez_1_to(random_zc,
+                                 ET[ET[below].right].value, Result);
+                             break;
+    
+                         case PARENT_SYSF:
+                             {  assembly_operand AO;
+                                AO = ET[ET[below].right].value;
+                                if (runtime_error_checking_switch)
+                                    AO = check_nonzero_at_runtime(AO, -1,
+                                        PARENT_RTE);
+                                assemblez_1_to(get_parent_zc, AO, Result);
+                             }
+                             break;
+    
+                         case ELDEST_SYSF:
+                         case CHILD_SYSF:
+                             {  assembly_operand AO;
+                                AO = ET[ET[below].right].value;
+                                if (runtime_error_checking_switch)
+                                   AO = check_nonzero_at_runtime(AO, -1,
+                                   (sf_number==CHILD_SYSF)?CHILD_RTE:ELDEST_RTE);
+                                assemblez_objcode(get_child_zc,
+                                   AO, Result, -2, TRUE);
+                             }
+                             break;
+    
+                         case YOUNGER_SYSF:
+                         case SIBLING_SYSF:
+                             {  assembly_operand AO;
+                                AO = ET[ET[below].right].value;
+                                if (runtime_error_checking_switch)
+                                   AO = check_nonzero_at_runtime(AO, -1,
+                                   (sf_number==SIBLING_SYSF)
+                                       ?SIBLING_RTE:YOUNGER_RTE);
+                                assemblez_objcode(get_sibling_zc,
+                                   AO, Result, -2, TRUE);
+                             }
+                             break;
+    
+                         case INDIRECT_SYSF:
+                             j=0; i = ET[below].right;
+                             check_warn_symbol_type(&ET[i].value, ROUTINE_T, 0, "indirect function call");
+                             goto IndirectFunctionCallZ;
+    
+                         case CHILDREN_SYSF:
+                             {  assembly_operand AO;
+                                 AO = ET[ET[below].right].value;
+                                 if (runtime_error_checking_switch)
+                                     AO = check_nonzero_at_runtime(AO, -1,
+                                         CHILDREN_RTE);
+                                 assemblez_store(temp_var1, zero_operand);
+                                 assemblez_objcode(get_child_zc,
+                                     AO, stack_pointer, next_label+1, FALSE);
+                                 assemble_label_no(next_label);
+                                 assemblez_inc(temp_var1);
+                                 assemblez_objcode(get_sibling_zc,
+                                     stack_pointer, stack_pointer,
+                                     next_label, TRUE);
+                                 assemble_label_no(next_label+1);
+                                 assemblez_store(temp_var2, stack_pointer);
+                                 if (!void_flag) write_result_z(Result, temp_var1);
+                                 next_label += 2;
+                             }
+                             break;
+    
+                         case YOUNGEST_SYSF:
+                             {  assembly_operand AO;
+                                 AO = ET[ET[below].right].value;
+                                 if (runtime_error_checking_switch)
+                                     AO = check_nonzero_at_runtime(AO, -1,
+                                         YOUNGEST_RTE);
+                                 assemblez_objcode(get_child_zc,
+                                     AO, temp_var1, next_label+1, FALSE);
+                                 assemblez_1(push_zc, temp_var1);
+                                 assemble_label_no(next_label);
+                                 assemblez_store(temp_var1, stack_pointer);
+                                 assemblez_objcode(get_sibling_zc,
+                                     temp_var1, stack_pointer, next_label, TRUE);
+                                 assemble_label_no(next_label+1);
+                                 if (!void_flag) write_result_z(Result, temp_var1);
+                                 next_label += 2;
+                             }
+                             break;
+    
+                         case ELDER_SYSF:
+                             assemblez_store(temp_var1, ET[ET[below].right].value);
+                             if (runtime_error_checking_switch)
+                                 check_nonzero_at_runtime(temp_var1, -1,
+                                     ELDER_RTE);
+                             assemblez_1_to(get_parent_zc, temp_var1, temp_var3);
+                             assemblez_1_branch(jz_zc, temp_var3,next_label+1,TRUE);
+                             assemblez_store(temp_var2, temp_var3);
+                             assemblez_store(temp_var3, zero_operand);
+                             assemblez_objcode(get_child_zc,
+                                 temp_var2, temp_var2, next_label, TRUE);
+                             assemble_label_no(next_label++);
+                             assemblez_2_branch(je_zc, temp_var1, temp_var2,
+                                 next_label, TRUE);
+                             assemblez_store(temp_var3, temp_var2);
+                             assemblez_objcode(get_sibling_zc,
+                                 temp_var2, temp_var2, next_label - 1, TRUE);
+                             assemble_label_no(next_label++);
+                             if (!void_flag) write_result_z(Result, temp_var3);
+                             break;
+    
+                         case METACLASS_SYSF:
+                             assemblez_2_to((version_number==3)?call_zc:call_vs_zc,
+                                 veneer_routine(Metaclass_VR),
+                                 ET[ET[below].right].value, Result);
+                             break;
+    
+                         case GLK_SYSF: 
+                             error("The glk() system function does not exist in Z-code");
+                             break;
+                     }
+                     break;
                  }
-             }
-
-             AI.branch_label_number = -1;
-             assemblez_instruction(&AI);
-             break;
-
-        case SETEQUALS_OP:
-             assemblez_store(ET[below].value,
-                 ET[ET[below].right].value);
-             if (!void_flag) write_result_z(Result, ET[below].value);
-             break;
-
-        case PROPERTY_SETEQUALS_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-             if (!void_flag)
-             {   if (runtime_error_checking_switch)
-                     assemblez_4_to(call_zc, veneer_routine(RT__ChPS_VR),
-                         ET[below].value, ET[ET[below].right].value,
-                         ET[ET[ET[below].right].right].value, Result);
+                 check_warn_symbol_type(&ET[below].value, ROUTINE_T, 0, "function call");
+    
+                 GenFunctionCallZ:
+    
+                 i = below;
+    
+                 IndirectFunctionCallZ:
+    
+                 while ((i != -1) && (j<8))
+                 {   AI.operand[j++] = ET[i].value;
+                     i = ET[i].right;
+                 }
+    
+                 if ((j > 4) && (version_number == 3))
+                 {   error("A function may be called with at most 3 arguments");
+                     j = 4;
+                 }
+                 if ((j==8) && (i != -1))
+                 {   error("A function may be called with at most 7 arguments");
+                 }
+    
+                 AI.operand_count = j;
+    
+                 if ((void_flag) && (version_number >= 5))
+                 {   AI.store_variable_number = -1;
+                     switch(j)
+                     {   case 1: AI.internal_number = call_1n_zc; break;
+                         case 2: AI.internal_number = call_2n_zc; break;
+                         case 3: case 4: AI.internal_number = call_vn_zc; break;
+                         case 5: case 6: case 7: case 8:
+                             AI.internal_number = call_vn2_zc; break;
+                     }
+                 }
                  else
+                 {   AI.store_variable_number = Result.value;
+                     if (version_number == 3)
+                         AI.internal_number = call_zc;
+                     else
+                     switch(j)
+                     {   case 1: AI.internal_number = call_1s_zc; break;
+                         case 2: AI.internal_number = call_2s_zc; break;
+                         case 3: case 4: AI.internal_number = call_vs_zc; break;
+                         case 5: case 6: case 7: case 8:
+                             AI.internal_number = call_vs2_zc; break;
+                     }
+                 }
+    
+                 AI.branch_label_number = -1;
+                 assemblez_instruction(&AI);
+                 break;
+    
+            case SETEQUALS_OP:
+                 assemblez_store(ET[below].value,
+                     ET[ET[below].right].value);
+                 if (!void_flag) write_result_z(Result, ET[below].value);
+                 break;
+    
+            case PROPERTY_SETEQUALS_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
+                 if (!void_flag)
+                 {   if (runtime_error_checking_switch)
+                         assemblez_4_to(call_zc, veneer_routine(RT__ChPS_VR),
+                             ET[below].value, ET[ET[below].right].value,
+                             ET[ET[ET[below].right].right].value, Result);
+                     else
+                     {   assemblez_store(temp_var1,
+                             ET[ET[ET[below].right].right].value);
+                         assemblez_3(put_prop_zc, ET[below].value,
+                             ET[ET[below].right].value,
+                             temp_var1);
+                         write_result_z(Result, temp_var1);
+                     }
+                 }
+                 else
+                 {   if (runtime_error_checking_switch && (!veneer_mode))
+                         assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
+                             ET[below].value, ET[ET[below].right].value,
+                             ET[ET[ET[below].right].right].value);
+                     else assemblez_3(put_prop_zc, ET[below].value,
+                         ET[ET[below].right].value,
+                         ET[ET[ET[below].right].right].value);
+                 }
+                 break;
+            case ARROW_SETEQUALS_OP:
+                 if (!void_flag)
                  {   assemblez_store(temp_var1,
                          ET[ET[ET[below].right].right].value);
-                     assemblez_3(put_prop_zc, ET[below].value,
+                     access_memory_z(storeb_zc, ET[below].value,
                          ET[ET[below].right].value,
                          temp_var1);
                      write_result_z(Result, temp_var1);
                  }
-             }
-             else
-             {   if (runtime_error_checking_switch && (!veneer_mode))
-                     assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
-                         ET[below].value, ET[ET[below].right].value,
+                 else access_memory_z(storeb_zc, ET[below].value,
+                         ET[ET[below].right].value,
                          ET[ET[ET[below].right].right].value);
-                 else assemblez_3(put_prop_zc, ET[below].value,
-                     ET[ET[below].right].value,
-                     ET[ET[ET[below].right].right].value);
-             }
-             break;
-        case ARROW_SETEQUALS_OP:
-             if (!void_flag)
-             {   assemblez_store(temp_var1,
-                     ET[ET[ET[below].right].right].value);
-                 access_memory_z(storeb_zc, ET[below].value,
-                     ET[ET[below].right].value,
-                     temp_var1);
-                 write_result_z(Result, temp_var1);
-             }
-             else access_memory_z(storeb_zc, ET[below].value,
-                     ET[ET[below].right].value,
-                     ET[ET[ET[below].right].right].value);
-             break;
-
-        case DARROW_SETEQUALS_OP:
-             if (!void_flag)
-             {   assemblez_store(temp_var1,
-                     ET[ET[ET[below].right].right].value);
-                 access_memory_z(storew_zc, ET[below].value,
-                     ET[ET[below].right].value,
-                     temp_var1);
-                 write_result_z(Result, temp_var1);
-             }
-             else
-                 access_memory_z(storew_zc, ET[below].value,
-                     ET[ET[below].right].value,
-                     ET[ET[ET[below].right].right].value);
-             break;
-
-        case INC_OP:
-             assemblez_inc(ET[below].value);
-             if (!void_flag) write_result_z(Result, ET[below].value);
-             break;
-        case DEC_OP:
-             assemblez_dec(ET[below].value);
-             if (!void_flag) write_result_z(Result, ET[below].value);
-             break;
-        case POST_INC_OP:
-             if (!void_flag) write_result_z(Result, ET[below].value);
-             assemblez_inc(ET[below].value);
-             break;
-        case POST_DEC_OP:
-             if (!void_flag) write_result_z(Result, ET[below].value);
-             assemblez_dec(ET[below].value);
-             break;
-
-        case ARROW_INC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
-             assemblez_inc(temp_var3);
-             access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             break;
-
-        case ARROW_DEC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
-             assemblez_dec(temp_var3);
-             access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             break;
-
-        case ARROW_POST_INC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             assemblez_inc(temp_var3);
-             access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case ARROW_POST_DEC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             assemblez_dec(temp_var3);
-             access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case DARROW_INC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
-             assemblez_inc(temp_var3);
-             access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             break;
-
-        case DARROW_DEC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
-             assemblez_dec(temp_var3);
-             access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             break;
-
-        case DARROW_POST_INC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             assemblez_inc(temp_var3);
-             access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case DARROW_POST_DEC_OP:
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             assemblez_dec(temp_var3);
-             access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case PROPERTY_INC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"++.\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"++.\" expression");
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
-             assemblez_inc(temp_var3);
-             if (runtime_error_checking_switch && (!veneer_mode))
-                  assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
-                         temp_var1, temp_var2, temp_var3);
-             else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             break;
-
-        case PROPERTY_DEC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"--.\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"--.\" expression");
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
-             assemblez_dec(temp_var3);
-             if (runtime_error_checking_switch && (!veneer_mode))
-                  assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
-                         temp_var1, temp_var2, temp_var3);
-             else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             break;
-
-        case PROPERTY_POST_INC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".++\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".++\" expression");
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             assemblez_inc(temp_var3);
-             if (runtime_error_checking_switch && (!veneer_mode))
-                  assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
-                         temp_var1, temp_var2, temp_var3);
-             else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case PROPERTY_POST_DEC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".--\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".--\" expression");
-             assemblez_store(temp_var1, ET[below].value);
-             assemblez_store(temp_var2, ET[ET[below].right].value);
-             assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_z(Result, temp_var3);
-             assemblez_dec(temp_var3);
-             if (runtime_error_checking_switch && (!veneer_mode))
-                  assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
-                         temp_var1, temp_var2, temp_var3);
-             else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        default:
-            printf("** Trouble op = %d i.e. '%s' **\n",
-                opnum, operators[opnum].description);
-            compiler_error("Expr code gen: Can't generate yet");
+                 break;
+    
+            case DARROW_SETEQUALS_OP:
+                 if (!void_flag)
+                 {   assemblez_store(temp_var1,
+                         ET[ET[ET[below].right].right].value);
+                     access_memory_z(storew_zc, ET[below].value,
+                         ET[ET[below].right].value,
+                         temp_var1);
+                     write_result_z(Result, temp_var1);
+                 }
+                 else
+                     access_memory_z(storew_zc, ET[below].value,
+                         ET[ET[below].right].value,
+                         ET[ET[ET[below].right].right].value);
+                 break;
+    
+            case INC_OP:
+                 assemblez_inc(ET[below].value);
+                 if (!void_flag) write_result_z(Result, ET[below].value);
+                 break;
+            case DEC_OP:
+                 assemblez_dec(ET[below].value);
+                 if (!void_flag) write_result_z(Result, ET[below].value);
+                 break;
+            case POST_INC_OP:
+                 if (!void_flag) write_result_z(Result, ET[below].value);
+                 assemblez_inc(ET[below].value);
+                 break;
+            case POST_DEC_OP:
+                 if (!void_flag) write_result_z(Result, ET[below].value);
+                 assemblez_dec(ET[below].value);
+                 break;
+    
+            case ARROW_INC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
+                 assemblez_inc(temp_var3);
+                 access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 break;
+    
+            case ARROW_DEC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
+                 assemblez_dec(temp_var3);
+                 access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 break;
+    
+            case ARROW_POST_INC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 assemblez_inc(temp_var3);
+                 access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case ARROW_POST_DEC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadb_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 assemblez_dec(temp_var3);
+                 access_memory_z(storeb_zc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case DARROW_INC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
+                 assemblez_inc(temp_var3);
+                 access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 break;
+    
+            case DARROW_DEC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
+                 assemblez_dec(temp_var3);
+                 access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 break;
+    
+            case DARROW_POST_INC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 assemblez_inc(temp_var3);
+                 access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case DARROW_POST_DEC_OP:
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_z(loadw_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 assemblez_dec(temp_var3);
+                 access_memory_z(storew_zc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case PROPERTY_INC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"++.\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"++.\" expression");
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
+                 assemblez_inc(temp_var3);
+                 if (runtime_error_checking_switch && (!veneer_mode))
+                      assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
+                             temp_var1, temp_var2, temp_var3);
+                 else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 break;
+    
+            case PROPERTY_DEC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"--.\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"--.\" expression");
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
+                 assemblez_dec(temp_var3);
+                 if (runtime_error_checking_switch && (!veneer_mode))
+                      assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
+                             temp_var1, temp_var2, temp_var3);
+                 else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 break;
+    
+            case PROPERTY_POST_INC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".++\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".++\" expression");
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 assemblez_inc(temp_var3);
+                 if (runtime_error_checking_switch && (!veneer_mode))
+                      assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
+                             temp_var1, temp_var2, temp_var3);
+                 else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case PROPERTY_POST_DEC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".--\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".--\" expression");
+                 assemblez_store(temp_var1, ET[below].value);
+                 assemblez_store(temp_var2, ET[ET[below].right].value);
+                 assemblez_2_to(get_prop_zc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_z(Result, temp_var3);
+                 assemblez_dec(temp_var3);
+                 if (runtime_error_checking_switch && (!veneer_mode))
+                      assemblez_4(call_vn_zc, veneer_routine(RT__ChPS_VR),
+                             temp_var1, temp_var2, temp_var3);
+                 else assemblez_3(put_prop_zc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            default:
+                printf("** Trouble op = %d i.e. '%s' **\n",
+                    opnum, operators[opnum].description);
+                compiler_error("Expr code gen: Can't generate yet");
+        }
     }
-  }
-  else { /* Glulx */
-    assembly_operand AO, AO2;
-    if (operators[opnum].opcode_number_g != -1)
-    {
-        /*  Operators directly translatable into opcodes: infix ops
-            take two operands whereas pre/postfix operators take only one */
-
-        if (operators[opnum].usage == IN_U)
-        {   int o_n = operators[opnum].opcode_number_g;
-            if (runtime_error_checking_switch && (!veneer_mode)
-                && ((o_n == div_gc) || (o_n == mod_gc)))
-            {   assembly_operand by_ao, error_ao; int ln;
-                by_ao = ET[ET[below].right].value;
-                if ((by_ao.value != 0) && (by_ao.marker == 0)
-                    && is_constant_ot(by_ao.type))
+    else { /* Glulx */
+        assembly_operand AO, AO2;
+        if (operators[opnum].opcode_number_g != -1)
+        {
+            /*  Operators directly translatable into opcodes: infix ops
+                take two operands whereas pre/postfix operators take only one */
+    
+            if (operators[opnum].usage == IN_U)
+            {   int o_n = operators[opnum].opcode_number_g;
+                if (runtime_error_checking_switch && (!veneer_mode)
+                    && ((o_n == div_gc) || (o_n == mod_gc)))
+                {   assembly_operand by_ao, error_ao; int ln;
+                    by_ao = ET[ET[below].right].value;
+                    if ((by_ao.value != 0) && (by_ao.marker == 0)
+                        && is_constant_ot(by_ao.type))
+                        assembleg_3(o_n, ET[below].value,
+                            by_ao, Result);
+                    else
+                    {   assembleg_store(temp_var1, ET[below].value);
+                        assembleg_store(temp_var2, by_ao);
+                        ln = next_label++;
+                        assembleg_1_branch(jnz_gc, temp_var2, ln);
+                        INITAO(&error_ao);
+                        error_ao.value = DBYZERO_RTE;
+                        set_constant_ot(&error_ao);
+                        assembleg_call_1(veneer_routine(RT__Err_VR),
+                          error_ao, zero_operand);
+                        assembleg_store(temp_var2, one_operand);
+                        assemble_label_no(ln);
+                        assembleg_3(o_n, temp_var1, temp_var2, Result);
+                    }
+                }
+                else if (try_optimize_expr_g(o_n, ET[below].value,
+                    ET[ET[below].right].value, Result)) {
+                    /* generated simplified code */
+                }
+                else {
                     assembleg_3(o_n, ET[below].value,
-                        by_ao, Result);
-                else
-                {   assembleg_store(temp_var1, ET[below].value);
-                    assembleg_store(temp_var2, by_ao);
-                    ln = next_label++;
-                    assembleg_1_branch(jnz_gc, temp_var2, ln);
-                    INITAO(&error_ao);
-                    error_ao.value = DBYZERO_RTE;
-                    set_constant_ot(&error_ao);
-                    assembleg_call_1(veneer_routine(RT__Err_VR),
-                      error_ao, zero_operand);
-                    assembleg_store(temp_var2, one_operand);
-                    assemble_label_no(ln);
-                    assembleg_3(o_n, temp_var1, temp_var2, Result);
+                        ET[ET[below].right].value, Result);
                 }
             }
-            else if (try_optimize_expr_g(o_n, ET[below].value,
-                ET[ET[below].right].value, Result)) {
-                /* generated simplified code */
-            }
-            else {
-                assembleg_3(o_n, ET[below].value,
-                    ET[ET[below].right].value, Result);
-            }
+            else
+                assembleg_2(operators[opnum].opcode_number_g, ET[below].value,
+                    Result);
         }
         else
-            assembleg_2(operators[opnum].opcode_number_g, ET[below].value,
-                Result);
-    }
-    else
-    switch(opnum)
-    {
-
-        case PUSH_OP:
-             if (ET[below].value.type == Result.type
-               && ET[below].value.value == Result.value
-               && ET[below].value.marker == Result.marker)
-               break;
-             assembleg_2(copy_gc, ET[below].value, Result);
-             break;
-
-        case UNARY_MINUS_OP:
-             assembleg_2(neg_gc, ET[below].value, Result);
-             break;
-        case ARTNOT_OP:
-             assembleg_2(bitnot_gc, ET[below].value, Result);
-             break;
-
-        case ARROW_OP:
-             access_memory_g(aloadb_gc, ET[below].value,
-                                      ET[ET[below].right].value, Result);
-             break;
-        case DARROW_OP:
-             access_memory_g(aload_gc, ET[below].value,
-                                     ET[ET[below].right].value, Result);
-             break;
-
-        case SETEQUALS_OP:
-             assembleg_store(ET[below].value,
-                 ET[ET[below].right].value);
-             if (!void_flag) write_result_g(Result, ET[below].value);
-             break;
-
-        case ARROW_SETEQUALS_OP:
-             if (!void_flag)
-             {   assembleg_store(temp_var1,
-                     ET[ET[ET[below].right].right].value);
-                 access_memory_g(astoreb_gc, ET[below].value,
-                     ET[ET[below].right].value,
-                     temp_var1);
-                 write_result_g(Result, temp_var1);
-             }
-             else access_memory_g(astoreb_gc, ET[below].value,
-                     ET[ET[below].right].value,
-                     ET[ET[ET[below].right].right].value);
-             break;
-
-        case DARROW_SETEQUALS_OP:
-             if (!void_flag)
-             {   assembleg_store(temp_var1,
-                     ET[ET[ET[below].right].right].value);
-                 access_memory_g(astore_gc, ET[below].value,
-                     ET[ET[below].right].value,
-                     temp_var1);
-                 write_result_g(Result, temp_var1);
-             }
-             else
-                 access_memory_g(astore_gc, ET[below].value,
-                     ET[ET[below].right].value,
-                     ET[ET[ET[below].right].right].value);
-             break;
-
-        case INC_OP:
-             assembleg_inc(ET[below].value);
-             if (!void_flag) write_result_g(Result, ET[below].value);
-             break;
-        case DEC_OP:
-             assembleg_dec(ET[below].value);
-             if (!void_flag) write_result_g(Result, ET[below].value);
-             break;
-        case POST_INC_OP:
-             if (!void_flag) write_result_g(Result, ET[below].value);
-             assembleg_inc(ET[below].value);
-             break;
-        case POST_DEC_OP:
-             if (!void_flag) write_result_g(Result, ET[below].value);
-             assembleg_dec(ET[below].value);
-             break;
-
-        case ARROW_INC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
-             assembleg_inc(temp_var3);
-             access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             break;
-
-        case ARROW_DEC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
-             assembleg_dec(temp_var3);
-             access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             break;
-
-        case ARROW_POST_INC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             assembleg_inc(temp_var3);
-             access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case ARROW_POST_DEC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             assembleg_dec(temp_var3);
-             access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case DARROW_INC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
-             assembleg_inc(temp_var3);
-             access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             break;
-
-        case DARROW_DEC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
-             assembleg_dec(temp_var3);
-             access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             break;
-
-        case DARROW_POST_INC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             assembleg_inc(temp_var3);
-             access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case DARROW_POST_DEC_OP:
-             assembleg_store(temp_var1, ET[below].value);
-             assembleg_store(temp_var2, ET[ET[below].right].value);
-             access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
-             if (!void_flag) write_result_g(Result, temp_var3);
-             assembleg_dec(temp_var3);
-             access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
-             break;
-
-        case PROPERTY_OP:
-        case MESSAGE_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-             AO = veneer_routine(RV__Pr_VR);
-             goto TwoArgFunctionCall;
-        case MPROP_ADD_OP:
-        case PROP_ADD_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".&\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
-             AO = veneer_routine(RA__Pr_VR);
-             goto TwoArgFunctionCall;
-        case MPROP_NUM_OP:
-        case PROP_NUM_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".#\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".#\" expression");
-             AO = veneer_routine(RL__Pr_VR);
-             goto TwoArgFunctionCall;
-
-        case PROP_CALL_OP:
-        case MESSAGE_CALL_OP:
-             check_warn_symbol_has_metaclass(&ET[below].value, "\".()\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".()\" expression");
-             AO2 = veneer_routine(CA__Pr_VR);
-             i = below;
-             goto DoFunctionCall;
-
-        case MESSAGE_INC_OP:
-        case PROPERTY_INC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"++.\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"++.\" expression");
-             AO = veneer_routine(IB__Pr_VR);
-             goto TwoArgFunctionCall;
-        case MESSAGE_DEC_OP:
-        case PROPERTY_DEC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"--.\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"--.\" expression");
-             AO = veneer_routine(DB__Pr_VR);
-             goto TwoArgFunctionCall;
-        case MESSAGE_POST_INC_OP:
-        case PROPERTY_POST_INC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".++\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".++\" expression");
-             AO = veneer_routine(IA__Pr_VR);
-             goto TwoArgFunctionCall;
-        case MESSAGE_POST_DEC_OP:
-        case PROPERTY_POST_DEC_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".--\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".--\" expression");
-             AO = veneer_routine(DA__Pr_VR);
-             goto TwoArgFunctionCall;
-        case SUPERCLASS_OP:
-             AO = veneer_routine(RA__Sc_VR);
-             goto TwoArgFunctionCall;
-
-             TwoArgFunctionCall:
-             {
-               assembly_operand AO2 = ET[below].value;
-               assembly_operand AO3 = ET[ET[below].right].value;
-               if (void_flag)
-                 assembleg_call_2(AO, AO2, AO3, zero_operand);
-               else
-                 assembleg_call_2(AO, AO2, AO3, Result);
-             }
-             break;
-
-        case PROPERTY_SETEQUALS_OP:
-        case MESSAGE_SETEQUALS_OP:
-             check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
-             check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
-             if (runtime_error_checking_switch && (!veneer_mode))
-                 AO = veneer_routine(RT__ChPS_VR);
-               else
-                 AO = veneer_routine(WV__Pr_VR);
-
-             {
-               assembly_operand AO2 = ET[below].value;
-               assembly_operand AO3 = ET[ET[below].right].value;
-               assembly_operand AO4 = ET[ET[ET[below].right].right].value;
-               if (AO4.type == LOCALVAR_OT && AO4.value == 0) {
-                 /* Rightmost is on the stack; reduce to previous case. */
-                 if (AO2.type == LOCALVAR_OT && AO2.value == 0) {
-                   if (AO3.type == LOCALVAR_OT && AO3.value == 0) {
-                     /* both already on stack. */
-                   }
-                   else {
-                     assembleg_store(stack_pointer, AO3);
-                     assembleg_0(stkswap_gc);
-                   }
+        switch(opnum)
+        {
+    
+            case PUSH_OP:
+                 if (ET[below].value.type == Result.type
+                   && ET[below].value.value == Result.value
+                   && ET[below].value.marker == Result.marker)
+                   break;
+                 assembleg_2(copy_gc, ET[below].value, Result);
+                 break;
+    
+            case UNARY_MINUS_OP:
+                 assembleg_2(neg_gc, ET[below].value, Result);
+                 break;
+            case ARTNOT_OP:
+                 assembleg_2(bitnot_gc, ET[below].value, Result);
+                 break;
+    
+            case ARROW_OP:
+                 access_memory_g(aloadb_gc, ET[below].value,
+                                          ET[ET[below].right].value, Result);
+                 break;
+            case DARROW_OP:
+                 access_memory_g(aload_gc, ET[below].value,
+                                         ET[ET[below].right].value, Result);
+                 break;
+    
+            case SETEQUALS_OP:
+                 assembleg_store(ET[below].value,
+                     ET[ET[below].right].value);
+                 if (!void_flag) write_result_g(Result, ET[below].value);
+                 break;
+    
+            case ARROW_SETEQUALS_OP:
+                 if (!void_flag)
+                 {   assembleg_store(temp_var1,
+                         ET[ET[ET[below].right].right].value);
+                     access_memory_g(astoreb_gc, ET[below].value,
+                         ET[ET[below].right].value,
+                         temp_var1);
+                     write_result_g(Result, temp_var1);
                  }
-                 else {
-                   if (AO3.type == LOCALVAR_OT && AO3.value == 0) {
-                     assembleg_store(stack_pointer, AO2);
-                   }
-                   else {
-                     assembleg_store(stack_pointer, AO3);
-                     assembleg_store(stack_pointer, AO2);
-                   }
-                 }
-               }
-               else {
-                 /* We have to get the rightmost on the stack, below the 
-                    others. */
-                 if (AO3.type == LOCALVAR_OT && AO3.value == 0) {
-                   if (AO2.type == LOCALVAR_OT && AO2.value == 0) {
-                     assembleg_store(stack_pointer, AO4);
-                     assembleg_2(stkroll_gc, three_operand, one_operand);
-                   }
-                   else {
-                     assembleg_store(stack_pointer, AO4);
-                     assembleg_0(stkswap_gc);
-                     assembleg_store(stack_pointer, AO2); 
-                   }
-                 }
-                 else {
-                   if (AO2.type == LOCALVAR_OT && AO2.value == 0) {
-                     assembleg_store(stack_pointer, AO4);
-                     assembleg_store(stack_pointer, AO3);
-                     assembleg_2(stkroll_gc, three_operand, two_operand);
-                   }
-                   else {
-                     assembleg_store(stack_pointer, AO4);
-                     assembleg_store(stack_pointer, AO3);
-                     assembleg_store(stack_pointer, AO2);
-                   }
-                 }
-               }
-               if (void_flag)
-                 assembleg_3(call_gc, AO, three_operand, zero_operand);
-               else
-                 assembleg_3(call_gc, AO, three_operand, Result);
-             }
-             break;
-
-        case FCALL_OP:
-             j = 0;
-
-             if (ET[below].value.type == SYSFUN_OT)
-             {   int sf_number = ET[below].value.value;
-
-                 i = ET[below].right;
-                 if (i == -1)
-                 {   error("Argument to system function missing");
-                     AI.operand[0] = one_operand;
-                     AI.operand_count = 1;
+                 else access_memory_g(astoreb_gc, ET[below].value,
+                         ET[ET[below].right].value,
+                         ET[ET[ET[below].right].right].value);
+                 break;
+    
+            case DARROW_SETEQUALS_OP:
+                 if (!void_flag)
+                 {   assembleg_store(temp_var1,
+                         ET[ET[ET[below].right].right].value);
+                     access_memory_g(astore_gc, ET[below].value,
+                         ET[ET[below].right].value,
+                         temp_var1);
+                     write_result_g(Result, temp_var1);
                  }
                  else
-                 {   j=0;
-                     while (i != -1) { j++; i = ET[i].right; }
-
-                     if (((sf_number != INDIRECT_SYSF) &&
-                         (sf_number != GLK_SYSF) &&
-                         (sf_number != RANDOM_SYSF) && (j > 1)))
-                     {   j=1;
-                         error("System function given with too many arguments");
-                     }
-                     if (sf_number != RANDOM_SYSF)
-                     {   int jcount;
-                         i = ET[below].right;
-                         for (jcount = 0; jcount < j; jcount++)
-                         {   AI.operand[jcount] = ET[i].value;
-                             i = ET[i].right;
-                         }
-                         AI.operand_count = j;
-                     }
-                 }
-
-                 switch(sf_number)
+                     access_memory_g(astore_gc, ET[below].value,
+                         ET[ET[below].right].value,
+                         ET[ET[ET[below].right].right].value);
+                 break;
+    
+            case INC_OP:
+                 assembleg_inc(ET[below].value);
+                 if (!void_flag) write_result_g(Result, ET[below].value);
+                 break;
+            case DEC_OP:
+                 assembleg_dec(ET[below].value);
+                 if (!void_flag) write_result_g(Result, ET[below].value);
+                 break;
+            case POST_INC_OP:
+                 if (!void_flag) write_result_g(Result, ET[below].value);
+                 assembleg_inc(ET[below].value);
+                 break;
+            case POST_DEC_OP:
+                 if (!void_flag) write_result_g(Result, ET[below].value);
+                 assembleg_dec(ET[below].value);
+                 break;
+    
+            case ARROW_INC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
+                 assembleg_inc(temp_var3);
+                 access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 break;
+    
+            case ARROW_DEC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
+                 assembleg_dec(temp_var3);
+                 access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 break;
+    
+            case ARROW_POST_INC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 assembleg_inc(temp_var3);
+                 access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case ARROW_POST_DEC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aloadb_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 assembleg_dec(temp_var3);
+                 access_memory_g(astoreb_gc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case DARROW_INC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
+                 assembleg_inc(temp_var3);
+                 access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 break;
+    
+            case DARROW_DEC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
+                 assembleg_dec(temp_var3);
+                 access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 break;
+    
+            case DARROW_POST_INC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 assembleg_inc(temp_var3);
+                 access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case DARROW_POST_DEC_OP:
+                 assembleg_store(temp_var1, ET[below].value);
+                 assembleg_store(temp_var2, ET[ET[below].right].value);
+                 access_memory_g(aload_gc, temp_var1, temp_var2, temp_var3);
+                 if (!void_flag) write_result_g(Result, temp_var3);
+                 assembleg_dec(temp_var3);
+                 access_memory_g(astore_gc, temp_var1, temp_var2, temp_var3);
+                 break;
+    
+            case PROPERTY_OP:
+            case MESSAGE_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
+                 AO = veneer_routine(RV__Pr_VR);
+                 goto TwoArgFunctionCall;
+            case MPROP_ADD_OP:
+            case PROP_ADD_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".&\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".&\" expression");
+                 AO = veneer_routine(RA__Pr_VR);
+                 goto TwoArgFunctionCall;
+            case MPROP_NUM_OP:
+            case PROP_NUM_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".#\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".#\" expression");
+                 AO = veneer_routine(RL__Pr_VR);
+                 goto TwoArgFunctionCall;
+    
+            case PROP_CALL_OP:
+            case MESSAGE_CALL_OP:
+                 check_warn_symbol_has_metaclass(&ET[below].value, "\".()\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".()\" expression");
+                 AO2 = veneer_routine(CA__Pr_VR);
+                 i = below;
+                 goto DoFunctionCall;
+    
+            case MESSAGE_INC_OP:
+            case PROPERTY_INC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"++.\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"++.\" expression");
+                 AO = veneer_routine(IB__Pr_VR);
+                 goto TwoArgFunctionCall;
+            case MESSAGE_DEC_OP:
+            case PROPERTY_DEC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\"--.\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\"--.\" expression");
+                 AO = veneer_routine(DB__Pr_VR);
+                 goto TwoArgFunctionCall;
+            case MESSAGE_POST_INC_OP:
+            case PROPERTY_POST_INC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".++\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".++\" expression");
+                 AO = veneer_routine(IA__Pr_VR);
+                 goto TwoArgFunctionCall;
+            case MESSAGE_POST_DEC_OP:
+            case PROPERTY_POST_DEC_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".--\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".--\" expression");
+                 AO = veneer_routine(DA__Pr_VR);
+                 goto TwoArgFunctionCall;
+            case SUPERCLASS_OP:
+                 AO = veneer_routine(RA__Sc_VR);
+                 goto TwoArgFunctionCall;
+    
+                 TwoArgFunctionCall:
                  {
-                     case RANDOM_SYSF:
-                         if (j>1)
-                         {  assembly_operand AO, AO2; 
-                            int arg_c, arg_et;
-                            INITAO(&AO);
-                            AO.value = j; 
-                            set_constant_ot(&AO);
-                            INITAOTV(&AO2, CONSTANT_OT, begin_word_array());
-                            AO2.marker = ARRAY_MV;
-
-                            for (arg_c=0, arg_et = ET[below].right;arg_c<j;
-                                 arg_c++, arg_et = ET[arg_et].right)
-                            {   if (ET[arg_et].value.type == LOCALVAR_OT
-                                    || ET[arg_et].value.type == GLOBALVAR_OT)
-              error("Only constants can be used as possible 'random' results");
-                                array_entry(arg_c, FALSE, ET[arg_et].value);
-                            }
-                            finish_array(arg_c, FALSE);
-
-                            assembleg_2(random_gc, AO, stack_pointer);
-                            assembleg_3(aload_gc, AO2, stack_pointer, Result);
-                         }
-                         else if (is_constant_ot(ET[ET[below].right].value.type) && ET[ET[below].right].value.marker == 0) {
-                           /* One argument, value known at compile time */
-                           int32 arg = ET[ET[below].right].value.value; /* signed */
-                           if (arg > 0) {
-                             assembly_operand AO;
-                             INITAO(&AO);
-                             AO.value = arg;
-                             set_constant_ot(&AO);
-                             assembleg_2(random_gc,
-                               AO, stack_pointer);
-                             assembleg_3(add_gc, stack_pointer, one_operand,
-                               Result);
-                           }
-                           else {
-                             /* This handles zero or negative */
-                             assembly_operand AO;
-                             INITAO(&AO);
-                             AO.value = -arg;
-                             set_constant_ot(&AO);
-                             assembleg_1(setrandom_gc,
-                               AO);
-                             assembleg_store(Result, zero_operand);
-                           }
-                         }
-                         else {
-                           /* One argument, not known at compile time */
-                           int ln, ln2;
-                           assembleg_store(temp_var1, ET[ET[below].right].value);
-                           ln = next_label++;
-                           ln2 = next_label++;
-                           assembleg_2_branch(jle_gc, temp_var1, zero_operand, ln);
-                           assembleg_2(random_gc,
-                             temp_var1, stack_pointer);
-                           assembleg_3(add_gc, stack_pointer, one_operand,
-                             Result);
-                           assembleg_0_branch(jump_gc, ln2);
-                           assemble_label_no(ln);
-                           assembleg_2(neg_gc, temp_var1, stack_pointer);
-                           assembleg_1(setrandom_gc,
-                             stack_pointer);
-                           assembleg_store(Result, zero_operand);
-                           assemble_label_no(ln2);
-                         }
-                         break;
-
-                     case PARENT_SYSF:
-                         {  assembly_operand AO;
-                            AO = ET[ET[below].right].value;
-                            if (runtime_error_checking_switch)
-                                AO = check_nonzero_at_runtime(AO, -1,
-                                    PARENT_RTE);
-                            INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_PARENT());
-                            assembleg_3(aload_gc, AO, AO2, Result);
-                         }
-                         break;
-
-                     case ELDEST_SYSF:
-                     case CHILD_SYSF:
-                         {  assembly_operand AO;
-                            AO = ET[ET[below].right].value;
-                            if (runtime_error_checking_switch)
-                               AO = check_nonzero_at_runtime(AO, -1,
-                               (sf_number==CHILD_SYSF)?CHILD_RTE:ELDEST_RTE);
-                            INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
-                            assembleg_3(aload_gc, AO, AO2, Result);
-                         }
-                         break;
-
-                     case YOUNGER_SYSF:
-                     case SIBLING_SYSF:
-                         {  assembly_operand AO;
-                            AO = ET[ET[below].right].value;
-                            if (runtime_error_checking_switch)
-                               AO = check_nonzero_at_runtime(AO, -1,
-                               (sf_number==SIBLING_SYSF)
-                                   ?SIBLING_RTE:YOUNGER_RTE);
-                            INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_SIBLING());
-                            assembleg_3(aload_gc, AO, AO2, Result);
-                         }
-                         break;
-
-                     case CHILDREN_SYSF:
-                         {  assembly_operand AO;
-                            AO = ET[ET[below].right].value;
-                            if (runtime_error_checking_switch)
-                                AO = check_nonzero_at_runtime(AO, -1,
-                                    CHILDREN_RTE);
-                            INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
-                            assembleg_store(temp_var1, zero_operand);
-                            assembleg_3(aload_gc, AO, AO2, temp_var2);
-                            AO2.value = GOBJFIELD_SIBLING();
-                            assemble_label_no(next_label);
-                            assembleg_1_branch(jz_gc, temp_var2, next_label+1);
-                            assembleg_3(add_gc, temp_var1, one_operand, 
-                              temp_var1);
-                            assembleg_3(aload_gc, temp_var2, AO2, temp_var2);
-                            assembleg_0_branch(jump_gc, next_label);
-                            assemble_label_no(next_label+1);
-                            next_label += 2;
-                            if (!void_flag) 
-                              write_result_g(Result, temp_var1);
-                         }
-                         break;
-
-                     case INDIRECT_SYSF: 
-                         i = ET[below].right;
-                         check_warn_symbol_type(&ET[i].value, ROUTINE_T, 0, "indirect function call");
-                         goto IndirectFunctionCallG;
-
-                     case GLK_SYSF: 
-                         AO2 = veneer_routine(Glk__Wrap_VR);
-                         i = ET[below].right;
-                         goto DoFunctionCall;
-
-                     case METACLASS_SYSF:
-                         assembleg_call_1(veneer_routine(Metaclass_VR),
-                             ET[ET[below].right].value, Result);
-                         break;
-
-                     case YOUNGEST_SYSF:
-                         AO = ET[ET[below].right].value;
-                         if (runtime_error_checking_switch)
-                           AO = check_nonzero_at_runtime(AO, -1,
-                             YOUNGEST_RTE);
-                         INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
-                         assembleg_3(aload_gc, AO, AO2, temp_var1);
-                         AO2.value = GOBJFIELD_SIBLING();
-                         assembleg_1_branch(jz_gc, temp_var1, next_label+1);
-                         assemble_label_no(next_label);
-                         assembleg_3(aload_gc, temp_var1, AO2, temp_var2);
-                         assembleg_1_branch(jz_gc, temp_var2, next_label+1);
-                         assembleg_store(temp_var1, temp_var2);
-                         assembleg_0_branch(jump_gc, next_label);
-                         assemble_label_no(next_label+1);
-                         if (!void_flag) 
-                           write_result_g(Result, temp_var1);
-                         next_label += 2;
-                         break;
-
-                     case ELDER_SYSF: 
-                         AO = ET[ET[below].right].value;
-                         if (runtime_error_checking_switch)
-                           AO = check_nonzero_at_runtime(AO, -1,
-                             YOUNGEST_RTE);
-                         assembleg_store(temp_var3, AO);
-                         INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_PARENT());
-                         assembleg_3(aload_gc, temp_var3, AO2, temp_var1);
-                         assembleg_1_branch(jz_gc, temp_var1, next_label+2);
-                         AO2.value = GOBJFIELD_CHILD();
-                         assembleg_3(aload_gc, temp_var1, AO2, temp_var1);
-                         assembleg_1_branch(jz_gc, temp_var1, next_label+2);
-                         assembleg_2_branch(jeq_gc, temp_var3, temp_var1, 
-                           next_label+1);
-                         assemble_label_no(next_label);
-                         AO2.value = GOBJFIELD_SIBLING();
-                         assembleg_3(aload_gc, temp_var1, AO2, temp_var2);
-                         assembleg_2_branch(jeq_gc, temp_var3, temp_var2,
-                           next_label+2);
-                         assembleg_store(temp_var1, temp_var2);
-                         assembleg_0_branch(jump_gc, next_label);
-                         assemble_label_no(next_label+1);
-                         assembleg_store(temp_var1, zero_operand);
-                         assemble_label_no(next_label+2);
-                         if (!void_flag)
-                           write_result_g(Result, temp_var1);
-                         next_label += 3;
-                         break;
-
-                     default:
-                         error("*** system function not implemented ***");
-                         break;
-
+                   assembly_operand AO2 = ET[below].value;
+                   assembly_operand AO3 = ET[ET[below].right].value;
+                   if (void_flag)
+                     assembleg_call_2(AO, AO2, AO3, zero_operand);
+                   else
+                     assembleg_call_2(AO, AO2, AO3, Result);
                  }
                  break;
-             }
-
-             check_warn_symbol_type(&ET[below].value, ROUTINE_T, 0, "function call");
-             i = below;
-
-             IndirectFunctionCallG:
-
-             /* Get the function address. */
-             AO2 = ET[i].value;
-             i = ET[i].right;
-
-             DoFunctionCall:
-
-             {
-               /* If all the function arguments are in local/global
-                  variables, we have to push them all on the stack.
-                  If all of them are on the stack, we have to do nothing.
-                  If some are and some aren't, we have a hopeless mess,
-                  and we should throw a compiler error.
-               */
-
-               int onstack = 0;
-               int offstack = 0;
-
-               /* begin part of patch G03701 */
-               int nargs = 0;
-               j = i;
-               while (j != -1) {
-                 nargs++;
-                 j = ET[j].right;
-               }
-
-               if (nargs==0) {
-                 assembleg_2(callf_gc, AO2, void_flag ? zero_operand : Result);
-               } else if (nargs==1) {
-                 assembleg_call_1(AO2, ET[i].value, void_flag ? zero_operand : Result);
-               } else if (nargs==2) {
-                 assembly_operand o1 = ET[i].value;
-                 assembly_operand o2 = ET[ET[i].right].value;
-                 assembleg_call_2(AO2, o1, o2, void_flag ? zero_operand : Result);
-               } else if (nargs==3) {
-                 assembly_operand o1 = ET[i].value;
-                 assembly_operand o2 = ET[ET[i].right].value;
-                 assembly_operand o3 = ET[ET[ET[i].right].right].value;
-                 assembleg_call_3(AO2, o1, o2, o3, void_flag ? zero_operand : Result);
-               } else {
-
-                 j = 0;
-                 while (i != -1) {
-                     if (ET[i].value.type == LOCALVAR_OT 
-                       && ET[i].value.value == 0) {
-                       onstack++;
+    
+            case PROPERTY_SETEQUALS_OP:
+            case MESSAGE_SETEQUALS_OP:
+                 check_warn_symbol_type(&ET[below].value, OBJECT_T, CLASS_T, "\".\" expression");
+                 check_warn_symbol_type(&ET[ET[below].right].value, PROPERTY_T, INDIVIDUAL_PROPERTY_T, "\".\" expression");
+                 if (runtime_error_checking_switch && (!veneer_mode))
+                     AO = veneer_routine(RT__ChPS_VR);
+                   else
+                     AO = veneer_routine(WV__Pr_VR);
+    
+                 {
+                   assembly_operand AO2 = ET[below].value;
+                   assembly_operand AO3 = ET[ET[below].right].value;
+                   assembly_operand AO4 = ET[ET[ET[below].right].right].value;
+                   if (AO4.type == LOCALVAR_OT && AO4.value == 0) {
+                     /* Rightmost is on the stack; reduce to previous case. */
+                     if (AO2.type == LOCALVAR_OT && AO2.value == 0) {
+                       if (AO3.type == LOCALVAR_OT && AO3.value == 0) {
+                         /* both already on stack. */
+                       }
+                       else {
+                         assembleg_store(stack_pointer, AO3);
+                         assembleg_0(stkswap_gc);
+                       }
                      }
                      else {
-                       assembleg_store(stack_pointer, ET[i].value);
-                       offstack++;
+                       if (AO3.type == LOCALVAR_OT && AO3.value == 0) {
+                         assembleg_store(stack_pointer, AO2);
+                       }
+                       else {
+                         assembleg_store(stack_pointer, AO3);
+                         assembleg_store(stack_pointer, AO2);
+                       }
                      }
-                     i = ET[i].right;
-                     j++;
+                   }
+                   else {
+                     /* We have to get the rightmost on the stack, below the 
+                        others. */
+                     if (AO3.type == LOCALVAR_OT && AO3.value == 0) {
+                       if (AO2.type == LOCALVAR_OT && AO2.value == 0) {
+                         assembleg_store(stack_pointer, AO4);
+                         assembleg_2(stkroll_gc, three_operand, one_operand);
+                       }
+                       else {
+                         assembleg_store(stack_pointer, AO4);
+                         assembleg_0(stkswap_gc);
+                         assembleg_store(stack_pointer, AO2); 
+                       }
+                     }
+                     else {
+                       if (AO2.type == LOCALVAR_OT && AO2.value == 0) {
+                         assembleg_store(stack_pointer, AO4);
+                         assembleg_store(stack_pointer, AO3);
+                         assembleg_2(stkroll_gc, three_operand, two_operand);
+                       }
+                       else {
+                         assembleg_store(stack_pointer, AO4);
+                         assembleg_store(stack_pointer, AO3);
+                         assembleg_store(stack_pointer, AO2);
+                       }
+                     }
+                   }
+                   if (void_flag)
+                     assembleg_3(call_gc, AO, three_operand, zero_operand);
+                   else
+                     assembleg_3(call_gc, AO, three_operand, Result);
                  }
-
-                 if (onstack && offstack)
-                     error("*** Function call cannot be generated with mixed arguments ***");
-                 if (offstack > 1)
-                     error("*** Function call cannot be generated with more than one nonstack argument ***");
-
-                 INITAO(&AO);
-                 AO.value = j;
-                 set_constant_ot(&AO);
-
-                 if (void_flag)
-                   assembleg_3(call_gc, AO2, AO, zero_operand);
-                 else
-                   assembleg_3(call_gc, AO2, AO, Result);
-
-               } /* else nargs>=4 */
-             } /* DoFunctionCall: */
-
-             break;
-
-        default:
-            printf("** Trouble op = %d i.e. '%s' **\n",
-                opnum, operators[opnum].description);
-            compiler_error("Expr code gen: Can't generate yet");
+                 break;
+    
+            case FCALL_OP:
+                 j = 0;
+    
+                 if (ET[below].value.type == SYSFUN_OT)
+                 {   int sf_number = ET[below].value.value;
+    
+                     i = ET[below].right;
+                     if (i == -1)
+                     {   error("Argument to system function missing");
+                         AI.operand[0] = one_operand;
+                         AI.operand_count = 1;
+                     }
+                     else
+                     {   j=0;
+                         while (i != -1) { j++; i = ET[i].right; }
+    
+                         if (((sf_number != INDIRECT_SYSF) &&
+                             (sf_number != GLK_SYSF) &&
+                             (sf_number != RANDOM_SYSF) && (j > 1)))
+                         {   j=1;
+                             error("System function given with too many arguments");
+                         }
+                         if (sf_number != RANDOM_SYSF)
+                         {   int jcount;
+                             i = ET[below].right;
+                             for (jcount = 0; jcount < j; jcount++)
+                             {   AI.operand[jcount] = ET[i].value;
+                                 i = ET[i].right;
+                             }
+                             AI.operand_count = j;
+                         }
+                     }
+    
+                     switch(sf_number)
+                     {
+                         case RANDOM_SYSF:
+                             if (j>1)
+                             {  assembly_operand AO, AO2; 
+                                int arg_c, arg_et;
+                                INITAO(&AO);
+                                AO.value = j; 
+                                set_constant_ot(&AO);
+                                INITAOTV(&AO2, CONSTANT_OT, begin_word_array());
+                                AO2.marker = ARRAY_MV;
+    
+                                for (arg_c=0, arg_et = ET[below].right;arg_c<j;
+                                     arg_c++, arg_et = ET[arg_et].right)
+                                {   if (ET[arg_et].value.type == LOCALVAR_OT
+                                        || ET[arg_et].value.type == GLOBALVAR_OT)
+                  error("Only constants can be used as possible 'random' results");
+                                    array_entry(arg_c, FALSE, ET[arg_et].value);
+                                }
+                                finish_array(arg_c, FALSE);
+    
+                                assembleg_2(random_gc, AO, stack_pointer);
+                                assembleg_3(aload_gc, AO2, stack_pointer, Result);
+                             }
+                             else if (is_constant_ot(ET[ET[below].right].value.type) && ET[ET[below].right].value.marker == 0) {
+                                 /* One argument, value known at compile time */
+                                 int32 arg = ET[ET[below].right].value.value; /* signed */
+                                 if (arg > 0) {
+                                     assembly_operand AO;
+                                     INITAO(&AO);
+                                     AO.value = arg;
+                                     set_constant_ot(&AO);
+                                     assembleg_2(random_gc,
+                                         AO, stack_pointer);
+                                     assembleg_3(add_gc, stack_pointer, one_operand,
+                                         Result);
+                                 }
+                                 else {
+                                     /* This handles zero or negative */
+                                     assembly_operand AO;
+                                     INITAO(&AO);
+                                     AO.value = -arg;
+                                     set_constant_ot(&AO);
+                                     assembleg_1(setrandom_gc,
+                                         AO);
+                                     assembleg_store(Result, zero_operand);
+                                 }
+                             }
+                             else {
+                                 /* One argument, not known at compile time */
+                                 int ln, ln2;
+                                 assembleg_store(temp_var1, ET[ET[below].right].value);
+                                 ln = next_label++;
+                                 ln2 = next_label++;
+                                 assembleg_2_branch(jle_gc, temp_var1, zero_operand, ln);
+                                 assembleg_2(random_gc,
+                                     temp_var1, stack_pointer);
+                                 assembleg_3(add_gc, stack_pointer, one_operand,
+                                     Result);
+                                 assembleg_0_branch(jump_gc, ln2);
+                                 assemble_label_no(ln);
+                                 assembleg_2(neg_gc, temp_var1, stack_pointer);
+                                 assembleg_1(setrandom_gc,
+                                     stack_pointer);
+                                 assembleg_store(Result, zero_operand);
+                                 assemble_label_no(ln2);
+                             }
+                             break;
+    
+                         case PARENT_SYSF:
+                             {  assembly_operand AO;
+                                AO = ET[ET[below].right].value;
+                                if (runtime_error_checking_switch)
+                                    AO = check_nonzero_at_runtime(AO, -1,
+                                        PARENT_RTE);
+                                INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_PARENT());
+                                assembleg_3(aload_gc, AO, AO2, Result);
+                             }
+                             break;
+    
+                         case ELDEST_SYSF:
+                         case CHILD_SYSF:
+                             {  assembly_operand AO;
+                                AO = ET[ET[below].right].value;
+                                if (runtime_error_checking_switch)
+                                   AO = check_nonzero_at_runtime(AO, -1,
+                                   (sf_number==CHILD_SYSF)?CHILD_RTE:ELDEST_RTE);
+                                INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
+                                assembleg_3(aload_gc, AO, AO2, Result);
+                             }
+                             break;
+    
+                         case YOUNGER_SYSF:
+                         case SIBLING_SYSF:
+                             {  assembly_operand AO;
+                                AO = ET[ET[below].right].value;
+                                if (runtime_error_checking_switch)
+                                   AO = check_nonzero_at_runtime(AO, -1,
+                                   (sf_number==SIBLING_SYSF)
+                                       ?SIBLING_RTE:YOUNGER_RTE);
+                                INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_SIBLING());
+                                assembleg_3(aload_gc, AO, AO2, Result);
+                             }
+                             break;
+    
+                         case CHILDREN_SYSF:
+                             {  assembly_operand AO;
+                                AO = ET[ET[below].right].value;
+                                if (runtime_error_checking_switch)
+                                    AO = check_nonzero_at_runtime(AO, -1,
+                                        CHILDREN_RTE);
+                                INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
+                                assembleg_store(temp_var1, zero_operand);
+                                assembleg_3(aload_gc, AO, AO2, temp_var2);
+                                AO2.value = GOBJFIELD_SIBLING();
+                                assemble_label_no(next_label);
+                                assembleg_1_branch(jz_gc, temp_var2, next_label+1);
+                                assembleg_3(add_gc, temp_var1, one_operand, 
+                                  temp_var1);
+                                assembleg_3(aload_gc, temp_var2, AO2, temp_var2);
+                                assembleg_0_branch(jump_gc, next_label);
+                                assemble_label_no(next_label+1);
+                                next_label += 2;
+                                if (!void_flag) 
+                                  write_result_g(Result, temp_var1);
+                             }
+                             break;
+    
+                         case INDIRECT_SYSF: 
+                             i = ET[below].right;
+                             check_warn_symbol_type(&ET[i].value, ROUTINE_T, 0, "indirect function call");
+                             goto IndirectFunctionCallG;
+    
+                         case GLK_SYSF: 
+                             AO2 = veneer_routine(Glk__Wrap_VR);
+                             i = ET[below].right;
+                             goto DoFunctionCall;
+    
+                         case METACLASS_SYSF:
+                             assembleg_call_1(veneer_routine(Metaclass_VR),
+                                 ET[ET[below].right].value, Result);
+                             break;
+    
+                         case YOUNGEST_SYSF:
+                             AO = ET[ET[below].right].value;
+                             if (runtime_error_checking_switch)
+                                 AO = check_nonzero_at_runtime(AO, -1,
+                                     YOUNGEST_RTE);
+                             INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
+                             assembleg_3(aload_gc, AO, AO2, temp_var1);
+                             AO2.value = GOBJFIELD_SIBLING();
+                             assembleg_1_branch(jz_gc, temp_var1, next_label+1);
+                             assemble_label_no(next_label);
+                             assembleg_3(aload_gc, temp_var1, AO2, temp_var2);
+                             assembleg_1_branch(jz_gc, temp_var2, next_label+1);
+                             assembleg_store(temp_var1, temp_var2);
+                             assembleg_0_branch(jump_gc, next_label);
+                             assemble_label_no(next_label+1);
+                             if (!void_flag) 
+                               write_result_g(Result, temp_var1);
+                             next_label += 2;
+                             break;
+    
+                         case ELDER_SYSF: 
+                             AO = ET[ET[below].right].value;
+                             if (runtime_error_checking_switch)
+                                 AO = check_nonzero_at_runtime(AO, -1,
+                                     YOUNGEST_RTE);
+                             assembleg_store(temp_var3, AO);
+                             INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_PARENT());
+                             assembleg_3(aload_gc, temp_var3, AO2, temp_var1);
+                             assembleg_1_branch(jz_gc, temp_var1, next_label+2);
+                             AO2.value = GOBJFIELD_CHILD();
+                             assembleg_3(aload_gc, temp_var1, AO2, temp_var1);
+                             assembleg_1_branch(jz_gc, temp_var1, next_label+2);
+                             assembleg_2_branch(jeq_gc, temp_var3, temp_var1, 
+                                 next_label+1);
+                             assemble_label_no(next_label);
+                             AO2.value = GOBJFIELD_SIBLING();
+                             assembleg_3(aload_gc, temp_var1, AO2, temp_var2);
+                             assembleg_2_branch(jeq_gc, temp_var3, temp_var2,
+                                 next_label+2);
+                             assembleg_store(temp_var1, temp_var2);
+                             assembleg_0_branch(jump_gc, next_label);
+                             assemble_label_no(next_label+1);
+                             assembleg_store(temp_var1, zero_operand);
+                             assemble_label_no(next_label+2);
+                             if (!void_flag)
+                                 write_result_g(Result, temp_var1);
+                             next_label += 3;
+                             break;
+    
+                         default:
+                             error("*** system function not implemented ***");
+                             break;
+    
+                     }
+                     break;
+                 }
+    
+                 check_warn_symbol_type(&ET[below].value, ROUTINE_T, 0, "function call");
+                 i = below;
+    
+                 IndirectFunctionCallG:
+    
+                 /* Get the function address. */
+                 AO2 = ET[i].value;
+                 i = ET[i].right;
+    
+                 DoFunctionCall:
+    
+                 {
+                     /* If all the function arguments are in local/global
+                        variables, we have to push them all on the stack.
+                        If all of them are on the stack, we have to do nothing.
+                        If some are and some aren't, we have a hopeless mess,
+                        and we should throw a compiler error.
+                     */
+    
+                     int onstack = 0;
+                     int offstack = 0;
+    
+                     /* begin part of patch G03701 */
+                     int nargs = 0;
+                     j = i;
+                     while (j != -1) {
+                         nargs++;
+                         j = ET[j].right;
+                     }
+    
+                     if (nargs==0) {
+                         assembleg_2(callf_gc, AO2, void_flag ? zero_operand : Result);
+                     } else if (nargs==1) {
+                         assembleg_call_1(AO2, ET[i].value, void_flag ? zero_operand : Result);
+                     } else if (nargs==2) {
+                         assembly_operand o1 = ET[i].value;
+                         assembly_operand o2 = ET[ET[i].right].value;
+                         assembleg_call_2(AO2, o1, o2, void_flag ? zero_operand : Result);
+                     } else if (nargs==3) {
+                         assembly_operand o1 = ET[i].value;
+                         assembly_operand o2 = ET[ET[i].right].value;
+                         assembly_operand o3 = ET[ET[ET[i].right].right].value;
+                         assembleg_call_3(AO2, o1, o2, o3, void_flag ? zero_operand : Result);
+                     } else {
+    
+                         j = 0;
+                         while (i != -1) {
+                             if (ET[i].value.type == LOCALVAR_OT 
+                                 && ET[i].value.value == 0) {
+                                 onstack++;
+                             }
+                             else {
+                                 assembleg_store(stack_pointer, ET[i].value);
+                                 offstack++;
+                             }
+                             i = ET[i].right;
+                             j++;
+                         }
+    
+                         if (onstack && offstack)
+                             error("*** Function call cannot be generated with mixed arguments ***");
+                         if (offstack > 1)
+                             error("*** Function call cannot be generated with more than one nonstack argument ***");
+    
+                         INITAO(&AO);
+                         AO.value = j;
+                         set_constant_ot(&AO);
+    
+                         if (void_flag)
+                             assembleg_3(call_gc, AO2, AO, zero_operand);
+                         else
+                             assembleg_3(call_gc, AO2, AO, Result);
+    
+                     } /* else nargs>=4 */
+                 } /* DoFunctionCall: */
+    
+                 break;
+    
+            default:
+                printf("** Trouble op = %d i.e. '%s' **\n",
+                    opnum, operators[opnum].description);
+                compiler_error("Expr code gen: Can't generate yet");
+        }
     }
-  }
-
+    
     ET[n].value = Result;
-
+    
     OperatorGenerated:
 
     if (!glulx_mode) {

--- a/expressp.c
+++ b/expressp.c
@@ -778,68 +778,68 @@ int glulx_system_constant_list[] =
 
 static int32 value_of_system_constant_g(int t)
 { 
-  switch (t) {
-  case classes_table_SC:
-    return Write_RAM_At + class_numbers_offset;
-  case identifiers_table_SC:
-    return Write_RAM_At + identifier_names_offset;
-  case array_names_offset_SC:
-    return Write_RAM_At + array_names_offset;
-  case cpv__start_SC:
-    return prop_defaults_offset;
-  case cpv__end_SC:
-    return Write_RAM_At + class_numbers_offset;
-  case dictionary_table_SC:
-    return dictionary_offset;
-  case dynam_string_table_SC:
-    return abbreviations_offset;
-  case grammar_table_SC:
-    return grammar_table_offset;
-  case actions_table_SC:
-    return actions_offset;
-  case globals_array_SC:
-    return variables_offset;
-  case highest_class_number_SC:
-    return no_classes-1;
-  case highest_object_number_SC:
-    return no_objects-1;
-  case highest_action_number_SC:
-    return no_actions-1;
-  case action_names_array_SC:
-    return Write_RAM_At + action_names_offset;
-  case lowest_fake_action_number_SC:
-    return lowest_fake_action();
-  case highest_fake_action_number_SC:
-    return lowest_fake_action() + no_fake_actions-1;
-  case fake_action_names_array_SC:
-    return Write_RAM_At + fake_action_names_offset;
+    switch (t) {
+    case classes_table_SC:
+        return Write_RAM_At + class_numbers_offset;
+    case identifiers_table_SC:
+        return Write_RAM_At + identifier_names_offset;
+    case array_names_offset_SC:
+        return Write_RAM_At + array_names_offset;
+    case cpv__start_SC:
+        return prop_defaults_offset;
+    case cpv__end_SC:
+        return Write_RAM_At + class_numbers_offset;
+    case dictionary_table_SC:
+        return dictionary_offset;
+    case dynam_string_table_SC:
+        return abbreviations_offset;
+    case grammar_table_SC:
+        return grammar_table_offset;
+    case actions_table_SC:
+        return actions_offset;
+    case globals_array_SC:
+        return variables_offset;
+    case highest_class_number_SC:
+        return no_classes-1;
+    case highest_object_number_SC:
+        return no_objects-1;
+    case highest_action_number_SC:
+        return no_actions-1;
+    case action_names_array_SC:
+        return Write_RAM_At + action_names_offset;
+    case lowest_fake_action_number_SC:
+        return lowest_fake_action();
+    case highest_fake_action_number_SC:
+        return lowest_fake_action() + no_fake_actions-1;
+    case fake_action_names_array_SC:
+        return Write_RAM_At + fake_action_names_offset;
 
-  case highest_meta_action_number_SC:
-    if (!GRAMMAR_META_FLAG)
-      error_named("Must set $GRAMMAR_META_FLAG to use option:", system_constants.keywords[t]);
-    return no_meta_actions-1;
-  }
+    case highest_meta_action_number_SC:
+        if (!GRAMMAR_META_FLAG)
+            error_named("Must set $GRAMMAR_META_FLAG to use option:", system_constants.keywords[t]);
+        return no_meta_actions-1;
+    }
 
-  error_named("System constant not implemented in Glulx",
-    system_constants.keywords[t]);
+    error_named("System constant not implemented in Glulx",
+                system_constants.keywords[t]);
 
-  return 0;
+    return 0;
 }
 
 extern int32 value_of_system_constant(int t)
 {
-  if (!glulx_mode)
-    return value_of_system_constant_z(t);
-  else
-    return value_of_system_constant_g(t);    
+    if (!glulx_mode)
+        return value_of_system_constant_z(t);
+    else
+        return value_of_system_constant_g(t);    
 }
 
 extern char *name_of_system_constant(int t)
 {
-  if (t < 0 || t >= NO_SYSTEM_CONSTANTS) {
-    return "???";
-  }
-  return system_constants.keywords[t];
+    if (t < 0 || t >= NO_SYSTEM_CONSTANTS) {
+        return "???";
+    }
+    return system_constants.keywords[t];
 }
 
 static int evaluate_term(const token_data *t, assembly_operand *o)
@@ -1829,50 +1829,50 @@ static unsigned int etoken_num_children(int n)
 
 static void func_args_on_stack(int n, int context)
 {
-  /* Make sure that the arguments of every function-call expression
-     are stored to the stack. If any aren't (ie, if any arguments are
-     constants or variables), cover them with push operators. 
-     (The very first argument does not need to be so treated, because
-     it's the function address, not a function argument. We also
-     skip the treatment for most system functions.) */
+    /* Make sure that the arguments of every function-call expression
+       are stored to the stack. If any aren't (ie, if any arguments are
+       constants or variables), cover them with push operators. 
+       (The very first argument does not need to be so treated, because
+       it's the function address, not a function argument. We also
+       skip the treatment for most system functions.) */
 
-  int new, pn, fnaddr, opnum;
+    int new, pn, fnaddr, opnum;
 
-  ASSERT_GLULX();
+    ASSERT_GLULX();
 
-  if (ET[n].right != -1) 
-    func_args_on_stack(ET[n].right, context);
-  if (ET[n].down == -1) {
-    pn = ET[n].up;
-    if (pn != -1) {
-      opnum = ET[pn].operator_number;
-      if (opnum == FCALL_OP
-        || opnum == MESSAGE_CALL_OP
-        || opnum == PROP_CALL_OP) {
-        /* If it's an FCALL, get the operand which contains the function 
-           address (or system-function number) */
-        if (opnum == MESSAGE_CALL_OP 
-          || opnum == PROP_CALL_OP
-          || ((fnaddr=ET[pn].down) != n
-            && (ET[fnaddr].value.type != SYSFUN_OT
-              || ET[fnaddr].value.value == INDIRECT_SYSF
-              || ET[fnaddr].value.value == GLK_SYSF))) {
-        if (etoken_num_children(pn) > (unsigned int)(opnum == FCALL_OP ? 4:3)) {
-          ensure_memory_list_available(&ET_memlist, ET_used+1);
-          new = ET_used++;
-          ET[new] = ET[n];
-          ET[n].down = new; 
-          ET[n].operator_number = PUSH_OP;
-          ET[new].up = n; 
-          ET[new].right = -1;
+    if (ET[n].right != -1) 
+        func_args_on_stack(ET[n].right, context);
+    if (ET[n].down == -1) {
+        pn = ET[n].up;
+        if (pn != -1) {
+            opnum = ET[pn].operator_number;
+            if (opnum == FCALL_OP
+                || opnum == MESSAGE_CALL_OP
+                || opnum == PROP_CALL_OP) {
+                /* If it's an FCALL, get the operand which contains the function 
+                   address (or system-function number) */
+                if (opnum == MESSAGE_CALL_OP 
+                    || opnum == PROP_CALL_OP
+                    || ((fnaddr=ET[pn].down) != n
+                        && (ET[fnaddr].value.type != SYSFUN_OT
+                            || ET[fnaddr].value.value == INDIRECT_SYSF
+                            || ET[fnaddr].value.value == GLK_SYSF))) {
+                    if (etoken_num_children(pn) > (unsigned int)(opnum == FCALL_OP ? 4:3)) {
+                        ensure_memory_list_available(&ET_memlist, ET_used+1);
+                        new = ET_used++;
+                        ET[new] = ET[n];
+                        ET[n].down = new; 
+                        ET[n].operator_number = PUSH_OP;
+                        ET[new].up = n; 
+                        ET[new].right = -1;
+                    }
+                }
+            }
         }
-        }
-      }
+        return;
     }
-    return;
-  }
 
-  func_args_on_stack(ET[n].down, context);
+    func_args_on_stack(ET[n].down, context);
 }
 
 static assembly_operand check_conditions(assembly_operand AO, int context)

--- a/files.c
+++ b/files.c
@@ -269,38 +269,38 @@ static void sf_put(int c)
 {
     if (!glulx_mode) {
 
-      /*  The checksum is the unsigned sum mod 65536 of the bytes in the
-          story file from 0x0040 (first byte after header) to the end.       */
+        /*  The checksum is the unsigned sum mod 65536 of the bytes in the
+            story file from 0x0040 (first byte after header) to the end.     */
 
-      checksum_low_byte += c;
-      if (checksum_low_byte>=256)
-      {   checksum_low_byte-=256;
-          if (++checksum_high_byte==256) checksum_high_byte=0;
-      }
-
+        checksum_low_byte += c;
+        if (checksum_low_byte>=256)
+        {   checksum_low_byte-=256;
+            if (++checksum_high_byte==256) checksum_high_byte=0;
+        }
+        
     }
     else {
 
-      /*  The checksum is the unsigned 32-bit sum of the entire story file,
-          considered as a list of 32-bit words, with the checksum field
-          being zero. */
-
-      switch (checksum_count) {
-      case 0:
-        checksum_long += (((uint32)(c & 0xFF)) << 24);
-        break;
-      case 1:
-        checksum_long += (((uint32)(c & 0xFF)) << 16);
-        break;
-      case 2:
-        checksum_long += (((uint32)(c & 0xFF)) << 8);
-        break;
-      case 3:
-        checksum_long += ((uint32)(c & 0xFF));
-        break;
-      }
+        /*  The checksum is the unsigned 32-bit sum of the entire story file,
+            considered as a list of 32-bit words, with the checksum field
+            being zero. */
+        
+        switch (checksum_count) {
+        case 0:
+            checksum_long += (((uint32)(c & 0xFF)) << 24);
+            break;
+        case 1:
+            checksum_long += (((uint32)(c & 0xFF)) << 16);
+            break;
+        case 2:
+            checksum_long += (((uint32)(c & 0xFF)) << 8);
+            break;
+        case 3:
+            checksum_long += ((uint32)(c & 0xFF));
+            break;
+        }
       
-      checksum_count = (checksum_count+1) & 3;
+        checksum_count = (checksum_count+1) & 3;
       
     }
 
@@ -1117,7 +1117,7 @@ static void output_file_g(void)
     fputc((checksum_long) & 0xFF, sf_handle);
 
     if (ferror(sf_handle))
-      fatalerror("I/O failure: couldn't backtrack on story file for checksum");
+        fatalerror("I/O failure: couldn't backtrack on story file for checksum");
 
     /*  Write a copy of the first 64 bytes into the debugging information file
         (mainly so that it can be used to identify which story file matches with
@@ -1462,7 +1462,7 @@ extern void write_debug_optional_identifier(int32 symbol_index)
         }
     }
     fgetpos
-      (Debug_fp, &symbol_debug_info[symbol_index].replacement_backpatch_pos.position);
+        (Debug_fp, &symbol_debug_info[symbol_index].replacement_backpatch_pos.position);
     symbol_debug_info[symbol_index].replacement_backpatch_pos.valid = TRUE;
     debug_file_printf("<identifier>%s</identifier>", symbols[symbol_index].name);
     /* Space for:       artificial="true" (superseded replacement) */

--- a/files.c
+++ b/files.c
@@ -81,7 +81,7 @@ static debug_backpatch_accumulator grammar_backpatch_accumulator;
 #include <windows.h>
 char *realpath(const char *path, char *resolved_path)
 {
-  return GetFullPathNameA(path,PATHLEN,resolved_path,NULL) != 0 ? resolved_path : 0;
+    return GetFullPathNameA(path,PATHLEN,resolved_path,NULL) != 0 ? resolved_path : 0;
 }
 #endif
 
@@ -311,65 +311,65 @@ static void sf_put(int c)
 
 static void output_compression(int entnum, uint32 *size, int *count)
 {
-  huffentity_t *ent = &(huff_entities[entnum]);
-  int32 val;
-  char *cx;
+    huffentity_t *ent = &(huff_entities[entnum]);
+    int32 val;
+    char *cx;
 
-  sf_put(ent->type);
-  (*size)++;
-  (*count)++;
+    sf_put(ent->type);
+    (*size)++;
+    (*count)++;
 
-  switch (ent->type) {
-  case 0:
-    val = Write_Strings_At + huff_entities[ent->u.branch[0]].addr;
-    sf_put((val >> 24) & 0xFF);
-    sf_put((val >> 16) & 0xFF);
-    sf_put((val >> 8) & 0xFF);
-    sf_put((val) & 0xFF);
-    (*size) += 4;
-    val = Write_Strings_At + huff_entities[ent->u.branch[1]].addr;
-    sf_put((val >> 24) & 0xFF);
-    sf_put((val >> 16) & 0xFF);
-    sf_put((val >> 8) & 0xFF);
-    sf_put((val) & 0xFF);
-    (*size) += 4;
-    output_compression(ent->u.branch[0], size, count);
-    output_compression(ent->u.branch[1], size, count);
-    break;
-  case 1:
-    /* no data */
-    break;
-  case 2:
-    sf_put(ent->u.ch);
-    (*size) += 1;
-    break;
-  case 3:
-    cx = abbreviation_text(ent->u.val);
-    while (*cx) {
-      sf_put(*cx);
-      cx++;
-      (*size) += 1;  
+    switch (ent->type) {
+    case 0:
+        val = Write_Strings_At + huff_entities[ent->u.branch[0]].addr;
+        sf_put((val >> 24) & 0xFF);
+        sf_put((val >> 16) & 0xFF);
+        sf_put((val >> 8) & 0xFF);
+        sf_put((val) & 0xFF);
+        (*size) += 4;
+        val = Write_Strings_At + huff_entities[ent->u.branch[1]].addr;
+        sf_put((val >> 24) & 0xFF);
+        sf_put((val >> 16) & 0xFF);
+        sf_put((val >> 8) & 0xFF);
+        sf_put((val) & 0xFF);
+        (*size) += 4;
+        output_compression(ent->u.branch[0], size, count);
+        output_compression(ent->u.branch[1], size, count);
+        break;
+    case 1:
+        /* no data */
+        break;
+    case 2:
+        sf_put(ent->u.ch);
+        (*size) += 1;
+        break;
+    case 3:
+        cx = abbreviation_text(ent->u.val);
+        while (*cx) {
+            sf_put(*cx);
+            cx++;
+            (*size) += 1;  
+        }
+        sf_put('\0');
+        (*size) += 1;  
+        break;
+    case 4:
+        val = unicode_usage_entries[ent->u.val].ch;
+        sf_put((val >> 24) & 0xFF);
+        sf_put((val >> 16) & 0xFF);
+        sf_put((val >> 8) & 0xFF);
+        sf_put((val) & 0xFF);
+        (*size) += 4;
+        break;
+    case 9:
+        val = abbreviations_offset + 4 + ent->u.val*4;
+        sf_put((val >> 24) & 0xFF);
+        sf_put((val >> 16) & 0xFF);
+        sf_put((val >> 8) & 0xFF);
+        sf_put((val) & 0xFF);
+        (*size) += 4;
+        break;
     }
-    sf_put('\0');
-    (*size) += 1;  
-    break;
-  case 4:
-    val = unicode_usage_entries[ent->u.val].ch;
-    sf_put((val >> 24) & 0xFF);
-    sf_put((val >> 16) & 0xFF);
-    sf_put((val >> 8) & 0xFF);
-    sf_put((val) & 0xFF);
-    (*size) += 4;
-    break;
-  case 9:
-    val = abbreviations_offset + 4 + ent->u.val*4;
-    sf_put((val >> 24) & 0xFF);
-    sf_put((val >> 16) & 0xFF);
-    sf_put((val >> 8) & 0xFF);
-    sf_put((val) & 0xFF);
-    (*size) += 4;
-    break;
-  }
 }
 
 static void output_file_z(void)
@@ -570,7 +570,7 @@ static void output_file_z(void)
     fputc(checksum_low_byte, sf_handle);
 
     if (ferror(sf_handle))
-      fatalerror("I/O failure: couldn't backtrack on story file for checksum");
+        fatalerror("I/O failure: couldn't backtrack on story file for checksum");
 
     fclose(sf_handle);
 
@@ -643,30 +643,30 @@ static void output_file_g(void)
 
     /* Increase for various features the game may have used. */
     if (no_unicode_chars != 0 || (uses_unicode_features)) {
-      final_glulx_version = 0x00030000;
+        final_glulx_version = 0x00030000;
     }
     if (uses_memheap_features) {
-      final_glulx_version = 0x00030100;
+        final_glulx_version = 0x00030100;
     }
     if (uses_acceleration_features) {
-      final_glulx_version = 0x00030101;
+        final_glulx_version = 0x00030101;
     }
     if (uses_float_features) {
-      final_glulx_version = 0x00030102;
+        final_glulx_version = 0x00030102;
     }
     if (uses_double_features || uses_extundo_features) {
-      final_glulx_version = 0x00030103;
+        final_glulx_version = 0x00030103;
     }
 
     /* And check if the user has requested a specific version. */
     if (requested_glulx_version) {
-      if (requested_glulx_version < final_glulx_version) {
-        warning_fmt("Version 0x%08lx requested, but game features require version 0x%08lx",
-                    (long)requested_glulx_version, (long)final_glulx_version);
-      }
-      else {
-        final_glulx_version = requested_glulx_version;
-      }
+        if (requested_glulx_version < final_glulx_version) {
+            warning_fmt("Version 0x%08lx requested, but game features require version 0x%08lx",
+                (long)requested_glulx_version, (long)final_glulx_version);
+        }
+        else {
+            final_glulx_version = requested_glulx_version;
+        }
     }
 
     /*  (1)  Output the header. We use sf_put here, instead of fputc,
@@ -744,10 +744,10 @@ static void output_file_g(void)
     sf_put(release_number & 0xFF);
     /* Game serial number */
     {
-      char serialnum[8];
-      write_serial_number(serialnum);
-      for (i=0; i<6; i++)
-        sf_put(serialnum[i]);
+        char serialnum[8];
+        write_serial_number(serialnum);
+        for (i=0; i<6; i++)
+            sf_put(serialnum[i]);
     }
     size += GLULX_STATIC_ROM_SIZE;
 
@@ -779,19 +779,19 @@ static void output_file_g(void)
     size_before_code = size;
 
     j=0;
-      for (i=0; i<zcode_backpatch_size; i=i+6) {
+    for (i=0; i<zcode_backpatch_size; i=i+6) {
         int data_len;
         int32 v;
         offset = 
-          (zcode_backpatch_table[i+2] << 24)
-          | (zcode_backpatch_table[i+3] << 16)
-          | (zcode_backpatch_table[i+4] << 8)
-          | (zcode_backpatch_table[i+5]);
+            (zcode_backpatch_table[i+2] << 24)
+            | (zcode_backpatch_table[i+3] << 16)
+            | (zcode_backpatch_table[i+4] << 8)
+            | (zcode_backpatch_table[i+5]);
         backpatch_error_flag = FALSE;
         backpatch_marker =
-          zcode_backpatch_table[i];
+            zcode_backpatch_table[i];
         data_len =
-          zcode_backpatch_table[i+1];
+            zcode_backpatch_table[i+1];
 
         /* All code up until the next backpatch marker gets flushed out
            as-is. (Unless we're in a stripped-out function.) */
@@ -817,63 +817,63 @@ static void output_file_g(void)
         switch (data_len) {
 
         case 4:
-          v = (zcode_area[j]);
-          v = (v << 8) | (zcode_area[j+1]);
-          v = (v << 8) | (zcode_area[j+2]);
-          v = (v << 8) | (zcode_area[j+3]);
-          j += 4;
-          if (!use_function)
-              break;
-          v = backpatch_value(v);
-          sf_put((v >> 24) & 0xFF);
-          sf_put((v >> 16) & 0xFF);
-          sf_put((v >> 8) & 0xFF);
-          sf_put((v) & 0xFF);
-          size += 4;
-          break;
+            v = (zcode_area[j]);
+            v = (v << 8) | (zcode_area[j+1]);
+            v = (v << 8) | (zcode_area[j+2]);
+            v = (v << 8) | (zcode_area[j+3]);
+            j += 4;
+            if (!use_function)
+                break;
+            v = backpatch_value(v);
+            sf_put((v >> 24) & 0xFF);
+            sf_put((v >> 16) & 0xFF);
+            sf_put((v >> 8) & 0xFF);
+            sf_put((v) & 0xFF);
+            size += 4;
+            break;
 
         case 2:
-          v = (zcode_area[j]);
-          v = (v << 8) | (zcode_area[j+1]);
-          j += 2;
-          if (!use_function)
-              break;
-          v = backpatch_value(v);
-          if (v >= 0x10000) {
-            printf("*** backpatch value does not fit ***\n");
-            backpatch_error_flag = TRUE;
-          }
-          sf_put((v >> 8) & 0xFF);
-          sf_put((v) & 0xFF);
-          size += 2;
-          break;
+            v = (zcode_area[j]);
+            v = (v << 8) | (zcode_area[j+1]);
+            j += 2;
+            if (!use_function)
+                break;
+            v = backpatch_value(v);
+            if (v >= 0x10000) {
+                printf("*** backpatch value does not fit ***\n");
+                backpatch_error_flag = TRUE;
+            }
+            sf_put((v >> 8) & 0xFF);
+            sf_put((v) & 0xFF);
+            size += 2;
+            break;
 
         case 1:
-          v = (zcode_area[j]);
-          j += 1;
-          if (!use_function)
-              break;
-          v = backpatch_value(v);
-          if (v >= 0x100) {
-            printf("*** backpatch value does not fit ***\n");
-            backpatch_error_flag = TRUE;
-          }
-          sf_put((v) & 0xFF);
-          size += 1;
-          break;
+            v = (zcode_area[j]);
+            j += 1;
+            if (!use_function)
+                break;
+            v = backpatch_value(v);
+            if (v >= 0x100) {
+                printf("*** backpatch value does not fit ***\n");
+                backpatch_error_flag = TRUE;
+            }
+            sf_put((v) & 0xFF);
+            size += 1;
+            break;
 
         default:
-          printf("*** unknown backpatch data len = %d ***\n",
-            data_len);
-          backpatch_error_flag = TRUE;
+            printf("*** unknown backpatch data len = %d ***\n",
+                   data_len);
+            backpatch_error_flag = TRUE;
         }
 
         if (j > next_cons_check)
-          compiler_error("Backpatch appears to straddle function break");
+            compiler_error("Backpatch appears to straddle function break");
 
         if (backpatch_error_flag) {
-          printf("*** %d bytes  zcode offset=%08lx  backpatch offset=%08lx ***\n",
-            data_len, (long int) j, (long int) i);
+            printf("*** %d bytes  zcode offset=%08lx  backpatch offset=%08lx ***\n",
+                   data_len, (long int) j, (long int) i);
         }
     }
 
@@ -903,150 +903,150 @@ static void output_file_g(void)
     /*  (4)  Output the static strings area.                                 */
 
     {
-      int32 ix, lx;
-      int ch, jx, curbyte, bx;
-      int depth, checkcount;
-      huffbitlist_t *bits;
-      int32 origsize;
+        int32 ix, lx;
+        int ch, jx, curbyte, bx;
+        int depth, checkcount;
+        huffbitlist_t *bits;
+        int32 origsize;
 
-      origsize = size;
+        origsize = size;
 
-      if (compression_switch) {
+        if (compression_switch) {
 
-        /* The 12-byte table header. */
-        lx = compression_table_size;
-        sf_put((lx >> 24) & 0xFF);
-        sf_put((lx >> 16) & 0xFF);
-        sf_put((lx >> 8) & 0xFF);
-        sf_put((lx) & 0xFF);
-        size += 4;
-        sf_put((no_huff_entities >> 24) & 0xFF);
-        sf_put((no_huff_entities >> 16) & 0xFF);
-        sf_put((no_huff_entities >> 8) & 0xFF);
-        sf_put((no_huff_entities) & 0xFF);
-        size += 4;
-        lx = Write_Strings_At + 12;
-        sf_put((lx >> 24) & 0xFF);
-        sf_put((lx >> 16) & 0xFF);
-        sf_put((lx >> 8) & 0xFF);
-        sf_put((lx) & 0xFF);
-        size += 4;
+            /* The 12-byte table header. */
+            lx = compression_table_size;
+            sf_put((lx >> 24) & 0xFF);
+            sf_put((lx >> 16) & 0xFF);
+            sf_put((lx >> 8) & 0xFF);
+            sf_put((lx) & 0xFF);
+            size += 4;
+            sf_put((no_huff_entities >> 24) & 0xFF);
+            sf_put((no_huff_entities >> 16) & 0xFF);
+            sf_put((no_huff_entities >> 8) & 0xFF);
+            sf_put((no_huff_entities) & 0xFF);
+            size += 4;
+            lx = Write_Strings_At + 12;
+            sf_put((lx >> 24) & 0xFF);
+            sf_put((lx >> 16) & 0xFF);
+            sf_put((lx >> 8) & 0xFF);
+            sf_put((lx) & 0xFF);
+            size += 4;
 
-        checkcount = 0;
-        output_compression(huff_entity_root, &size, &checkcount);
-        if (checkcount != no_huff_entities)
-          compiler_error("Compression table count mismatch.");
-      }
+            checkcount = 0;
+            output_compression(huff_entity_root, &size, &checkcount);
+            if (checkcount != no_huff_entities)
+                compiler_error("Compression table count mismatch.");
+        }
 
-      if ((int32)size - origsize != compression_table_size)
-        compiler_error("Compression table size mismatch.");
+        if ((int32)size - origsize != compression_table_size)
+            compiler_error("Compression table size mismatch.");
 
-      origsize = size;
+        origsize = size;
 
-      for (lx=0, ix=0; lx<no_strings; lx++) {
-        int escapelen=0, escapetype=0;
-        int done=FALSE;
-        int32 escapeval=0;
-        if (compression_switch)
-          sf_put(0xE1); /* type byte -- compressed string */
-        else
-          sf_put(0xE0); /* type byte -- non-compressed string */
-        size++;
-        jx = 0; 
-        curbyte = 0;
-        while (!done) {
-          ch = static_strings_area[ix];
-          ix++;
-          if (ix > static_strings_extent || ch < 0)
-            compiler_error("Read too much not-yet-compressed text.");
+        for (lx=0, ix=0; lx<no_strings; lx++) {
+            int escapelen=0, escapetype=0;
+            int done=FALSE;
+            int32 escapeval=0;
+            if (compression_switch)
+                sf_put(0xE1); /* type byte -- compressed string */
+            else
+                sf_put(0xE0); /* type byte -- non-compressed string */
+            size++;
+            jx = 0; 
+            curbyte = 0;
+            while (!done) {
+                ch = static_strings_area[ix];
+                ix++;
+                if (ix > static_strings_extent || ch < 0)
+                    compiler_error("Read too much not-yet-compressed text.");
 
-          if (escapelen == -1) {
-            escapelen = 0;
-            if (ch == '@') {
-              ch = '@';
+                if (escapelen == -1) {
+                    escapelen = 0;
+                    if (ch == '@') {
+                        ch = '@';
+                    }
+                    else if (ch == '0') {
+                        ch = '\0';
+                    }
+                    else if (ch == 'A' || ch == 'D' || ch == 'U') {
+                        escapelen = 4;
+                        escapetype = ch;
+                        escapeval = 0;
+                        continue;
+                    }
+                    else {
+                        compiler_error("Strange @ escape in processed text.");
+                    }
+                }
+                else if (escapelen) {
+                    escapeval = (escapeval << 4) | ((ch-'A') & 0x0F);
+                    escapelen--;
+                    if (escapelen == 0) {
+                        if (escapetype == 'A') {
+                            ch = huff_abbrev_start+escapeval;
+                        }
+                        else if (escapetype == 'D') {
+                            ch = huff_dynam_start+escapeval;
+                        }
+                        else if (escapetype == 'U') {
+                            ch = huff_unicode_start+escapeval;
+                        }
+                        else {
+                            compiler_error("Strange @ escape in processed text.");
+                        }
+                    }
+                    else 
+                        continue;
+                }
+                else {
+                    if (ch == '@') {
+                        escapelen = -1;
+                        continue;
+                    }
+                    if (ch == 0) {
+                        ch = 256;
+                        done = TRUE;
+                    }
+                }
+
+                if (compression_switch) {
+                    bits = &(huff_entities[ch].bits);
+                    depth = huff_entities[ch].depth;
+                    for (bx=0; bx<depth; bx++) {
+                        if (bits->b[bx / 8] & (1 << (bx % 8)))
+                            curbyte |= (1 << jx);
+                        jx++;
+                        if (jx == 8) {
+                            sf_put(curbyte);
+                            size++;
+                            curbyte = 0;
+                            jx = 0;
+                        }
+                    }
+                }
+                else {
+                    if (ch >= huff_dynam_start) {
+                        sf_put(' '); sf_put(' '); sf_put(' ');
+                        size += 3;
+                    }
+                    else if (ch >= huff_abbrev_start) {
+                        /* nothing */
+                    }
+                    else {
+                        /* 256, the string terminator, comes out as zero */
+                        sf_put(ch & 0xFF);
+                        size++;
+                    }
+                }
             }
-            else if (ch == '0') {
-              ch = '\0';
-            }
-            else if (ch == 'A' || ch == 'D' || ch == 'U') {
-              escapelen = 4;
-              escapetype = ch;
-              escapeval = 0;
-              continue;
-            }
-            else {
-              compiler_error("Strange @ escape in processed text.");
-            }
-          }
-          else if (escapelen) {
-            escapeval = (escapeval << 4) | ((ch-'A') & 0x0F);
-            escapelen--;
-            if (escapelen == 0) {
-              if (escapetype == 'A') {
-                ch = huff_abbrev_start+escapeval;
-              }
-              else if (escapetype == 'D') {
-                ch = huff_dynam_start+escapeval;
-              }
-              else if (escapetype == 'U') {
-                ch = huff_unicode_start+escapeval;
-              }
-              else {
-                compiler_error("Strange @ escape in processed text.");
-              }
-            }
-            else 
-              continue;
-          }
-          else {
-            if (ch == '@') {
-              escapelen = -1;
-              continue;
-            }
-            if (ch == 0) {
-              ch = 256;
-              done = TRUE;
-            }
-          }
-
-          if (compression_switch) {
-            bits = &(huff_entities[ch].bits);
-            depth = huff_entities[ch].depth;
-            for (bx=0; bx<depth; bx++) {
-              if (bits->b[bx / 8] & (1 << (bx % 8)))
-                curbyte |= (1 << jx);
-              jx++;
-              if (jx == 8) {
+            if (compression_switch && jx) {
                 sf_put(curbyte);
                 size++;
-                curbyte = 0;
-                jx = 0;
-              }
             }
-          }
-          else {
-            if (ch >= huff_dynam_start) {
-              sf_put(' '); sf_put(' '); sf_put(' ');
-              size += 3;
-            }
-            else if (ch >= huff_abbrev_start) {
-              /* nothing */
-            }
-            else {
-              /* 256, the string terminator, comes out as zero */
-              sf_put(ch & 0xFF);
-              size++;
-            }
-          }
         }
-        if (compression_switch && jx) {
-          sf_put(curbyte);
-          size++;
-        }
-      }
       
-      if ((int32)size - origsize != compression_string_size)
-        compiler_error("Compression string size mismatch.");
+        if ((int32)size - origsize != compression_string_size)
+            compiler_error("Compression string size mismatch.");
 
     }
     
@@ -1155,10 +1155,10 @@ static void output_file_g(void)
 
 extern void output_file(void)
 {
-  if (!glulx_mode)
-    output_file_z();
-  else
-    output_file_g();
+    if (!glulx_mode)
+        output_file_z();
+    else
+        output_file_g();
 }
 
 /* ------------------------------------------------------------------------- */

--- a/header.h
+++ b/header.h
@@ -537,17 +537,17 @@
 #endif
 
 #if defined(USE_OLD_TIME_API)
-  #define TIMEVALUE time_t
-  #define TIMEVALUE_NOW(t) (*t) = time(0)
-  #define TIMEVALUE_DIFFERENCE(begt, endt) (float)(*(endt) - *(begt))
+    #define TIMEVALUE time_t
+    #define TIMEVALUE_NOW(t) (*t) = time(0)
+    #define TIMEVALUE_DIFFERENCE(begt, endt) (float)(*(endt) - *(begt))
 #elif defined(USE_C11_TIME_API)
-  #define TIMEVALUE struct timespec
-  #define TIMEVALUE_NOW(t) timespec_get((t), TIME_UTC)
-  #define TIMEVALUE_DIFFERENCE(begt, endt) ((float)((endt)->tv_sec - (begt)->tv_sec) + (float)((endt)->tv_nsec - (begt)->tv_nsec) / 1000000000.0F)
+    #define TIMEVALUE struct timespec
+    #define TIMEVALUE_NOW(t) timespec_get((t), TIME_UTC)
+    #define TIMEVALUE_DIFFERENCE(begt, endt) ((float)((endt)->tv_sec - (begt)->tv_sec) + (float)((endt)->tv_nsec - (begt)->tv_nsec) / 1000000000.0F)
 #elif defined(USE_POSIX_TIME_API)
-  #define TIMEVALUE struct timespec
-  #define TIMEVALUE_NOW(t) clock_gettime(CLOCK_REALTIME, (t))
-  #define TIMEVALUE_DIFFERENCE(begt, endt) ((float)((endt)->tv_sec - (begt)->tv_sec) + (float)((endt)->tv_nsec - (begt)->tv_nsec) / 1000000000.0F)
+    #define TIMEVALUE struct timespec
+    #define TIMEVALUE_NOW(t) clock_gettime(CLOCK_REALTIME, (t))
+    #define TIMEVALUE_DIFFERENCE(begt, endt) ((float)((endt)->tv_sec - (begt)->tv_sec) + (float)((endt)->tv_nsec - (begt)->tv_nsec) / 1000000000.0F)
 #endif
 
 /* ------------------------------------------------------------------------- */
@@ -574,25 +574,25 @@
 #define ASSERT_GLULX()
 
 
-#define ReadInt32(ptr)                               \
-  (   (((uint32)(((uchar *)(ptr))[0])) << 24)         \
-    | (((uint32)(((uchar *)(ptr))[1])) << 16)         \
-    | (((uint32)(((uchar *)(ptr))[2])) <<  8)         \
-    | (((uint32)(((uchar *)(ptr))[3]))      ) )
+#define ReadInt32(ptr)                                  \
+    (   (((uint32)(((uchar *)(ptr))[0])) << 24)         \
+      | (((uint32)(((uchar *)(ptr))[1])) << 16)         \
+      | (((uint32)(((uchar *)(ptr))[2])) <<  8)         \
+      | (((uint32)(((uchar *)(ptr))[3]))      ) )
 
-#define ReadInt16(ptr)                               \
-  (   (((uint32)(((uchar *)(ptr))[0])) << 8)          \
-    | (((uint32)(((uchar *)(ptr))[1]))     ) )
+#define ReadInt16(ptr)                                  \
+    (   (((uint32)(((uchar *)(ptr))[0])) << 8)          \
+      | (((uint32)(((uchar *)(ptr))[1]))     ) )
 
-#define WriteInt32(ptr, val)                         \
-  ((ptr)[0] = (uchar)(((int32)(val)) >> 24),         \
-   (ptr)[1] = (uchar)(((int32)(val)) >> 16),         \
-   (ptr)[2] = (uchar)(((int32)(val)) >>  8),         \
-   (ptr)[3] = (uchar)(((int32)(val))      ) )
+#define WriteInt32(ptr, val)                            \
+    ((ptr)[0] = (uchar)(((int32)(val)) >> 24),          \
+     (ptr)[1] = (uchar)(((int32)(val)) >> 16),          \
+     (ptr)[2] = (uchar)(((int32)(val)) >>  8),          \
+     (ptr)[3] = (uchar)(((int32)(val))      ) )
 
-#define WriteInt16(ptr, val)                         \
-  ((ptr)[0] = (uchar)(((int32)(val)) >> 8),          \
-   (ptr)[1] = (uchar)(((int32)(val))     ) )
+#define WriteInt16(ptr, val)                            \
+    ((ptr)[0] = (uchar)(((int32)(val)) >> 8),           \
+     (ptr)[1] = (uchar)(((int32)(val))     ) )
 
 /* Precedence for compiler options (see set_compiler_option()) */
 #define DEFAULT_OPTPREC (0)   /* original default value */
@@ -619,11 +619,11 @@
 #define  VENEER_CONSTRAINT_ON_CLASSES_G       32768
 #define  VENEER_CONSTRAINT_ON_IP_TABLE_SIZE_G 32768
 #define  VENEER_CONSTRAINT_ON_CLASSES  \
-  (glulx_mode ? VENEER_CONSTRAINT_ON_CLASSES_G  \
-              : VENEER_CONSTRAINT_ON_CLASSES_Z)
+    (glulx_mode ? VENEER_CONSTRAINT_ON_CLASSES_G  \
+                : VENEER_CONSTRAINT_ON_CLASSES_Z)
 #define  VENEER_CONSTRAINT_ON_IP_TABLE_SIZE  \
-  (glulx_mode ? VENEER_CONSTRAINT_ON_IP_TABLE_SIZE_G  \
-              : VENEER_CONSTRAINT_ON_IP_TABLE_SIZE_Z)
+    (glulx_mode ? VENEER_CONSTRAINT_ON_IP_TABLE_SIZE_G  \
+                : VENEER_CONSTRAINT_ON_IP_TABLE_SIZE_Z)
 
 #define  GLULX_HEADER_SIZE 36
 /* Number of bytes in the header. */
@@ -2263,26 +2263,26 @@ extern void assemblez_jump(int n);
 extern void assembleg_0(int internal_number);
 extern void assembleg_1(int internal_number, assembly_operand o1);
 extern void assembleg_2(int internal_number, assembly_operand o1,
-  assembly_operand o2);
+    assembly_operand o2);
 extern void assembleg_3(int internal_number, assembly_operand o1,
-  assembly_operand o2, assembly_operand o3);
+    assembly_operand o2, assembly_operand o3);
 extern void assembleg_4(int internal_number, assembly_operand o1,
-  assembly_operand o2, assembly_operand o3, assembly_operand o4);
+    assembly_operand o2, assembly_operand o3, assembly_operand o4);
 extern void assembleg_5(int internal_number, assembly_operand o1,
-  assembly_operand o2, assembly_operand o3, assembly_operand o4,
-  assembly_operand o5);
+    assembly_operand o2, assembly_operand o3, assembly_operand o4,
+    assembly_operand o5);
 extern void assembleg_0_branch(int internal_number,
-  int label);
+    int label);
 extern void assembleg_1_branch(int internal_number,
-  assembly_operand o1, int label);
+    assembly_operand o1, int label);
 extern void assembleg_2_branch(int internal_number,
-  assembly_operand o1, assembly_operand o2, int label);
+    assembly_operand o1, assembly_operand o2, int label);
 extern void assembleg_call_1(assembly_operand oaddr, assembly_operand o1, 
-  assembly_operand odest);
+    assembly_operand odest);
 extern void assembleg_call_2(assembly_operand oaddr, assembly_operand o1, 
-  assembly_operand o2, assembly_operand odest);
+    assembly_operand o2, assembly_operand odest);
 extern void assembleg_call_3(assembly_operand oaddr, assembly_operand o1, 
-  assembly_operand o2, assembly_operand o3, assembly_operand odest);
+    assembly_operand o2, assembly_operand o3, assembly_operand odest);
 extern void assembleg_inc(assembly_operand o1);
 extern void assembleg_dec(assembly_operand o1);
 extern void assembleg_store(assembly_operand o1, assembly_operand o2);
@@ -2416,7 +2416,7 @@ extern assembly_operand stack_pointer, temp_var1, temp_var2, temp_var3,
 
 assembly_operand code_generate(assembly_operand AO, int context, int label);
 assembly_operand check_nonzero_at_runtime(assembly_operand AO1, int label,
-       int rte_number);
+    int rte_number);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "expressp"                                       */
@@ -2839,8 +2839,8 @@ extern int no_unicode_chars;
 
 typedef struct unicode_usage_s unicode_usage_t;
 struct unicode_usage_s {
-  int32 ch;
-  int next; /* index in unicode_usage_entries of next */
+    int32 ch;
+    int next; /* index in unicode_usage_entries of next */
 };
 
 extern unicode_usage_t *unicode_usage_entries;
@@ -2851,19 +2851,19 @@ extern unicode_usage_t *unicode_usage_entries;
 #define MAXHUFFBYTES (4)
 
 typedef struct huffbitlist_struct {
-  uchar b[MAXHUFFBYTES];
+    uchar b[MAXHUFFBYTES];
 } huffbitlist_t;
 typedef struct huffentity_struct {
-  int count;
-  int type;
-  union {
-    int branch[2];
-    uchar ch;
-    int val;
-  } u;
-  int depth;
-  int32 addr;
-  huffbitlist_t bits;
+    int count;
+    int type;
+    union {
+        int branch[2];
+        uchar ch;
+        int val;
+    } u;
+    int depth;
+    int32 addr;
+    huffbitlist_t bits;
 } huffentity_t;
 
 extern huffentity_t *huff_entities;

--- a/inform.c
+++ b/inform.c
@@ -1187,18 +1187,18 @@ Copyright (c) Graham Nelson 1993 - 2025.\n\n");
 
    /* For people typing just "inform", a summary only: */
 
-   if (help_level==0)
-   {
+    if (help_level==0)
+    {
 
 #ifndef PROMPT_INPUT
-    printf("Usage: \"inform [commands...] <file1> [<file2>]\"\n\n");
+        printf("Usage: \"inform [commands...] <file1> [<file2>]\"\n\n");
 #else
-    printf("When run, Inform prompts you for commands (and switches),\n\
+        printf("When run, Inform prompts you for commands (and switches),\n\
 which are optional, then an input <file1> and an (optional) output\n\
 <file2>.\n\n");
 #endif
 
-    printf(
+        printf(
 "<file1> is the Inform source file of the game to be compiled. <file2>,\n\
 if given, overrides the filename Inform would normally use for the\n\
 compiled output.  Try \"inform -h1\" for file-naming conventions.\n\n\
@@ -1211,7 +1211,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   ++PATH=dir    add this directory to the PATH\n\n\
   $...          one of the following configuration commands:\n");
   
-    printf(
+        printf(
 "     $list            list current settings\n\
      $?SETTING        explain briefly what SETTING is for\n\
      $SETTING=number  change SETTING to given number\n\
@@ -1220,7 +1220,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
                       $! by itself to list all trace options)\n\
      $#SYMBOL=number  define SYMBOL as a constant in the story\n\n");
 
-    printf(
+        printf(
 "  (filename)    read in a list of commands (in the format above)\n\
                 from this \"setup file\"\n\n");
 
@@ -1238,20 +1238,20 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   --config filename      (read setup file)\n\n");
 
 #ifndef PROMPT_INPUT
-    printf("For example: \"inform -dexs curses\".\n\n");
+        printf("For example: \"inform -dexs curses\".\n\n");
 #endif
 
-    printf(
+        printf(
 "For fuller information, see the Inform Designer's Manual.\n");
 
-       return;
-   }
+        return;
+    }
 
-   /* The -h1 (filenaming) help information: */
+    /* The -h1 (filenaming) help information: */
 
-   if (help_level == 1) { help_on_filenames(); return; }
+    if (help_level == 1) { help_on_filenames(); return; }
 
-   /* The -h2 (switches) help information: */
+    /* The -h2 (switches) help information: */
 
     printf("Help on the full list of legal switch commands:\n\n\
   a   trace assembly-language\n\

--- a/inform.c
+++ b/inform.c
@@ -1191,14 +1191,14 @@ Copyright (c) Graham Nelson 1993 - 2025.\n\n");
    {
 
 #ifndef PROMPT_INPUT
-  printf("Usage: \"inform [commands...] <file1> [<file2>]\"\n\n");
+    printf("Usage: \"inform [commands...] <file1> [<file2>]\"\n\n");
 #else
-  printf("When run, Inform prompts you for commands (and switches),\n\
+    printf("When run, Inform prompts you for commands (and switches),\n\
 which are optional, then an input <file1> and an (optional) output\n\
 <file2>.\n\n");
 #endif
 
-  printf(
+    printf(
 "<file1> is the Inform source file of the game to be compiled. <file2>,\n\
 if given, overrides the filename Inform would normally use for the\n\
 compiled output.  Try \"inform -h1\" for file-naming conventions.\n\n\
@@ -1211,7 +1211,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   ++PATH=dir    add this directory to the PATH\n\n\
   $...          one of the following configuration commands:\n");
   
-  printf(
+    printf(
 "     $list            list current settings\n\
      $?SETTING        explain briefly what SETTING is for\n\
      $SETTING=number  change SETTING to given number\n\
@@ -1220,11 +1220,11 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
                       $! by itself to list all trace options)\n\
      $#SYMBOL=number  define SYMBOL as a constant in the story\n\n");
 
-  printf(
+    printf(
 "  (filename)    read in a list of commands (in the format above)\n\
                 from this \"setup file\"\n\n");
 
-  printf("Alternate command-line formats for the above:\n\
+    printf("Alternate command-line formats for the above:\n\
   --help                 (this page)\n\
   --path PATH=dir        (set path)\n\
   --addpath PATH=dir     (add to path)\n\
@@ -1253,7 +1253,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
 
    /* The -h2 (switches) help information: */
 
-   printf("Help on the full list of legal switch commands:\n\n\
+    printf("Help on the full list of legal switch commands:\n\n\
   a   trace assembly-language\n\
   a2  trace assembly with hex dumps\n\
   c   more concise error messages\n\
@@ -1261,7 +1261,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   d2  contract double spaces after exclamation and question marks, too\n\
   e   economy mode (slower): make use of declared abbreviations\n");
 
-   printf("\
+    printf("\
   f   frequencies mode: show how useful abbreviations are\n\
   g   traces calls to all game functions\n\
   g2  traces calls to all game and library functions\n\
@@ -1270,17 +1270,17 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   h1  print help information on filenames and path options\n\
   h2  print help information on switches (this page)\n");
 
-   printf("\
+    printf("\
   i   ignore default switches set within the file\n\
   k   output debugging information to \"%s\"\n",
           Debugging_Name);
-   printf("\
+    printf("\
   q   keep quiet about obsolete usages\n\
   r   record all the text to \"%s\"\n\
   s   give statistics\n",
       Transcript_Name);
 
-   printf("\
+    printf("\
   u   work out most useful abbreviations (very very slowly)\n\
   v3  compile to version-3 (\"Standard\"/\"ZIP\") story file\n\
   v4  compile to version-4 (\"Plus\"/\"EZIP\") story file\n\
@@ -1292,36 +1292,36 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   x   print # for every 100 lines compiled\n\
   z   print memory map of the virtual machine\n\n");
 
-printf("\
+    printf("\
   B   use big memory model (for large V6/V7 files)\n\
   C0  text character set is plain ASCII only\n\
   Cu  text character set is UTF-8\n\
   Cn  text character set is ISO 8859-n (n = 1 to 9)\n\
       (1 to 4, Latin1 to Latin4; 5, Cyrillic; 6, Arabic;\n\
        7, Greek; 8, Hebrew; 9, Latin5.  Default is -C1.)\n");
-printf("  D   insert \"Constant DEBUG;\" automatically\n");
-printf("  E0  Archimedes-style error messages%s\n",
-      (error_format==0)?" (current setting)":"");
-printf("  E1  Microsoft-style error messages%s\n",
-      (error_format==1)?" (current setting)":"");
-printf("  E2  Macintosh MPW-style error messages%s\n",
-      (error_format==2)?" (current setting)":"");
-printf("  G   compile a Glulx game file\n");
-printf("  H   use Huffman encoding to compress Glulx strings\n");
+    printf("  D   insert \"Constant DEBUG;\" automatically\n");
+    printf("  E0  Archimedes-style error messages%s\n",
+        (error_format==0)?" (current setting)":"");
+    printf("  E1  Microsoft-style error messages%s\n",
+        (error_format==1)?" (current setting)":"");
+    printf("  E2  Macintosh MPW-style error messages%s\n",
+        (error_format==2)?" (current setting)":"");
+    printf("  G   compile a Glulx game file\n");
+    printf("  H   use Huffman encoding to compress Glulx strings\n");
 
 #ifdef ARCHIMEDES
-printf("\
+    printf("\
   R0  use filetype 060 + version number for games (default)\n\
   R1  use official Acorn filetype 11A for all games\n");
 #endif
-printf("  S   compile strict error-checking at run-time (on by default)\n");
+    printf("  S   compile strict error-checking at run-time (on by default)\n");
 #ifdef ARC_THROWBACK
-printf("  T   enable throwback of errors in the DDE\n");
+    printf("  T   enable throwback of errors in the DDE\n");
 #endif
-printf("  V   print the version and date of this program\n");
-printf("  Wn  header extension table is at least n words (n = 3 to 99)\n");
-printf("  X   compile with INFIX debugging facilities present\n");
-  printf("\n");
+    printf("  V   print the version and date of this program\n");
+    printf("  Wn  header extension table is at least n words (n = 3 to 99)\n");
+    printf("  X   compile with INFIX debugging facilities present\n");
+    printf("\n");
 }
 
 extern void switches(char *p, int cmode)

--- a/lexer.c
+++ b/lexer.c
@@ -473,8 +473,8 @@ static char *opcode_list_g[] = {
 };
 
 keyword_group opcode_macros =
-{ { "" },
-  OPCODE_MACRO_TT, FALSE, TRUE
+{   { "" },
+    OPCODE_MACRO_TT, FALSE, TRUE
 };
 
 static char *opmacro_list_z[] = { "" };

--- a/lexer.c
+++ b/lexer.c
@@ -178,7 +178,7 @@ extern debug_locations get_token_location_end
        prior block and last exactly zero bytes there.  It's misleading to
        include such ranges, so we gobble them. */
     if (beginning.head->location.end_byte_index ==
-          beginning.beginning_byte_index &&
+        beginning.beginning_byte_index &&
         beginning.head->next)
     {   beginning.head = beginning.head->next;
         result.location = beginning.head->location;

--- a/objects.c
+++ b/objects.c
@@ -957,7 +957,7 @@ static int32 write_property_block_g(void)
     }
 
     qsort(full_object_g.props, full_object_g.numprops, sizeof(propg), 
-          (int (*)(const void *, const void *))(&gpropsort));
+        (int (*)(const void *, const void *))(&gpropsort));
 
     full_object_g.finalpropaddr = mark;
 
@@ -2077,7 +2077,7 @@ extern void make_object(int nearby_flag,
 
     if ((token_type == SEP_TT) && (token_value == ARROW_SEP))
     {   if (nearby_flag)
-          error("The syntax '->' is only used as an alternative to 'Nearby'");
+            error("The syntax '->' is only used as an alternative to 'Nearby'");
 
         while ((token_type == SEP_TT) && (token_value == ARROW_SEP))
         {   tree_depth++;

--- a/objects.c
+++ b/objects.c
@@ -105,31 +105,31 @@ extern void make_attribute(void)
     debug_location_beginning beginning_debug_location =
         get_token_location_beginning();
 
- if (!glulx_mode) { 
-    if (no_attributes==((version_number==3)?32:48))
-    {   discard_token_location(beginning_debug_location);
-        if (version_number==3)
-            error("All 32 attributes already declared (compile as Advanced \
+    if (!glulx_mode) { 
+        if (no_attributes==((version_number==3)?32:48))
+            {   discard_token_location(beginning_debug_location);
+                if (version_number==3)
+                    error("All 32 attributes already declared (compile as Advanced \
 game to get an extra 16)");
-        else
-            error("All 48 attributes already declared");
-        panic_mode_error_recovery();
-        put_token_back();
-        return;
+                else
+                    error("All 48 attributes already declared");
+                panic_mode_error_recovery();
+                put_token_back();
+                return;
+            }
     }
- }
- else {
-    if (no_attributes==NUM_ATTR_BYTES*8) {
-      discard_token_location(beginning_debug_location);
-      error_fmt(
-        "All %d attributes already declared -- increase NUM_ATTR_BYTES to use \
+    else {
+        if (no_attributes==NUM_ATTR_BYTES*8) {
+            discard_token_location(beginning_debug_location);
+            error_fmt(
+                "All %d attributes already declared -- increase NUM_ATTR_BYTES to use \
 more", 
-        NUM_ATTR_BYTES*8);
-      panic_mode_error_recovery(); 
-      put_token_back();
-      return;
+                NUM_ATTR_BYTES*8);
+            panic_mode_error_recovery(); 
+            put_token_back();
+            return;
+        }
     }
- }
 
     get_next_token();
     i = token_value; name = token_text;
@@ -1100,7 +1100,7 @@ static void manufacture_object_g(void)
     }
 
     objectsg[no_objects].shortname = compile_string(shortname_buffer,
-      STRCTX_OBJNAME);
+        STRCTX_OBJNAME);
 
         /*  The properties table consists simply of a sequence of property
             blocks, one for each object in order of definition, exactly as
@@ -2401,23 +2401,23 @@ extern void objects_allocate_arrays(void)
         "temporary storage for inline function name");
     
     if (!glulx_mode) {
-      initialise_memory_list(&objectsz_memlist,
-          sizeof(objecttz), 256, (void**)&objectsz,
-          "z-objects");
+        initialise_memory_list(&objectsz_memlist,
+            sizeof(objecttz), 256, (void**)&objectsz,
+            "z-objects");
     }
     else {
-      initialise_memory_list(&objectsg_memlist,
-          sizeof(objecttg), 256, (void**)&objectsg,
-          "g-objects");
-      initialise_memory_list(&objectatts_memlist,
-          NUM_ATTR_BYTES, 256, (void**)&objectatts,
-          "g-attributes");
-      initialise_memory_list(&full_object_g.props_memlist,
-          sizeof(propg), 64, (void**)&full_object_g.props,
-          "object property list");
-      initialise_memory_list(&full_object_g.propdata_memlist,
-          sizeof(assembly_operand), 1024, (void**)&full_object_g.propdata,
-          "object property data table");
+        initialise_memory_list(&objectsg_memlist,
+            sizeof(objecttg), 256, (void**)&objectsg,
+            "g-objects");
+        initialise_memory_list(&objectatts_memlist,
+            NUM_ATTR_BYTES, 256, (void**)&objectatts,
+            "g-attributes");
+        initialise_memory_list(&full_object_g.props_memlist,
+            sizeof(propg), 64, (void**)&full_object_g.props,
+            "object property list");
+        initialise_memory_list(&full_object_g.propdata_memlist,
+            sizeof(assembly_operand), 1024, (void**)&full_object_g.propdata,
+            "object property data table");
     }
 }
 

--- a/objects.c
+++ b/objects.c
@@ -712,116 +712,116 @@ so many values that the list has overflowed the maximum 4 entries");
 
 static void property_inheritance_g(void)
 {
-  /*  Apply the property inheritance rules to full_object, which should
-      initially be complete (i.e., this routine takes place after the whole
-      Nearby/Object/Class definition has been parsed through).
+    /*  Apply the property inheritance rules to full_object, which should
+        initially be complete (i.e., this routine takes place after the whole
+        Nearby/Object/Class definition has been parsed through).
       
-      On exit, full_object contains the final state of the properties to
-      be written. */
+        On exit, full_object contains the final state of the properties to
+        be written. */
 
-  int i, j, k, class, num_props,
-    prop_number, prop_length, prop_flags, prop_in_current_defn;
-  int32 mark, prop_addr;
-  uchar *cpb, *pe;
+    int i, j, k, class, num_props,
+        prop_number, prop_length, prop_flags, prop_in_current_defn;
+    int32 mark, prop_addr;
+    uchar *cpb, *pe;
 
-  ASSERT_GLULX();
+    ASSERT_GLULX();
 
-  for (class=0; class<no_classes_to_inherit_from; class++) {
-    mark = class_info[classes_to_inherit_from[class] - 1].begins_at;
-    cpb = (properties_table + mark);
-    /* This now points to the compiled property-table for the class.
-       We'll have to go through and decompile it. (For our sins.) */
-    num_props = ReadInt32(cpb);
-    for (j=0; j<num_props; j++) {
-      pe = cpb + 4 + j*10;
-      prop_number = ReadInt16(pe);
-      pe += 2;
-      prop_length = ReadInt16(pe);
-      pe += 2;
-      prop_addr = ReadInt32(pe);
-      pe += 4;
-      prop_flags = ReadInt16(pe);
-      pe += 2;
+    for (class=0; class<no_classes_to_inherit_from; class++) {
+        mark = class_info[classes_to_inherit_from[class] - 1].begins_at;
+        cpb = (properties_table + mark);
+        /* This now points to the compiled property-table for the class.
+           We'll have to go through and decompile it. (For our sins.) */
+        num_props = ReadInt32(cpb);
+        for (j=0; j<num_props; j++) {
+            pe = cpb + 4 + j*10;
+            prop_number = ReadInt16(pe);
+            pe += 2;
+            prop_length = ReadInt16(pe);
+            pe += 2;
+            prop_addr = ReadInt32(pe);
+            pe += 4;
+            prop_flags = ReadInt16(pe);
+            pe += 2;
 
-      /*  So we now have property number prop_number present in the
-          property block for the class being read. Its bytes are
-          cpb[prop_addr ... prop_addr + prop_length - 1]
-          Question now is: is there already a value given in the
-          current definition under this property name? */
+            /*  So we now have property number prop_number present in the
+                property block for the class being read. Its bytes are
+                cpb[prop_addr ... prop_addr + prop_length - 1]
+                Question now is: is there already a value given in the
+                current definition under this property name? */
 
-      prop_in_current_defn = FALSE;
+            prop_in_current_defn = FALSE;
 
-      for (k=0; k<full_object_g.numprops; k++) {
-        if (full_object_g.props[k].num == prop_number) {
-          prop_in_current_defn = TRUE;
-          break;
-        }
-      }
-
-      if (prop_in_current_defn) {
-        if ((prop_number==1)
-          || (prop_number < INDIV_PROP_START 
-            && commonprops[prop_number].is_additive)) {
-          /*  The additive case: we accumulate the class
-              property values onto the end of the full_object
-              properties. Remember that k is still the index number
-              of the first prop-block matching our property number. */
-          int prevcont;
-          if (full_object_g.props[k].continuation == 0) {
-            full_object_g.props[k].continuation = 1;
-            prevcont = 1;
-          }
-          else {
-            prevcont = full_object_g.props[k].continuation;
-            for (k++; k<full_object_g.numprops; k++) {
-              if (full_object_g.props[k].num == prop_number) {
-                prevcont = full_object_g.props[k].continuation;
-              }
+            for (k=0; k<full_object_g.numprops; k++) {
+                if (full_object_g.props[k].num == prop_number) {
+                    prop_in_current_defn = TRUE;
+                    break;
+                }
             }
-          }
-          k = full_object_g.numprops++;
-          ensure_memory_list_available(&full_object_g.props_memlist, k+1);
-          full_object_g.props[k].num = prop_number;
-          full_object_g.props[k].flags = 0;
-          full_object_g.props[k].datastart = full_object_g.propdatasize;
-          full_object_g.props[k].continuation = prevcont+1;
-          full_object_g.props[k].datalen = prop_length;
+
+            if (prop_in_current_defn) {
+                if ((prop_number==1)
+                    || (prop_number < INDIV_PROP_START 
+                        && commonprops[prop_number].is_additive)) {
+                    /*  The additive case: we accumulate the class
+                        property values onto the end of the full_object
+                        properties. Remember that k is still the index number
+                        of the first prop-block matching our property number. */
+                    int prevcont;
+                    if (full_object_g.props[k].continuation == 0) {
+                        full_object_g.props[k].continuation = 1;
+                        prevcont = 1;
+                    }
+                    else {
+                        prevcont = full_object_g.props[k].continuation;
+                        for (k++; k<full_object_g.numprops; k++) {
+                            if (full_object_g.props[k].num == prop_number) {
+                                prevcont = full_object_g.props[k].continuation;
+                            }
+                        }
+                    }
+                    k = full_object_g.numprops++;
+                    ensure_memory_list_available(&full_object_g.props_memlist, k+1);
+                    full_object_g.props[k].num = prop_number;
+                    full_object_g.props[k].flags = 0;
+                    full_object_g.props[k].datastart = full_object_g.propdatasize;
+                    full_object_g.props[k].continuation = prevcont+1;
+                    full_object_g.props[k].datalen = prop_length;
           
-          ensure_memory_list_available(&full_object_g.propdata_memlist, full_object_g.propdatasize + prop_length);
-          for (i=0; i<prop_length; i++) {
-            int ppos = full_object_g.propdatasize++;
-            INITAOTV(&full_object_g.propdata[ppos], CONSTANT_OT, prop_addr + 4*i);
-            full_object_g.propdata[ppos].marker = INHERIT_MV;
-          }
-        }
-        else {
-          /*  The ordinary case: the full_object_g property
-              values simply overrides the class definition,
-              so we skip over the values in the class table. */
-        }
-      }
-          else {
-            /*  The case where the class defined a property which wasn't
-                defined at all in full_object_g: we copy out the data into
-                a new property added to full_object_g. */
-            k = full_object_g.numprops++;
-            ensure_memory_list_available(&full_object_g.props_memlist, k+1);
-            full_object_g.props[k].num = prop_number;
-            full_object_g.props[k].flags = prop_flags;
-            full_object_g.props[k].datastart = full_object_g.propdatasize;
-            full_object_g.props[k].continuation = 0;
-            full_object_g.props[k].datalen = prop_length;
-
-            ensure_memory_list_available(&full_object_g.propdata_memlist, full_object_g.propdatasize + prop_length);
-            for (i=0; i<prop_length; i++) {
-              int ppos = full_object_g.propdatasize++;
-              INITAOTV(&full_object_g.propdata[ppos], CONSTANT_OT, prop_addr + 4*i);
-              full_object_g.propdata[ppos].marker = INHERIT_MV; 
+                    ensure_memory_list_available(&full_object_g.propdata_memlist, full_object_g.propdatasize + prop_length);
+                    for (i=0; i<prop_length; i++) {
+                        int ppos = full_object_g.propdatasize++;
+                        INITAOTV(&full_object_g.propdata[ppos], CONSTANT_OT, prop_addr + 4*i);
+                        full_object_g.propdata[ppos].marker = INHERIT_MV;
+                    }
+                }
+                else {
+                    /*  The ordinary case: the full_object_g property
+                        values simply overrides the class definition,
+                        so we skip over the values in the class table. */
+                }
             }
-          }
+            else {
+                /*  The case where the class defined a property which wasn't
+                    defined at all in full_object_g: we copy out the data into
+                    a new property added to full_object_g. */
+                k = full_object_g.numprops++;
+                ensure_memory_list_available(&full_object_g.props_memlist, k+1);
+                full_object_g.props[k].num = prop_number;
+                full_object_g.props[k].flags = prop_flags;
+                full_object_g.props[k].datastart = full_object_g.propdatasize;
+                full_object_g.props[k].continuation = 0;
+                full_object_g.props[k].datalen = prop_length;
 
+                ensure_memory_list_available(&full_object_g.propdata_memlist, full_object_g.propdatasize + prop_length);
+                for (i=0; i<prop_length; i++) {
+                    int ppos = full_object_g.propdatasize++;
+                    INITAOTV(&full_object_g.propdata[ppos], CONSTANT_OT, prop_addr + 4*i);
+                    full_object_g.propdata[ppos].marker = INHERIT_MV; 
+                }
+            }
+
+        }
     }
-  }
   
 }
 
@@ -920,104 +920,104 @@ static int write_property_block_z(char *shortname)
 
 static int gpropsort(void *ptr1, void *ptr2)
 {
-  propg *prop1 = ptr1;
-  propg *prop2 = ptr2;
+    propg *prop1 = ptr1;
+    propg *prop2 = ptr2;
   
-  if (prop2->num == -1)
-    return -1;
-  if (prop1->num == -1)
-    return 1;
-  if (prop1->num < prop2->num)
-    return -1;
-  if (prop1->num > prop2->num)
-    return 1;
+    if (prop2->num == -1)
+        return -1;
+    if (prop1->num == -1)
+        return 1;
+    if (prop1->num < prop2->num)
+        return -1;
+    if (prop1->num > prop2->num)
+        return 1;
 
-  return (prop1->continuation - prop2->continuation);
+    return (prop1->continuation - prop2->continuation);
 }
 
 static int32 write_property_block_g(void)
 {
-  /*  Compile the (now complete) full_object properties into a
-      property-table block at "p" in Inform's memory. 
-      Return the number of bytes written to the block. 
-      In Glulx, the shortname property isn't used here; it's already
-      been compiled into an ordinary string. */
+    /*  Compile the (now complete) full_object properties into a
+        property-table block at "p" in Inform's memory. 
+        Return the number of bytes written to the block. 
+        In Glulx, the shortname property isn't used here; it's already
+        been compiled into an ordinary string. */
 
-  int32 i;
-  int ix, jx, kx, totalprops;
-  int32 mark = properties_table_size;
-  int32 datamark;
+    int32 i;
+    int ix, jx, kx, totalprops;
+    int32 mark = properties_table_size;
+    int32 datamark;
 
-  if (current_defn_is_class) {
-    ensure_memory_list_available(&properties_table_memlist, mark+NUM_ATTR_BYTES);
-    for (i=0;i<NUM_ATTR_BYTES;i++)
-      properties_table[mark++] = full_object_g.atts[i];
-    ensure_memory_list_available(&class_info_memlist, no_classes+1);
-    class_info[no_classes++].begins_at = mark;
-  }
-
-  qsort(full_object_g.props, full_object_g.numprops, sizeof(propg), 
-    (int (*)(const void *, const void *))(&gpropsort));
-
-  full_object_g.finalpropaddr = mark;
-
-  totalprops = 0;
-
-  for (ix=0; ix<full_object_g.numprops; ix=jx) {
-    int propnum = full_object_g.props[ix].num;
-    if (propnum == -1)
-        break;
-    for (jx=ix; 
-        jx<full_object_g.numprops && full_object_g.props[jx].num == propnum;
-        jx++);
-    totalprops++;
-  }
-
-  /* Write out the number of properties in this table. */
-  ensure_memory_list_available(&properties_table_memlist, mark+4);
-  WriteInt32(properties_table+mark, totalprops);
-  mark += 4;
-
-  datamark = mark + 10*totalprops;
-
-  for (ix=0; ix<full_object_g.numprops; ix=jx) {
-    int propnum = full_object_g.props[ix].num;
-    int flags = full_object_g.props[ix].flags;
-    int totallen = 0;
-    int32 datamarkstart = datamark;
-    if (propnum == -1)
-      break;
-    for (jx=ix; 
-        jx<full_object_g.numprops && full_object_g.props[jx].num == propnum;
-        jx++) {
-      int32 datastart = full_object_g.props[jx].datastart;
-      ensure_memory_list_available(&properties_table_memlist, datamark+4*full_object_g.props[jx].datalen);
-      for (kx=0; kx<full_object_g.props[jx].datalen; kx++) {
-        int32 val = full_object_g.propdata[datastart+kx].value;
-        WriteInt32(properties_table+datamark, val);
-        if (full_object_g.propdata[datastart+kx].marker != 0)
-          backpatch_zmachine(full_object_g.propdata[datastart+kx].marker,
-            PROP_ZA, datamark);
-        totallen++;
-        datamark += 4;
-      }
+    if (current_defn_is_class) {
+        ensure_memory_list_available(&properties_table_memlist, mark+NUM_ATTR_BYTES);
+        for (i=0;i<NUM_ATTR_BYTES;i++)
+            properties_table[mark++] = full_object_g.atts[i];
+        ensure_memory_list_available(&class_info_memlist, no_classes+1);
+        class_info[no_classes++].begins_at = mark;
     }
-    ensure_memory_list_available(&properties_table_memlist, mark+10);
-    WriteInt16(properties_table+mark, propnum);
-    mark += 2;
-    WriteInt16(properties_table+mark, totallen);
-    mark += 2;
-    WriteInt32(properties_table+mark, datamarkstart); 
+
+    qsort(full_object_g.props, full_object_g.numprops, sizeof(propg), 
+          (int (*)(const void *, const void *))(&gpropsort));
+
+    full_object_g.finalpropaddr = mark;
+
+    totalprops = 0;
+
+    for (ix=0; ix<full_object_g.numprops; ix=jx) {
+        int propnum = full_object_g.props[ix].num;
+        if (propnum == -1)
+            break;
+        for (jx=ix; 
+             jx<full_object_g.numprops && full_object_g.props[jx].num == propnum;
+             jx++);
+        totalprops++;
+    }
+
+    /* Write out the number of properties in this table. */
+    ensure_memory_list_available(&properties_table_memlist, mark+4);
+    WriteInt32(properties_table+mark, totalprops);
     mark += 4;
-    WriteInt16(properties_table+mark, flags);
-    mark += 2;
-  }
 
-  mark = datamark;
+    datamark = mark + 10*totalprops;
 
-  i = mark - properties_table_size;
-  properties_table_size = mark;
-  return i;
+    for (ix=0; ix<full_object_g.numprops; ix=jx) {
+        int propnum = full_object_g.props[ix].num;
+        int flags = full_object_g.props[ix].flags;
+        int totallen = 0;
+        int32 datamarkstart = datamark;
+        if (propnum == -1)
+            break;
+        for (jx=ix; 
+             jx<full_object_g.numprops && full_object_g.props[jx].num == propnum;
+             jx++) {
+            int32 datastart = full_object_g.props[jx].datastart;
+            ensure_memory_list_available(&properties_table_memlist, datamark+4*full_object_g.props[jx].datalen);
+            for (kx=0; kx<full_object_g.props[jx].datalen; kx++) {
+                int32 val = full_object_g.propdata[datastart+kx].value;
+                WriteInt32(properties_table+datamark, val);
+                if (full_object_g.propdata[datastart+kx].marker != 0)
+                    backpatch_zmachine(full_object_g.propdata[datastart+kx].marker,
+                                       PROP_ZA, datamark);
+                totallen++;
+                datamark += 4;
+            }
+        }
+        ensure_memory_list_available(&properties_table_memlist, mark+10);
+        WriteInt16(properties_table+mark, propnum);
+        mark += 2;
+        WriteInt16(properties_table+mark, totallen);
+        mark += 2;
+        WriteInt32(properties_table+mark, datamarkstart); 
+        mark += 4;
+        WriteInt16(properties_table+mark, flags);
+        mark += 2;
+    }
+
+    mark = datamark;
+
+    i = mark - properties_table_size;
+    properties_table_size = mark;
+    return i;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -1648,10 +1648,10 @@ the names \"%s\" and \"%s\" actually refer to the same property",
 
 static void properties_segment(int this_segment)
 {
-  if (!glulx_mode)
-    properties_segment_z(this_segment);
-  else
-    properties_segment_g(this_segment);
+    if (!glulx_mode)
+        properties_segment_z(this_segment);
+    else
+        properties_segment_g(this_segment);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -1843,24 +1843,24 @@ object/class definition but found", token_text);
 
 static void initialise_full_object(void)
 {
-  int i;
-  if (!glulx_mode) {
-    full_object.symbol = 0;
-    full_object.l = 0;
-    full_object.atts[0] = 0;
-    full_object.atts[1] = 0;
-    full_object.atts[2] = 0;
-    full_object.atts[3] = 0;
-    full_object.atts[4] = 0;
-    full_object.atts[5] = 0;
-  }
-  else {
-    full_object_g.symbol = 0;
-    full_object_g.numprops = 0;
-    full_object_g.propdatasize = 0;
-    for (i=0; i<NUM_ATTR_BYTES; i++)
-      full_object_g.atts[i] = 0;
-  }
+    int i;
+    if (!glulx_mode) {
+        full_object.symbol = 0;
+        full_object.l = 0;
+        full_object.atts[0] = 0;
+        full_object.atts[1] = 0;
+        full_object.atts[2] = 0;
+        full_object.atts[3] = 0;
+        full_object.atts[4] = 0;
+        full_object.atts[5] = 0;
+    }
+    else {
+        full_object_g.symbol = 0;
+        full_object_g.numprops = 0;
+        full_object_g.propdatasize = 0;
+        for (i=0; i<NUM_ATTR_BYTES; i++)
+            full_object_g.atts[i] = 0;
+    }
 }
 
 extern void make_class(char * metaclass_name)
@@ -1937,26 +1937,26 @@ inconvenience, please contact the maintainers.");
         since property 2 is always set to "additive" -- see below)           */
 
     if (!glulx_mode) {
-      full_object.symbol = current_classname_symbol;
-      full_object.l = 1;
-      full_object.pp[0].num = 2;
-      full_object.pp[0].l = 1;
-      INITAOTV(&full_object.pp[0].ao[0], LONG_CONSTANT_OT, no_objects + 1);
-      full_object.pp[0].ao[0].marker = OBJECT_MV;
+        full_object.symbol = current_classname_symbol;
+        full_object.l = 1;
+        full_object.pp[0].num = 2;
+        full_object.pp[0].l = 1;
+        INITAOTV(&full_object.pp[0].ao[0], LONG_CONSTANT_OT, no_objects + 1);
+        full_object.pp[0].ao[0].marker = OBJECT_MV;
     }
     else {
-      full_object_g.symbol = current_classname_symbol;
-      full_object_g.numprops = 1;
-      ensure_memory_list_available(&full_object_g.props_memlist, 1);
-      full_object_g.props[0].num = 2;
-      full_object_g.props[0].flags = 0;
-      full_object_g.props[0].datastart = 0;
-      full_object_g.props[0].continuation = 0;
-      full_object_g.props[0].datalen = 1;
-      full_object_g.propdatasize = 1;
-      ensure_memory_list_available(&full_object_g.propdata_memlist, 1);
-      INITAOTV(&full_object_g.propdata[0], CONSTANT_OT, no_objects + 1);
-      full_object_g.propdata[0].marker = OBJECT_MV;
+        full_object_g.symbol = current_classname_symbol;
+        full_object_g.numprops = 1;
+        ensure_memory_list_available(&full_object_g.props_memlist, 1);
+        full_object_g.props[0].num = 2;
+        full_object_g.props[0].flags = 0;
+        full_object_g.props[0].datastart = 0;
+        full_object_g.props[0].continuation = 0;
+        full_object_g.props[0].datalen = 1;
+        full_object_g.propdatasize = 1;
+        ensure_memory_list_available(&full_object_g.propdata_memlist, 1);
+        INITAOTV(&full_object_g.propdata[0], CONSTANT_OT, no_objects + 1);
+        full_object_g.propdata[0].marker = OBJECT_MV;
     }
 
     if (!metaclass_flag)
@@ -2001,9 +2001,9 @@ inconvenience, please contact the maintainers.");
     }
 
     if (!glulx_mode)
-      manufacture_object_z();
+        manufacture_object_z();
     else
-      manufacture_object_g();
+        manufacture_object_g();
 
     if (individual_prop_table_size >= VENEER_CONSTRAINT_ON_IP_TABLE_SIZE)
         error("This class is too complex: it now carries too many properties. \
@@ -2270,9 +2270,9 @@ extern void make_object(int nearby_flag,
     }
 
     if (!glulx_mode)
-      manufacture_object_z();
+        manufacture_object_z();
     else
-      manufacture_object_g();
+        manufacture_object_g();
 }
 
 /* ========================================================================= */

--- a/states.c
+++ b/states.c
@@ -2561,16 +2561,16 @@ static void parse_statement_g(int break_label, int continue_label)
     /*  -------------------------------------------------------------------- */
 
         case RFALSE_CODE:   
-          assembleg_1(return_gc, zero_operand); 
-          break;
+            assembleg_1(return_gc, zero_operand); 
+            break;
 
     /*  -------------------------------------------------------------------- */
     /*  rtrue -------------------------------------------------------------- */
     /*  -------------------------------------------------------------------- */
 
         case RTRUE_CODE:   
-          assembleg_1(return_gc, one_operand); 
-          break;
+            assembleg_1(return_gc, one_operand); 
+            break;
 
     /*  -------------------------------------------------------------------- */
     /*  spaces <expression> ------------------------------------------------ */

--- a/states.c
+++ b/states.c
@@ -2529,33 +2529,33 @@ static void parse_statement_g(int break_label, int continue_label)
     /*  -------------------------------------------------------------------- */
 
         case REMOVE_CODE:
-                 AO = code_generate(parse_expression(QUANTITY_CONTEXT),
-                     QUANTITY_CONTEXT, -1);
-                 check_warn_symbol_type(&AO, OBJECT_T, 0, "\"remove\" statement");
-                 if ((runtime_error_checking_switch) && (veneer_mode == FALSE))
-                     assembleg_call_1(veneer_routine(RT__ChR_VR), AO,
-                         zero_operand);
-                 else
-                     assembleg_call_1(veneer_routine(OB__Remove_VR), AO,
-                         zero_operand);
-                 break;
+            AO = code_generate(parse_expression(QUANTITY_CONTEXT),
+                QUANTITY_CONTEXT, -1);
+            check_warn_symbol_type(&AO, OBJECT_T, 0, "\"remove\" statement");
+            if ((runtime_error_checking_switch) && (veneer_mode == FALSE))
+                assembleg_call_1(veneer_routine(RT__ChR_VR), AO,
+                    zero_operand);
+            else
+                assembleg_call_1(veneer_routine(OB__Remove_VR), AO,
+                    zero_operand);
+            break;
 
     /*  -------------------------------------------------------------------- */
     /*  return [<expression>] ---------------------------------------------- */
     /*  -------------------------------------------------------------------- */
 
         case RETURN_CODE:
-          get_next_token();
-          if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) {
-            assembleg_1(return_gc, one_operand); 
-            return; 
-          }
-          put_token_back();
-          AO = code_generate(parse_expression(RETURN_Q_CONTEXT),
-            QUANTITY_CONTEXT, -1);
-          assembleg_1(return_gc, AO);
-          break;
-
+            get_next_token();
+            if ((token_type == SEP_TT) && (token_value == SEMICOLON_SEP)) {
+                assembleg_1(return_gc, one_operand); 
+                return; 
+            }
+            put_token_back();
+            AO = code_generate(parse_expression(RETURN_Q_CONTEXT),
+                QUANTITY_CONTEXT, -1);
+            assembleg_1(return_gc, AO);
+            break;
+            
     /*  -------------------------------------------------------------------- */
     /*  rfalse ------------------------------------------------------------- */
     /*  -------------------------------------------------------------------- */
@@ -2726,8 +2726,8 @@ static void parse_statement_g(int break_label, int continue_label)
        Inform compiler, but which is important in development. */
 
         default:
-          error("*** Statement code gen: Can't generate yet ***\n");
-          panic_mode_error_recovery(); return;
+            error("*** Statement code gen: Can't generate yet ***\n");
+            panic_mode_error_recovery(); return;
     }
 
     StatementTerminator:

--- a/states.c
+++ b/states.c
@@ -140,43 +140,43 @@ static void parse_action(void)
 
     if (!glulx_mode) {
 
-      AO = veneer_routine(R_Process_VR);
+        AO = veneer_routine(R_Process_VR);
 
-      switch(args)
-      {   case 0:
-            if (codegen_action) AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
-            if (version_number>=5)
-                assemblez_2(call_2n_zc, AO, AO2);
-            else
-            if (version_number==4)
-                assemblez_2_to(call_vs_zc, AO, AO2, temp_var1);
-            else
-                assemblez_2_to(call_zc, AO, AO2, temp_var1);
-            break;
-          case 1:
+        switch(args)
+        {   case 0:
+                if (codegen_action) AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
+                if (version_number>=5)
+                    assemblez_2(call_2n_zc, AO, AO2);
+                else
+                    if (version_number==4)
+                        assemblez_2_to(call_vs_zc, AO, AO2, temp_var1);
+                    else
+                        assemblez_2_to(call_zc, AO, AO2, temp_var1);
+                break;
+        case 1:
             AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
             if (codegen_action) AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
             if (version_number>=5)
                 assemblez_3(call_vn_zc, AO, AO2, AO3);
             else
-            if (version_number==4)
-                assemblez_3_to(call_vs_zc, AO, AO2, AO3, temp_var1);
-            else
-                assemblez_3_to(call_zc, AO, AO2, AO3, temp_var1);
+                if (version_number==4)
+                    assemblez_3_to(call_vs_zc, AO, AO2, AO3, temp_var1);
+                else
+                    assemblez_3_to(call_zc, AO, AO2, AO3, temp_var1);
             break;
-          case 2:
+        case 2:
             AO4 = code_generate(AO4, QUANTITY_CONTEXT, -1);
             AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
             if (codegen_action) AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
             if (version_number>=5)
                 assemblez_4(call_vn_zc, AO, AO2, AO3, AO4);
             else
-            if (version_number==4)
-                assemblez_4_to(call_vs_zc, AO, AO2, AO3, AO4, temp_var1);
-            else
-                assemblez_4_to(call_zc, AO, AO2, AO3, AO4, temp_var1);
+                if (version_number==4)
+                    assemblez_4_to(call_vs_zc, AO, AO2, AO3, AO4, temp_var1);
+                else
+                    assemblez_4_to(call_zc, AO, AO2, AO3, AO4, temp_var1);
             break;
-          case 3:
+        case 3:
             AO5 = code_generate(AO5, QUANTITY_CONTEXT, -1);
             AO4 = code_generate(AO4, QUANTITY_CONTEXT, -1);
             AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
@@ -184,63 +184,63 @@ static void parse_action(void)
             if (version_number>=5)
                 assemblez_5(call_vn2_zc, AO, AO2, AO3, AO4, AO5);
             else
-            if (version_number==4)
-                assemblez_5_to(call_vs2_zc, AO, AO2, AO3, AO4, AO5, temp_var1);
+                if (version_number==4)
+                    assemblez_5_to(call_vs2_zc, AO, AO2, AO3, AO4, AO5, temp_var1);
             /* if V3 or earlier, we've already displayed an error */
             break;
             break;
-      }
+        }
 
-      if (level == 2) assemblez_0(rtrue_zc);
+        if (level == 2) assemblez_0(rtrue_zc);
 
     }
     else {
 
-      AO = veneer_routine(R_Process_VR);
+        AO = veneer_routine(R_Process_VR);
 
-      switch (args) {
+        switch (args) {
 
-      case 0:
-        if (codegen_action) 
-          AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
-        assembleg_call_1(AO, AO2, zero_operand);
-        break;
+        case 0:
+            if (codegen_action) 
+                AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
+            assembleg_call_1(AO, AO2, zero_operand);
+            break;
 
-      case 1:
-        AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
-        if (codegen_action)
-          AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
-        assembleg_call_2(AO, AO2, AO3, zero_operand);
-        break;
+        case 1:
+            AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
+            if (codegen_action)
+                AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
+            assembleg_call_2(AO, AO2, AO3, zero_operand);
+            break;
 
-      case 2:
-        AO4 = code_generate(AO4, QUANTITY_CONTEXT, -1);
-        AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
-        if (codegen_action) 
-          AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
-        assembleg_call_3(AO, AO2, AO3, AO4, zero_operand);
-        break;
+        case 2:
+            AO4 = code_generate(AO4, QUANTITY_CONTEXT, -1);
+            AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
+            if (codegen_action) 
+                AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
+            assembleg_call_3(AO, AO2, AO3, AO4, zero_operand);
+            break;
 
-      case 3:
-        AO5 = code_generate(AO5, QUANTITY_CONTEXT, -1);
-        if (!((AO5.type == LOCALVAR_OT) && (AO5.value == 0)))
-            assembleg_store(stack_pointer, AO5);
-        AO4 = code_generate(AO4, QUANTITY_CONTEXT, -1);
-        if (!((AO4.type == LOCALVAR_OT) && (AO4.value == 0)))
-            assembleg_store(stack_pointer, AO4);
-        AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
-        if (!((AO3.type == LOCALVAR_OT) && (AO3.value == 0)))
-            assembleg_store(stack_pointer, AO3);
-        if (codegen_action) 
-          AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
-        if (!((AO2.type == LOCALVAR_OT) && (AO2.value == 0)))
-          assembleg_store(stack_pointer, AO2);
-        assembleg_3(call_gc, AO, four_operand, zero_operand);
-        break;
-      }
+        case 3:
+            AO5 = code_generate(AO5, QUANTITY_CONTEXT, -1);
+            if (!((AO5.type == LOCALVAR_OT) && (AO5.value == 0)))
+                assembleg_store(stack_pointer, AO5);
+            AO4 = code_generate(AO4, QUANTITY_CONTEXT, -1);
+            if (!((AO4.type == LOCALVAR_OT) && (AO4.value == 0)))
+                assembleg_store(stack_pointer, AO4);
+            AO3 = code_generate(AO3, QUANTITY_CONTEXT, -1);
+            if (!((AO3.type == LOCALVAR_OT) && (AO3.value == 0)))
+                assembleg_store(stack_pointer, AO3);
+            if (codegen_action) 
+                AO2 = code_generate(AO2, QUANTITY_CONTEXT, -1);
+            if (!((AO2.type == LOCALVAR_OT) && (AO2.value == 0)))
+                assembleg_store(stack_pointer, AO2);
+            assembleg_3(call_gc, AO, four_operand, zero_operand);
+            break;
+        }
 
-      if (level == 2) 
-        assembleg_1(return_gc, one_operand);
+        if (level == 2) 
+            assembleg_1(return_gc, one_operand);
 
     }
 }

--- a/symbols.c
+++ b/symbols.c
@@ -945,50 +945,50 @@ static void stockup_symbols(void)
         /* In Glulx, these system globals are entered in order, not down 
            from 255. */
         create_symbol("temp_global",  MAX_LOCAL_VARIABLES+0, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("temp__global2", MAX_LOCAL_VARIABLES+1, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("temp__global3", MAX_LOCAL_VARIABLES+2, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("temp__global4", MAX_LOCAL_VARIABLES+3, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("self",         MAX_LOCAL_VARIABLES+4, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("sender",       MAX_LOCAL_VARIABLES+5, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("sw__var",      MAX_LOCAL_VARIABLES+6, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
 
         /* These are almost certainly meaningless, and can be removed. */
         create_symbol("sys__glob0",     MAX_LOCAL_VARIABLES+7, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("sys__glob1",     MAX_LOCAL_VARIABLES+8, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
         create_symbol("sys__glob2",     MAX_LOCAL_VARIABLES+9, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
 
         /* value of statusline_flag to be written later */
         create_symbol("sys_statusline_flag",  MAX_LOCAL_VARIABLES+10, 
-          GLOBAL_VARIABLE_T);
+            GLOBAL_VARIABLE_T);
 
         /* These are created in order, but not necessarily at a fixed
            value. */
         create_symbol("create",        INDIV_PROP_START+0, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
         create_symbol("recreate",      INDIV_PROP_START+1, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
         create_symbol("destroy",       INDIV_PROP_START+2, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
         create_symbol("remaining",     INDIV_PROP_START+3, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
         create_symbol("copy",          INDIV_PROP_START+4, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
         create_symbol("call",          INDIV_PROP_START+5, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
         create_symbol("print",         INDIV_PROP_START+6, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
         create_symbol("print_to_array",INDIV_PROP_START+7, 
-          INDIVIDUAL_PROPERTY_T);
+            INDIVIDUAL_PROPERTY_T);
 
         /* Floating-point constants. Note that FLOAT_NINFINITY is not
            -FLOAT_INFINITY, because float negation doesn't work that

--- a/symbols.c
+++ b/symbols.c
@@ -1146,8 +1146,8 @@ static int df_functions_sorted_count;
 static df_reference_t **df_symbol_map;
 
 /* Globals used while a function is being compiled. When a function
-  *isn't* being compiled, df_current_function_addr will be DF_NOT_IN_FUNCTION
-  and df_current_function will refer to the global namespace record. */
+   *isn't* being compiled, df_current_function_addr will be DF_NOT_IN_FUNCTION
+   and df_current_function will refer to the global namespace record. */
 static df_function_t *df_current_function;
 static char *df_current_function_name;
 static uint32 df_current_function_addr;

--- a/syntax.c
+++ b/syntax.c
@@ -349,7 +349,7 @@ static void parse_switch_spec(assembly_operand switch_value, int label,
         }
         else {
             spec_stack[spec_sp] =
-      code_generate(parse_expression(CONSTANT_CONTEXT), CONSTANT_CONTEXT, -1);
+                code_generate(parse_expression(CONSTANT_CONTEXT), CONSTANT_CONTEXT, -1);
         }
 
         misc_keywords.enabled = TRUE;

--- a/syntax.c
+++ b/syntax.c
@@ -297,12 +297,12 @@ static void compile_alternatives_g(assembly_operand switch_value, int n,
     int the_zc = (flag) ? jeq_gc : jne_gc;
 
     if (n == 1) {
-      assembleg_2_branch(the_zc, switch_value,
-        spec_stack[stack_level],
-        label); 
+        assembleg_2_branch(the_zc, switch_value,
+            spec_stack[stack_level],
+            label); 
     }
     else {
-      error("*** Cannot generate multi-equality tests in Glulx ***");
+        error("*** Cannot generate multi-equality tests in Glulx ***");
     }
 }
 

--- a/syntax.c
+++ b/syntax.c
@@ -309,10 +309,10 @@ static void compile_alternatives_g(assembly_operand switch_value, int n,
 static void compile_alternatives(assembly_operand switch_value, int n,
     int stack_level, int label, int flag)
 {
-  if (!glulx_mode)
-    compile_alternatives_z(switch_value, n, stack_level, label, flag);
-  else
-    compile_alternatives_g(switch_value, n, stack_level, label, flag);
+    if (!glulx_mode)
+        compile_alternatives_z(switch_value, n, stack_level, label, flag);
+    else
+        compile_alternatives_g(switch_value, n, stack_level, label, flag);
 }
 
 static void generate_switch_spec(assembly_operand switch_value, int label, int label_after, int speccount);

--- a/syntax.c
+++ b/syntax.c
@@ -405,37 +405,37 @@ static void generate_switch_spec(assembly_operand switch_value, int label, int l
         }
         else
         {   
-          if (!glulx_mode) {
-            if (i == speccount - 2)
-            {   assemblez_2_branch(jl_zc, switch_value, spec_stack[i],
-                    label, TRUE);
-                assemblez_2_branch(jg_zc, switch_value, spec_stack[i+1],
-                    label, TRUE);
+            if (!glulx_mode) {
+                if (i == speccount - 2)
+                {   assemblez_2_branch(jl_zc, switch_value, spec_stack[i],
+                        label, TRUE);
+                    assemblez_2_branch(jg_zc, switch_value, spec_stack[i+1],
+                        label, TRUE);
+                }
+                else
+                {   assemblez_2_branch(jl_zc, switch_value, spec_stack[i],
+                        next_label, TRUE);
+                    assemblez_2_branch(jg_zc, switch_value, spec_stack[i+1],
+                        label_after, FALSE);
+                    assemble_label_no(next_label++);
+                }
             }
-            else
-            {   assemblez_2_branch(jl_zc, switch_value, spec_stack[i],
-                    next_label, TRUE);
-                assemblez_2_branch(jg_zc, switch_value, spec_stack[i+1],
-                    label_after, FALSE);
-                assemble_label_no(next_label++);
+            else {
+                if (i == speccount - 2)
+                {   assembleg_2_branch(jlt_gc, switch_value, spec_stack[i],
+                        label);
+                    assembleg_2_branch(jgt_gc, switch_value, spec_stack[i+1],
+                        label);
+                }
+                else
+                {   assembleg_2_branch(jlt_gc, switch_value, spec_stack[i],
+                        next_label);
+                    assembleg_2_branch(jle_gc, switch_value, spec_stack[i+1],
+                        label_after);
+                    assemble_label_no(next_label++);
+                }
             }
-          }
-          else {
-            if (i == speccount - 2)
-            {   assembleg_2_branch(jlt_gc, switch_value, spec_stack[i],
-                    label);
-                assembleg_2_branch(jgt_gc, switch_value, spec_stack[i+1],
-                    label);
-            }
-            else
-            {   assembleg_2_branch(jlt_gc, switch_value, spec_stack[i],
-                    next_label);
-                assembleg_2_branch(jle_gc, switch_value, spec_stack[i+1],
-                    label_after);
-                assemble_label_no(next_label++);
-            }
-          }
-          i = i+2;
+            i = i+2;
         }
     }
 

--- a/tables.c
+++ b/tables.c
@@ -248,7 +248,7 @@ static int32 rough_size_of_paged_memory_g(void)
     total += dictionary_top;
 
     while (total % GPAGESIZE)
-      total++;
+        total++;
 
     return(total);
 }
@@ -1267,7 +1267,7 @@ static void construct_storyfile_g(void)
     Write_RAM_At = static_arrays_at + static_array_area_size;
     /* The Write_RAM_At boundary must be a multiple of GPAGESIZE. */
     while (Write_RAM_At % GPAGESIZE)
-      Write_RAM_At++;
+        Write_RAM_At++;
 
     /* Now work out all those RAM positions. */
     mark = 0;
@@ -1276,9 +1276,9 @@ static void construct_storyfile_g(void)
 
     globals_at = mark;
     for (i=0; i<no_globals; i++) {
-      j = global_initial_value[i].value;
-      WriteInt32(p+mark, j);
-      mark += 4;
+        j = global_initial_value[i].value;
+        WriteInt32(p+mark, j);
+        mark += 4;
     }
 
     arrays_at = mark;
@@ -1291,9 +1291,9 @@ static void construct_storyfile_g(void)
     WriteInt32(p+mark, no_dynamic_strings);
     mark += 4;
     for (i=0; i<no_dynamic_strings; i++) {
-      j = Write_Strings_At + compressed_offsets[threespaces-1];
-      WriteInt32(p+mark, j);
-      mark += 4;
+        j = Write_Strings_At + compressed_offsets[threespaces-1];
+        WriteInt32(p+mark, j);
+        mark += 4;
     }
 
     /*  -------------------- Objects and Properties ------------------------ */
@@ -1303,94 +1303,94 @@ static void construct_storyfile_g(void)
     object_props_at = mark + no_objects*OBJECT_BYTE_LENGTH;
 
     for (i=0; i<no_objects; i++) {
-      int32 objmark = mark;
-      p[mark++] = 0x70; /* type byte -- object */
-      for (j=0; j<NUM_ATTR_BYTES; j++) {
-        p[mark++] = objectatts[i*NUM_ATTR_BYTES+j];
-      }
-      for (j=0; j<6; j++) {
-        int32 val = 0;
-        switch (j) {
-        case 0: /* next object in the linked list. */
-          if (i == no_objects-1)
-            val = 0;
-          else
-            val = Write_RAM_At + objmark + OBJECT_BYTE_LENGTH;
-          break;
-        case 1: /* hardware name address */
-          val = Write_Strings_At + compressed_offsets[objectsg[i].shortname-1];
-          break;
-        case 2: /* property table address */
-          val = Write_RAM_At + object_props_at + objectsg[i].propaddr;
-          break;
-        case 3: /* parent */
-          if (objectsg[i].parent == 0)
-            val = 0;
-          else
-            val = Write_RAM_At + object_tree_at +
-              (OBJECT_BYTE_LENGTH*(objectsg[i].parent-1));
-          break;
-        case 4: /* sibling */
-          if (objectsg[i].next == 0)
-            val = 0;
-          else
-            val = Write_RAM_At + object_tree_at +
-              (OBJECT_BYTE_LENGTH*(objectsg[i].next-1));
-          break;
-        case 5: /* child */
-          if (objectsg[i].child == 0)
-            val = 0;
-          else
-            val = Write_RAM_At + object_tree_at +
-              (OBJECT_BYTE_LENGTH*(objectsg[i].child-1));
-          break;
+        int32 objmark = mark;
+        p[mark++] = 0x70; /* type byte -- object */
+        for (j=0; j<NUM_ATTR_BYTES; j++) {
+            p[mark++] = objectatts[i*NUM_ATTR_BYTES+j];
         }
-        p[mark++] = (val >> 24) & 0xFF;
-        p[mark++] = (val >> 16) & 0xFF;
-        p[mark++] = (val >> 8) & 0xFF;
-        p[mark++] = (val) & 0xFF;
-      }
+        for (j=0; j<6; j++) {
+            int32 val = 0;
+            switch (j) {
+            case 0: /* next object in the linked list. */
+                if (i == no_objects-1)
+                    val = 0;
+                else
+                    val = Write_RAM_At + objmark + OBJECT_BYTE_LENGTH;
+                break;
+            case 1: /* hardware name address */
+                val = Write_Strings_At + compressed_offsets[objectsg[i].shortname-1];
+                break;
+            case 2: /* property table address */
+                val = Write_RAM_At + object_props_at + objectsg[i].propaddr;
+                break;
+            case 3: /* parent */
+                if (objectsg[i].parent == 0)
+                    val = 0;
+                else
+                    val = Write_RAM_At + object_tree_at +
+                        (OBJECT_BYTE_LENGTH*(objectsg[i].parent-1));
+                break;
+            case 4: /* sibling */
+                if (objectsg[i].next == 0)
+                    val = 0;
+                else
+                    val = Write_RAM_At + object_tree_at +
+                        (OBJECT_BYTE_LENGTH*(objectsg[i].next-1));
+                break;
+            case 5: /* child */
+                if (objectsg[i].child == 0)
+                    val = 0;
+                else
+                    val = Write_RAM_At + object_tree_at +
+                        (OBJECT_BYTE_LENGTH*(objectsg[i].child-1));
+                break;
+            }
+            p[mark++] = (val >> 24) & 0xFF;
+            p[mark++] = (val >> 16) & 0xFF;
+            p[mark++] = (val >> 8) & 0xFF;
+            p[mark++] = (val) & 0xFF;
+        }
 
-      for (j=0; j<GLULX_OBJECT_EXT_BYTES; j++) {
-        p[mark++] = 0;
-      }
+        for (j=0; j<GLULX_OBJECT_EXT_BYTES; j++) {
+            p[mark++] = 0;
+        }
     }
 
     if (object_props_at != mark)
-      error("*** Object table was impossible length ***");
+        error("*** Object table was impossible length ***");
 
     for (i=0; i<properties_table_size; i++)
-      p[mark+i]=properties_table[i];
+        p[mark+i]=properties_table[i];
 
     for (i=0; i<no_objects; i++) { 
-      int32 tableaddr = object_props_at + objectsg[i].propaddr;
-      int32 tablelen = ReadInt32(p+tableaddr);
-      tableaddr += 4;
-      for (j=0; j<tablelen; j++) {
-        k = ReadInt32(p+tableaddr+4);
-        k += (Write_RAM_At + object_props_at);
-        WriteInt32(p+tableaddr+4, k);
-        tableaddr += 10;
-      }
+        int32 tableaddr = object_props_at + objectsg[i].propaddr;
+        int32 tablelen = ReadInt32(p+tableaddr);
+        tableaddr += 4;
+        for (j=0; j<tablelen; j++) {
+            k = ReadInt32(p+tableaddr+4);
+            k += (Write_RAM_At + object_props_at);
+            WriteInt32(p+tableaddr+4, k);
+            tableaddr += 10;
+        }
     }
 
     mark += properties_table_size;
 
     prop_defaults_at = mark;
     for (i=0; i<no_properties; i++) {
-      k = commonprops[i].default_value;
-      WriteInt32(p+mark, k);
-      mark += 4;
+        k = commonprops[i].default_value;
+        WriteInt32(p+mark, k);
+        mark += 4;
     }
 
     /*  ----------- Table of Class Prototype Object Numbers ---------------- */
     
     class_numbers_offset = mark;
     for (i=0; i<no_classes; i++) {
-      j = Write_RAM_At + object_tree_at +
-        (OBJECT_BYTE_LENGTH*(class_info[i].object_number-1));
-      WriteInt32(p+mark, j);
-      mark += 4;
+        j = Write_RAM_At + object_tree_at +
+            (OBJECT_BYTE_LENGTH*(class_info[i].object_number-1));
+        WriteInt32(p+mark, j);
+        mark += 4;
     }
     WriteInt32(p+mark, 0);
     mark += 4;
@@ -1409,71 +1409,71 @@ static void construct_storyfile_g(void)
     */
 
     if (!OMIT_SYMBOL_TABLE) {
-      identifier_names_offset = mark;
-      mark += 32; /* eight pairs of values, to be filled in. */
+        identifier_names_offset = mark;
+        mark += 32; /* eight pairs of values, to be filled in. */
   
-      WriteInt32(p+identifier_names_offset+0, Write_RAM_At + mark);
-      WriteInt32(p+identifier_names_offset+4, no_properties);
-      for (i=0; i<no_properties; i++) {
-        j = individual_name_strings[i];
-        if (j)
-          j = Write_Strings_At + compressed_offsets[j-1];
-        WriteInt32(p+mark, j);
-        mark += 4;
-      }
+        WriteInt32(p+identifier_names_offset+0, Write_RAM_At + mark);
+        WriteInt32(p+identifier_names_offset+4, no_properties);
+        for (i=0; i<no_properties; i++) {
+            j = individual_name_strings[i];
+            if (j)
+                j = Write_Strings_At + compressed_offsets[j-1];
+            WriteInt32(p+mark, j);
+            mark += 4;
+        }
   
-      WriteInt32(p+identifier_names_offset+8, Write_RAM_At + mark);
-      WriteInt32(p+identifier_names_offset+12, 
-        no_individual_properties-INDIV_PROP_START);
-      for (i=INDIV_PROP_START; i<no_individual_properties; i++) {
-        j = individual_name_strings[i];
-        if (j)
-          j = Write_Strings_At + compressed_offsets[j-1];
-        WriteInt32(p+mark, j);
-        mark += 4;
-      }
+        WriteInt32(p+identifier_names_offset+8, Write_RAM_At + mark);
+        WriteInt32(p+identifier_names_offset+12, 
+                   no_individual_properties-INDIV_PROP_START);
+        for (i=INDIV_PROP_START; i<no_individual_properties; i++) {
+            j = individual_name_strings[i];
+            if (j)
+                j = Write_Strings_At + compressed_offsets[j-1];
+            WriteInt32(p+mark, j);
+            mark += 4;
+        }
   
-      WriteInt32(p+identifier_names_offset+16, Write_RAM_At + mark);
-      WriteInt32(p+identifier_names_offset+20, NUM_ATTR_BYTES*8);
-      for (i=0; i<NUM_ATTR_BYTES*8; i++) {
-        j = attribute_name_strings[i];
-        if (j)
-          j = Write_Strings_At + compressed_offsets[j-1];
-        WriteInt32(p+mark, j);
-        mark += 4;
-      }
+        WriteInt32(p+identifier_names_offset+16, Write_RAM_At + mark);
+        WriteInt32(p+identifier_names_offset+20, NUM_ATTR_BYTES*8);
+        for (i=0; i<NUM_ATTR_BYTES*8; i++) {
+            j = attribute_name_strings[i];
+            if (j)
+                j = Write_Strings_At + compressed_offsets[j-1];
+            WriteInt32(p+mark, j);
+            mark += 4;
+        }
   
-      WriteInt32(p+identifier_names_offset+24, Write_RAM_At + mark);
-      WriteInt32(p+identifier_names_offset+28, no_actions + no_fake_actions);
-      action_names_offset = mark;
-      fake_action_names_offset = mark + 4*no_actions;
-      for (i=0; i<no_actions + no_fake_actions; i++) {
-        int ax = i;
-        if (i<no_actions && GRAMMAR_META_FLAG)
-          ax = sorted_actions[i].external_to_int;
-        j = action_name_strings[ax];
-        if (j)
-          j = Write_Strings_At + compressed_offsets[j-1];
-        WriteInt32(p+mark, j);
-        mark += 4;
-      }
+        WriteInt32(p+identifier_names_offset+24, Write_RAM_At + mark);
+        WriteInt32(p+identifier_names_offset+28, no_actions + no_fake_actions);
+        action_names_offset = mark;
+        fake_action_names_offset = mark + 4*no_actions;
+        for (i=0; i<no_actions + no_fake_actions; i++) {
+            int ax = i;
+            if (i<no_actions && GRAMMAR_META_FLAG)
+                ax = sorted_actions[i].external_to_int;
+            j = action_name_strings[ax];
+            if (j)
+                j = Write_Strings_At + compressed_offsets[j-1];
+            WriteInt32(p+mark, j);
+            mark += 4;
+        }
   
-      array_names_offset = mark;
-      WriteInt32(p+mark, no_arrays);
-      mark += 4;
-      for (i=0; i<no_arrays; i++) {
-        j = array_name_strings[i];
-        if (j)
-          j = Write_Strings_At + compressed_offsets[j-1];
-        WriteInt32(p+mark, j);
+        array_names_offset = mark;
+        WriteInt32(p+mark, no_arrays);
         mark += 4;
-      }
+        for (i=0; i<no_arrays; i++) {
+            j = array_name_strings[i];
+            if (j)
+                j = Write_Strings_At + compressed_offsets[j-1];
+            WriteInt32(p+mark, j);
+            mark += 4;
+        }
     }
     else {
-      identifier_names_offset = mark;
-      action_names_offset = mark;
-      fake_action_names_offset = mark;
-      array_names_offset = mark;
+        identifier_names_offset = mark;
+        action_names_offset = mark;
+        fake_action_names_offset = mark;
+        array_names_offset = mark;
     }
 
     individuals_offset = mark;
@@ -1488,31 +1488,31 @@ static void construct_storyfile_g(void)
     mark += no_Inform_verbs*4;
 
     for (i=0; i<no_Inform_verbs; i++) {
-      j = mark + Write_RAM_At;
-      WriteInt32(p+(grammar_table_at+4+i*4), j);
-      if (!Inform_verbs[i].used) {
-          /* This verb was marked unused at locate_dead_grammar_lines()
-             time. Omit the grammar lines. */
-          p[mark++] = 0;
-          continue;
-      }
-      p[mark++] = Inform_verbs[i].lines;
-      for (j=0; j<Inform_verbs[i].lines; j++) {
-        int tok;
-        k = Inform_verbs[i].l[j];
-        p[mark++] = grammar_lines[k++];
-        p[mark++] = grammar_lines[k++];
-        p[mark++] = grammar_lines[k++];
-        for (;;) {
-          tok = grammar_lines[k++];
-          p[mark++] = tok;
-          if (tok == 15) break;
-          p[mark++] = grammar_lines[k++];
-          p[mark++] = grammar_lines[k++];
-          p[mark++] = grammar_lines[k++];
-          p[mark++] = grammar_lines[k++];
+        j = mark + Write_RAM_At;
+        WriteInt32(p+(grammar_table_at+4+i*4), j);
+        if (!Inform_verbs[i].used) {
+            /* This verb was marked unused at locate_dead_grammar_lines()
+               time. Omit the grammar lines. */
+            p[mark++] = 0;
+            continue;
         }
-      }
+        p[mark++] = Inform_verbs[i].lines;
+        for (j=0; j<Inform_verbs[i].lines; j++) {
+            int tok;
+            k = Inform_verbs[i].l[j];
+            p[mark++] = grammar_lines[k++];
+            p[mark++] = grammar_lines[k++];
+            p[mark++] = grammar_lines[k++];
+            for (;;) {
+                tok = grammar_lines[k++];
+                p[mark++] = tok;
+                if (tok == 15) break;
+                p[mark++] = grammar_lines[k++];
+                p[mark++] = grammar_lines[k++];
+                p[mark++] = grammar_lines[k++];
+                p[mark++] = grammar_lines[k++];
+            }
+        }
     }
 
     /*  ------------------- Actions and Preactions ------------------------- */
@@ -1524,9 +1524,9 @@ static void construct_storyfile_g(void)
     /* Values to be written in later. */
 
     if (DICT_CHAR_SIZE != 1) {
-      /* If the dictionary is Unicode, we'd like it to be word-aligned. */
-      while (mark % 4)
-        p[mark++]=0;
+        /* If the dictionary is Unicode, we'd like it to be word-aligned. */
+        while (mark % 4)
+            p[mark++]=0;
     }
 
     preactions_at = mark;
@@ -1539,13 +1539,13 @@ static void construct_storyfile_g(void)
 
     WriteInt32(dictionary+0, dict_entries);
     for (i=0; i<4; i++) 
-      p[mark+i] = dictionary[i];
+        p[mark+i] = dictionary[i];
 
     for (i=0; i<dict_entries; i++) {
-      k = 4 + i*DICT_ENTRY_BYTE_LENGTH;
-      j = mark + 4 + final_dict_order[i]*DICT_ENTRY_BYTE_LENGTH;
-      for (l=0; l<DICT_ENTRY_BYTE_LENGTH; l++)
-        p[j++] = dictionary[k++];
+        k = 4 + i*DICT_ENTRY_BYTE_LENGTH;
+        j = mark + 4 + final_dict_order[i]*DICT_ENTRY_BYTE_LENGTH;
+        for (l=0; l<DICT_ENTRY_BYTE_LENGTH; l++)
+            p[j++] = dictionary[k++];
     }
     mark += 4 + dict_entries * DICT_ENTRY_BYTE_LENGTH;
 
@@ -1553,7 +1553,7 @@ static void construct_storyfile_g(void)
     
     /* The end-of-RAM boundary must be a multiple of GPAGESIZE. */
     while (mark % GPAGESIZE)
-      p[mark++]=0;
+        p[mark++]=0;
 
     RAM_Size = mark;
 
@@ -1585,61 +1585,61 @@ static void construct_storyfile_g(void)
     /*  ------ Backpatch the machine, now that all information is in ------- */
 
     if (TRUE)
-    {   backpatch_zmachine_image_g();
+        {   backpatch_zmachine_image_g();
 
-        /* The action and grammar tables must be backpatched specially. */
+            /* The action and grammar tables must be backpatched specially. */
         
-        mark = actions_at + 4;
-        for (i=0; i<no_actions; i++) {
-          int ax = i;
-          if (GRAMMAR_META_FLAG)
-            ax = sorted_actions[i].external_to_int;
-          j = actions[ax].byte_offset;
-          if (OMIT_UNUSED_ROUTINES)
-            j = df_stripped_address_for_address(j);
-          j += code_offset;
-          WriteInt32(p+mark, j);
-          mark += 4;
-        }
-
-        for (l = 0; l<no_Inform_verbs; l++) {
-          int linecount;
-          k = grammar_table_at + 4 + 4*l; 
-          i = ((p[k] << 24) | (p[k+1] << 16) | (p[k+2] << 8) | (p[k+3]));
-          i -= Write_RAM_At;
-          linecount = p[i++];
-          for (j=0; j<linecount; j++) {
-            if (GRAMMAR_META_FLAG) {
-              /* backpatch the action number */
-              int action = (p[i+0] << 8) | (p[i+1]);
-              action = sorted_actions[action].internal_to_ext;
-              p[i+0] = (action >> 8) & 0xFF;
-              p[i+1] = (action & 0xFF);
-            }
-            i = i + 3;
-            while (p[i] != 15) {
-              int topbits = (p[i]/0x40) & 3;
-              int32 value = ((p[i+1] << 24) | (p[i+2] << 16) 
-                | (p[i+3] << 8) | (p[i+4]));
-              switch(topbits) {
-              case 1:
-                value = dictionary_offset + 4
-                  + final_dict_order[value]*DICT_ENTRY_BYTE_LENGTH;
-                break;
-              case 2:
+            mark = actions_at + 4;
+            for (i=0; i<no_actions; i++) {
+                int ax = i;
+                if (GRAMMAR_META_FLAG)
+                    ax = sorted_actions[i].external_to_int;
+                j = actions[ax].byte_offset;
                 if (OMIT_UNUSED_ROUTINES)
-                  value = df_stripped_address_for_address(value);
-                value += code_offset;
-                break;
-              }
-              WriteInt32(p+(i+1), value);
-              i = i + 5;
+                    j = df_stripped_address_for_address(j);
+                j += code_offset;
+                WriteInt32(p+mark, j);
+                mark += 4;
             }
-            i++;
-          }
-        }
 
-    }
+            for (l = 0; l<no_Inform_verbs; l++) {
+                int linecount;
+                k = grammar_table_at + 4 + 4*l; 
+                i = ((p[k] << 24) | (p[k+1] << 16) | (p[k+2] << 8) | (p[k+3]));
+                i -= Write_RAM_At;
+                linecount = p[i++];
+                for (j=0; j<linecount; j++) {
+                    if (GRAMMAR_META_FLAG) {
+                        /* backpatch the action number */
+                        int action = (p[i+0] << 8) | (p[i+1]);
+                        action = sorted_actions[action].internal_to_ext;
+                        p[i+0] = (action >> 8) & 0xFF;
+                        p[i+1] = (action & 0xFF);
+                    }
+                    i = i + 3;
+                    while (p[i] != 15) {
+                        int topbits = (p[i]/0x40) & 3;
+                        int32 value = ((p[i+1] << 24) | (p[i+2] << 16) 
+                                       | (p[i+3] << 8) | (p[i+4]));
+                        switch(topbits) {
+                        case 1:
+                            value = dictionary_offset + 4
+                                + final_dict_order[value]*DICT_ENTRY_BYTE_LENGTH;
+                            break;
+                        case 2:
+                            if (OMIT_UNUSED_ROUTINES)
+                                value = df_stripped_address_for_address(value);
+                            value += code_offset;
+                            break;
+                        }
+                        WriteInt32(p+(i+1), value);
+                        i = i + 5;
+                    }
+                    i++;
+                }
+            }
+
+        }
 
     /*  ---- From here on, it's all reportage: construction is finished ---- */
 
@@ -2061,34 +2061,34 @@ extern void init_tables_vars(void)
     zmachine_paged_memory = NULL;
 
     if (!glulx_mode) {
-      code_offset = 0x800;
-      actions_offset = 0x800;
-      preactions_offset = 0x800;
-      dictionary_offset = 0x800;
-      adjectives_offset = 0x800;
-      variables_offset = 0;
-      strings_offset = 0xc00;
-      individuals_offset=0x800;
-      identifier_names_offset=0x800;
-      class_numbers_offset = 0x800;
-      arrays_offset = 0x0800;
-      static_arrays_offset = 0x0800;
-      zcode_compact_globals_adjustment = 0;
+        code_offset = 0x800;
+        actions_offset = 0x800;
+        preactions_offset = 0x800;
+        dictionary_offset = 0x800;
+        adjectives_offset = 0x800;
+        variables_offset = 0;
+        strings_offset = 0xc00;
+        individuals_offset=0x800;
+        identifier_names_offset=0x800;
+        class_numbers_offset = 0x800;
+        arrays_offset = 0x0800;
+        static_arrays_offset = 0x0800;
+        zcode_compact_globals_adjustment = 0;
     }
     else {
-      code_offset = 0x12345;
-      actions_offset = 0x12345;
-      preactions_offset = 0x12345;
-      dictionary_offset = 0x12345;
-      adjectives_offset = 0x12345;
-      variables_offset = 0x12345;
-      arrays_offset = 0x12345;
-      strings_offset = 0x12345;
-      individuals_offset=0x12345;
-      identifier_names_offset=0x12345;
-      class_numbers_offset = 0x12345;
-      static_arrays_offset = 0x12345;
-      zcode_compact_globals_adjustment = -1;
+        code_offset = 0x12345;
+        actions_offset = 0x12345;
+        preactions_offset = 0x12345;
+        dictionary_offset = 0x12345;
+        adjectives_offset = 0x12345;
+        variables_offset = 0x12345;
+        arrays_offset = 0x12345;
+        strings_offset = 0x12345;
+        individuals_offset=0x12345;
+        identifier_names_offset=0x12345;
+        class_numbers_offset = 0x12345;
+        static_arrays_offset = 0x12345;
+        zcode_compact_globals_adjustment = -1;
     }
 }
 

--- a/tables.c
+++ b/tables.c
@@ -138,20 +138,20 @@ static char *show_percentage(int32 x, int32 total)
 
 static char *version_name(int v)
 {
-  if (!glulx_mode) {
-    switch(v)
-    {   case 3: return "Standard";
-        case 4: return "Plus";
-        case 5: return "Advanced";
-        case 6: return "Graphical";
-        case 7: return "Extended Alternate";
-        case 8: return "Extended";
+    if (!glulx_mode) {
+        switch(v)
+            {   case 3: return "Standard";
+            case 4: return "Plus";
+            case 5: return "Advanced";
+            case 6: return "Graphical";
+            case 7: return "Extended Alternate";
+            case 8: return "Extended";
+            }
+        return "experimental format";
     }
-    return "experimental format";
-  }
-  else {
-    return "Glulx";
-  }
+    else {
+        return "Glulx";
+    }
 }
 
 static int32 rough_size_of_paged_memory_z(void)

--- a/tables.c
+++ b/tables.c
@@ -1697,63 +1697,63 @@ printf("        +---------------------+   %06lx\n", (long int) Write_Code_At);
 printf("        |        code         |   %s\n",
     show_percentage(Write_Strings_At-Write_Code_At, Out_Size));
 printf("        +---------------------+   %06lx\n",
-  (long int) Write_Strings_At);
+    (long int) Write_Strings_At);
 printf("        | string decode table |   %s\n",
     show_percentage(compression_table_size, Out_Size));
 printf("        + - - - - - - - - - - +   %06lx\n",
-  (long int) Write_Strings_At + compression_table_size);
+    (long int) Write_Strings_At + compression_table_size);
 addr = (static_array_area_size ? static_arrays_at : Write_RAM_At+globals_at);
 printf("        |       strings       |   %s\n",
     show_percentage(addr-(Write_Strings_At + compression_table_size), Out_Size));
             if (static_array_area_size)
             {
 printf("        +---------------------+   %06lx\n", 
-  (long int) (static_arrays_at));
+    (long int) (static_arrays_at));
 printf("        |    static arrays    |   %s\n",
     show_percentage(Write_RAM_At+globals_at-static_arrays_at, Out_Size));
             }
 printf("        +=====================+   %06lx\n", 
-  (long int) (Write_RAM_At+globals_at));
+    (long int) (Write_RAM_At+globals_at));
 printf("Dynamic |  global variables   |   %s\n",
     show_percentage(arrays_at-globals_at, Out_Size));
 printf("memory  + - - - - - - - - - - +   %06lx\n",
-  (long int) (Write_RAM_At+arrays_at));
+    (long int) (Write_RAM_At+arrays_at));
 printf("        |       arrays        |   %s\n",
     show_percentage(abbrevs_at-arrays_at, Out_Size));
 printf("        +---------------------+   %06lx\n",
-  (long int) (Write_RAM_At+abbrevs_at));
+    (long int) (Write_RAM_At+abbrevs_at));
 printf("        | printing variables  |   %s\n",
     show_percentage(object_tree_at-abbrevs_at, Out_Size));
 printf("        +---------------------+   %06lx\n", 
-  (long int) (Write_RAM_At+object_tree_at));
+    (long int) (Write_RAM_At+object_tree_at));
 printf("        |       objects       |   %s\n",
     show_percentage(object_props_at-object_tree_at, Out_Size));
 printf("        + - - - - - - - - - - +   %06lx\n",
-  (long int) (Write_RAM_At+object_props_at));
+    (long int) (Write_RAM_At+object_props_at));
 printf("        |   property values   |   %s\n",
     show_percentage(prop_defaults_at-object_props_at, Out_Size));
 printf("        + - - - - - - - - - - +   %06lx\n",
-  (long int) (Write_RAM_At+prop_defaults_at));
+    (long int) (Write_RAM_At+prop_defaults_at));
 printf("        |  property defaults  |   %s\n",
     show_percentage(class_numbers_offset-prop_defaults_at, Out_Size));
 printf("        + - - - - - - - - - - +   %06lx\n",
-  (long int) (Write_RAM_At+class_numbers_offset));
+    (long int) (Write_RAM_At+class_numbers_offset));
 printf("        | class numbers table |   %s\n",
     show_percentage(identifier_names_offset-class_numbers_offset, Out_Size));
 printf("        + - - - - - - - - - - +   %06lx\n",
-  (long int) (Write_RAM_At+identifier_names_offset));
+    (long int) (Write_RAM_At+identifier_names_offset));
 printf("        |   id names table    |   %s\n",
     show_percentage(grammar_table_at-identifier_names_offset, Out_Size));
 printf("        +---------------------+   %06lx\n",
-  (long int) (Write_RAM_At+grammar_table_at));
+    (long int) (Write_RAM_At+grammar_table_at));
 printf("        |    grammar table    |   %s\n",
     show_percentage(actions_at-grammar_table_at, Out_Size));
 printf("        + - - - - - - - - - - +   %06lx\n", 
-  (long int) (Write_RAM_At+actions_at));
+    (long int) (Write_RAM_At+actions_at));
 printf("        |       actions       |   %s\n",
     show_percentage(dictionary_offset-(Write_RAM_At+actions_at), Out_Size));
 printf("        +---------------------+   %06lx\n", 
-  (long int) dictionary_offset);
+    (long int) dictionary_offset);
 printf("        |     dictionary      |   %s\n",
     show_percentage(Out_Size-dictionary_offset, Out_Size));
             if (MEMORY_MAP_EXTENSION == 0)

--- a/text.c
+++ b/text.c
@@ -2467,7 +2467,7 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
         p[0]=prepared_sort[0]; p[1]=prepared_sort[1];
         p[2]=prepared_sort[2]; p[3]=prepared_sort[3];
         if (version_number > 3)
-          {   p[4]=prepared_sort[4]; p[5]=prepared_sort[5]; }
+        {   p[4]=prepared_sort[4]; p[5]=prepared_sort[5]; }
         p[res]=flag1; p[res+1]=flag2;
         if (!ZCODE_LESS_DICT_DATA) p[res+2]=flag3;
 
@@ -2482,7 +2482,7 @@ extern int dictionary_add(char *dword, int flag1, int flag2, int flag3)
 
         p += DICT_CHAR_SIZE;
         for (i=0; i<DICT_WORD_BYTES; i++)
-          p[i] = prepared_sort[i];
+            p[i] = prepared_sort[i];
         
         p += DICT_WORD_BYTES;
         p[0] = (flag1/256); p[1] = (flag1%256);

--- a/text.c
+++ b/text.c
@@ -1069,12 +1069,12 @@ string; substituting '?'.");
         write_z_char_g(0);
         zchars_trans_in_last_string=total_zchars_trans-zchars_trans_in_last_string;
 
-  }
+    }
 
-  if (text_out_overflow)
-      return -1;
-  else
-      return text_out_pos;
+    if (text_out_overflow)
+        return -1;
+    else
+        return text_out_pos;
 }
 
 static int unicode_entity_index(int32 unicode)

--- a/text.c
+++ b/text.c
@@ -600,175 +600,144 @@ extern int32 translate_text(int32 p_limit, char *s_text, int strctx)
 
 
     
-  if (!glulx_mode) {
+    if (!glulx_mode) {
 
-    /*  The empty string of Z-text is illegal, since it can't carry an end
-        bit: so we translate an empty string of ASCII text to just the
-        pad character 5.  Printing this causes nothing to appear on screen.  */
-
-    if (text_in[0]==0) write_z_char_z(5);
-
-    /*  Loop through the characters of the null-terminated input text: note
-        that if 1 is written over a character in the input text, it is
-        afterwards ignored                                                   */
-
-    for (i=0; text_in[i]!=0; i++)
-    {   total_chars_trans++;
-
-        /*  Contract ".  " into ". " if double-space-removing switch set:
-            likewise "?  " and "!  " if the setting is high enough           */
-
-        if ((double_space_setting >= 1)
-            && (text_in[i+1]==' ') && (text_in[i+2]==' '))
-        {   if (text_in[i]=='.') text_in[i+2]=1;
-            if (double_space_setting >= 2)
-            {   if (text_in[i]=='?') text_in[i+2]=1;
-                if (text_in[i]=='!') text_in[i+2]=1;
+        /*  The empty string of Z-text is illegal, since it can't carry an end
+            bit: so we translate an empty string of ASCII text to just the
+            pad character 5.  Printing this causes nothing to appear on screen. */
+    
+        if (text_in[0]==0) write_z_char_z(5);
+    
+        /*  Loop through the characters of the null-terminated input text: note
+            that if 1 is written over a character in the input text, it is
+            afterwards ignored  */
+    
+        for (i=0; text_in[i]!=0; i++)
+        {   total_chars_trans++;
+    
+            /*  Contract ".  " into ". " if double-space-removing switch set:
+                likewise "?  " and "!  " if the setting is high enough */
+    
+            if ((double_space_setting >= 1)
+                && (text_in[i+1]==' ') && (text_in[i+2]==' '))
+            {   if (text_in[i]=='.') text_in[i+2]=1;
+                if (double_space_setting >= 2)
+                {   if (text_in[i]=='?') text_in[i+2]=1;
+                    if (text_in[i]=='!') text_in[i+2]=1;
+                }
             }
-        }
-
-        /*  Try abbreviations if the economy switch set. */
-        /*  Look at the abbreviation schedule to see if we should abbreviate here. */
-        /*  Note: Just because the schedule has something doesn't mean we should abbreviate there; */
-        /*  sometimes you abbreviate before because it's better. If we have already replaced the */
-        /*  char by a '1', it means we're in the middle of an abbreviation; don't try to abbreviate then. */
-        if ((economy_switch) && (!is_abbreviation) && text_in[i] != 1 &&
-            ((j = abbreviations_optimal_parse_schedule[i]) != -1))
-        {
-            /* Fill with 1s, which will get ignored by everyone else. */
-            uchar *p = (uchar *)abbreviation_text(j);
-            for (k=0; p[k]!=0; k++) text_in[i+k]=1;
-            /* Actually write the abbreviation in the story file. */
-            abbreviations[j].freq++;
-            /* Abbreviations run from MAX_DYNAMIC_STRINGS to 96. */
-            j += MAX_DYNAMIC_STRINGS;
-            write_z_char_z(j/32+1); write_z_char_z(j%32);
-        }
-        
-
-        /* If Unicode switch set, use text_to_unicode to perform UTF-8
-           decoding */
-        if (character_set_unicode && (text_in[i] & 0x80))
-        {   unicode = text_to_unicode((char *) (text_in+i));
-            zscii = unicode_to_zscii(unicode);
-            if (zscii != 5) write_zscii(zscii);
-            else
-            {   unicode_char_error(
-                    "Character can only be used if declared in \
+    
+            /*  Try abbreviations if the economy switch set. */
+            /*  Look at the abbreviation schedule to see if we should abbreviate here. */
+            /*  Note: Just because the schedule has something doesn't mean we should abbreviate there; */
+            /*  sometimes you abbreviate before because it's better. If we have already replaced the */
+            /*  char by a '1', it means we're in the middle of an abbreviation; don't try to abbreviate then. */
+            if ((economy_switch) && (!is_abbreviation) && text_in[i] != 1 &&
+                ((j = abbreviations_optimal_parse_schedule[i]) != -1))
+            {
+                /* Fill with 1s, which will get ignored by everyone else. */
+                uchar *p = (uchar *)abbreviation_text(j);
+                for (k=0; p[k]!=0; k++) text_in[i+k]=1;
+                /* Actually write the abbreviation in the story file. */
+                abbreviations[j].freq++;
+                /* Abbreviations run from MAX_DYNAMIC_STRINGS to 96. */
+                j += MAX_DYNAMIC_STRINGS;
+                write_z_char_z(j/32+1); write_z_char_z(j%32);
+            }
+            
+    
+            /* If Unicode switch set, use text_to_unicode to perform UTF-8
+               decoding */
+            if (character_set_unicode && (text_in[i] & 0x80))
+            {   unicode = text_to_unicode((char *) (text_in+i));
+                zscii = unicode_to_zscii(unicode);
+                if (zscii != 5) write_zscii(zscii);
+                else
+                {   unicode_char_error(
+                        "Character can only be used if declared in \
 advance as part of 'Zcharacter table':", unicode);
-            }
-            i += textual_form_length - 1;
-            continue;
-        }
-
-        /*  '@' is the escape character in Inform string notation: the various
-            possibilities are:
-
-                @@decimalnumber  :  write this ZSCII char (0 to 1023)
-                @twodigits or    :  write the abbreviation string with this
-                @(digits)           decimal number
-                @(symbol)        :  write the abbreviation string with this
-                                    (constant) value
-                @accentcode      :  this accented character: e.g.,
-                                        for @'e write an E-acute
-                @{...}           :  this Unicode char (in hex)              */
-
-        if (text_in[i]=='@')
-        {   if (text_in[i+1]=='@')
-            {
-                /*   @@... (ascii value)  */
-
-                i+=2; j=atoi((char *) (text_in+i));
-                switch(j)
-                {   /* Prevent ~ and ^ from being translated to double-quote
-                       and new-line, as they ordinarily would be */
-
-                    case 94:   write_z_char_z(5); write_z_char_z(6);
-                               write_z_char_z(94/32); write_z_char_z(94%32);
-                               break;
-                    case 126:  write_z_char_z(5); write_z_char_z(6);
-                               write_z_char_z(126/32); write_z_char_z(126%32);
-                               break;
-
-                    default:   write_zscii(j); break;
                 }
-                while (isdigit(text_in[i])) i++;
-                i--;
+                i += textual_form_length - 1;
+                continue;
             }
-            else if (text_in[i+1]=='(')
-            {
-                /*   @(...) (dynamic string)   */
-                int len = 0, digits = 0;
-                i += 2;
-                /* This accepts "12xyz" as a symbol, which it really isn't,
-                   but that just means it won't be found. */
-                while ((text_in[i] == '_' || isalnum(text_in[i]))) {
-                    char ch = text_in[i++];
-                    if (isdigit(ch)) digits++;
+    
+            /*  '@' is the escape character in Inform string notation: the various
+                possibilities are:
+    
+                    @@decimalnumber  :  write this ZSCII char (0 to 1023)
+                    @twodigits or    :  write the abbreviation string with this
+                    @(digits)           decimal number
+                    @(symbol)        :  write the abbreviation string with this
+                                        (constant) value
+                    @accentcode      :  this accented character: e.g.,
+                                            for @'e write an E-acute
+                    @{...}           :  this Unicode char (in hex)          */
+    
+            if (text_in[i]=='@')
+            {   if (text_in[i+1]=='@')
+                {
+                    /*   @@... (ascii value)  */
+    
+                    i+=2; j=atoi((char *) (text_in+i));
+                    switch(j)
+                    {   /* Prevent ~ and ^ from being translated to double-quote
+                           and new-line, as they ordinarily would be */
+    
+                        case 94:   write_z_char_z(5); write_z_char_z(6);
+                                   write_z_char_z(94/32); write_z_char_z(94%32);
+                                   break;
+                        case 126:  write_z_char_z(5); write_z_char_z(6);
+                                   write_z_char_z(126/32); write_z_char_z(126%32);
+                                   break;
+    
+                        default:   write_zscii(j); break;
+                    }
+                    while (isdigit(text_in[i])) i++;
+                    i--;
+                }
+                else if (text_in[i+1]=='(')
+                {
+                    /*   @(...) (dynamic string)   */
+                    int len = 0, digits = 0;
+                    i += 2;
+                    /* This accepts "12xyz" as a symbol, which it really isn't,
+                       but that just means it won't be found. */
+                    while ((text_in[i] == '_' || isalnum(text_in[i]))) {
+                        char ch = text_in[i++];
+                        if (isdigit(ch)) digits++;
+                        ensure_memory_list_available(&temp_symbol_memlist, len+1);
+                        temp_symbol[len++] = ch;
+                    }
                     ensure_memory_list_available(&temp_symbol_memlist, len+1);
-                    temp_symbol[len++] = ch;
-                }
-                ensure_memory_list_available(&temp_symbol_memlist, len+1);
-                temp_symbol[len] = '\0';
-                j = -1;
-                /* We would like to parse temp_symbol as *either* a decimal
-                   number or a constant symbol. */
-                if (text_in[i] != ')' || len == 0) {
-                    error("'@(...)' abbreviation must contain a symbol");
-                }
-                else if (digits == len) {
-                    /* all digits; parse as decimal */
-                    j = atoi(temp_symbol);
-                }
-                else {
-                    int sym = get_symbol_index(temp_symbol);
-                    if (sym < 0 || (symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
-                        error_named("'@(...)' abbreviation expected a known constant value, but contained", temp_symbol);
+                    temp_symbol[len] = '\0';
+                    j = -1;
+                    /* We would like to parse temp_symbol as *either* a decimal
+                       number or a constant symbol. */
+                    if (text_in[i] != ')' || len == 0) {
+                        error("'@(...)' abbreviation must contain a symbol");
+                    }
+                    else if (digits == len) {
+                        /* all digits; parse as decimal */
+                        j = atoi(temp_symbol);
                     }
                     else {
-                        symbols[sym].flags |= USED_SFLAG;
-                        j = symbols[sym].value;
+                        int sym = get_symbol_index(temp_symbol);
+                        if (sym < 0 || (symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
+                            error_named("'@(...)' abbreviation expected a known constant value, but contained", temp_symbol);
+                        }
+                        else {
+                            symbols[sym].flags |= USED_SFLAG;
+                            j = symbols[sym].value;
+                        }
                     }
-                }
-                if (!glulx_mode && j >= 96) {
-                    error_max_dynamic_strings(j);
-                    j = -1;
-                }
-                if (j >= MAX_DYNAMIC_STRINGS) {
-                    error_max_dynamic_strings(j);
-                    j = -1;
-                }
-                if (j >= 0) {
-                    write_z_char_z(j/32+1); write_z_char_z(j%32);
-                }
-                else {
-                    write_z_char_z(' '); /* error fallback */
-                }
-            }
-            else if (isdigit(text_in[i+1])!=0)
-            {   int d1, d2;
-
-                /*   @.. (dynamic string)   */
-
-                d1 = character_digit_value[text_in[i+1]];
-                d2 = character_digit_value[text_in[i+2]];
-                if ((d1 == 127) || (d1 >= 10) || (d2 == 127) || (d2 >= 10))
-                    error("'@..' must have two decimal digits");
-                else
-                {
-                    if (strctx == STRCTX_ABBREV || strctx == STRCTX_LOWSTRING)
-                        warning("The Z-machine standard does not allow dynamic strings inside an abbreviation or dynamic string.");
-                    j = d1*10 + d2;
                     if (!glulx_mode && j >= 96) {
                         error_max_dynamic_strings(j);
                         j = -1;
                     }
                     if (j >= MAX_DYNAMIC_STRINGS) {
-                        /* Shouldn't get here with two digits */
                         error_max_dynamic_strings(j);
                         j = -1;
                     }
-                    i+=2;
                     if (j >= 0) {
                         write_z_char_z(j/32+1); write_z_char_z(j%32);
                     }
@@ -776,298 +745,329 @@ advance as part of 'Zcharacter table':", unicode);
                         write_z_char_z(' '); /* error fallback */
                     }
                 }
+                else if (isdigit(text_in[i+1])!=0)
+                {   int d1, d2;
+    
+                    /*   @.. (dynamic string)   */
+    
+                    d1 = character_digit_value[text_in[i+1]];
+                    d2 = character_digit_value[text_in[i+2]];
+                    if ((d1 == 127) || (d1 >= 10) || (d2 == 127) || (d2 >= 10))
+                        error("'@..' must have two decimal digits");
+                    else
+                    {
+                        if (strctx == STRCTX_ABBREV || strctx == STRCTX_LOWSTRING)
+                            warning("The Z-machine standard does not allow dynamic strings inside an abbreviation or dynamic string.");
+                        j = d1*10 + d2;
+                        if (!glulx_mode && j >= 96) {
+                            error_max_dynamic_strings(j);
+                            j = -1;
+                        }
+                        if (j >= MAX_DYNAMIC_STRINGS) {
+                            /* Shouldn't get here with two digits */
+                            error_max_dynamic_strings(j);
+                            j = -1;
+                        }
+                        i+=2;
+                        if (j >= 0) {
+                            write_z_char_z(j/32+1); write_z_char_z(j%32);
+                        }
+                        else {
+                            write_z_char_z(' '); /* error fallback */
+                        }
+                    }
+                }
+                else
+                {
+                    /*   A string escape specifying an unusual character   */
+    
+                    unicode = text_to_unicode((char *) (text_in+i));
+                    zscii = unicode_to_zscii(unicode);
+                    if (zscii != 5) write_zscii(zscii);
+                    else
+                    {   unicode_char_error(
+                           "Character can only be used if declared in \
+advance as part of 'Zcharacter table':", unicode);
+                    }
+                    i += textual_form_length - 1;
+                }
             }
             else
-            {
-                /*   A string escape specifying an unusual character   */
-
-                unicode = text_to_unicode((char *) (text_in+i));
-                zscii = unicode_to_zscii(unicode);
-                if (zscii != 5) write_zscii(zscii);
-                else
-                {   unicode_char_error(
-                       "Character can only be used if declared in \
-advance as part of 'Zcharacter table':", unicode);
-                }
-                i += textual_form_length - 1;
-            }
-        }
-        else
-        {   /*  Skip a character which has been over-written with the null
-                value 1 earlier on                                           */
-
-            if (text_in[i]!=1)
-            {   if (text_in[i]==' ') write_z_char_z(0);
-                else
-                {   j = (int) text_in[i];
-                    lookup_value = iso_to_alphabet_grid[j];
-                    if (lookup_value < 0)
-                    {   /*  The character isn't in the standard alphabets, so
-                            we have to use the ZSCII 4-Z-char sequence */
-
-                        if (lookup_value == -5)
-                        {   /*  Character isn't in the ZSCII set at all */
-
-                            unicode = iso_to_unicode(j);
-                            unicode_char_error(
-                                "Character can only be used if declared in \
-advance as part of 'Zcharacter table':", unicode);
-                            write_zscii(0x200 + unicode/0x100);
-                            write_zscii(0x300 + unicode%0x100);
-                        }
-                        else write_zscii(-lookup_value);
-                    }
+            {   /*  Skip a character which has been over-written with the null
+                    value 1 earlier on                                           */
+    
+                if (text_in[i]!=1)
+                {   if (text_in[i]==' ') write_z_char_z(0);
                     else
-                    {   /*  The character is in one of the standard alphabets:
-                            write a SHIFT to temporarily change alphabet if
-                            it isn't in alphabet 0, then write the Z-char    */
-
-                        alphabet_used[lookup_value] = 'Y';
-                        in_alphabet = lookup_value/26;
-                        if (in_alphabet==1) write_z_char_z(4);  /* SHIFT to A1 */
-                        if (in_alphabet==2) write_z_char_z(5);  /* SHIFT to A2 */
-                        write_z_char_z(lookup_value%26 + 6);
+                    {   j = (int) text_in[i];
+                        lookup_value = iso_to_alphabet_grid[j];
+                        if (lookup_value < 0)
+                        {   /*  The character isn't in the standard alphabets, so
+                                we have to use the ZSCII 4-Z-char sequence */
+    
+                            if (lookup_value == -5)
+                            {   /*  Character isn't in the ZSCII set at all */
+    
+                                unicode = iso_to_unicode(j);
+                                unicode_char_error(
+                                    "Character can only be used if declared in \
+advance as part of 'Zcharacter table':", unicode);
+                                write_zscii(0x200 + unicode/0x100);
+                                write_zscii(0x300 + unicode%0x100);
+                            }
+                            else write_zscii(-lookup_value);
+                        }
+                        else
+                        {   /*  The character is in one of the standard alphabets:
+                                write a SHIFT to temporarily change alphabet if
+                                it isn't in alphabet 0, then write the Z-char    */
+    
+                            alphabet_used[lookup_value] = 'Y';
+                            in_alphabet = lookup_value/26;
+                            if (in_alphabet==1) write_z_char_z(4);  /* SHIFT to A1 */
+                            if (in_alphabet==2) write_z_char_z(5);  /* SHIFT to A2 */
+                            write_z_char_z(lookup_value%26 + 6);
+                        }
                     }
                 }
             }
         }
+    
+        /*  Flush the Z-characters output buffer and set the "end" bit  */
+    
+        end_z_chars();
     }
+    else {
 
-    /*  Flush the Z-characters output buffer and set the "end" bit           */
+        /* The text storage here is, of course, temporary. Compression
+           will occur when we're finished compiling, so that all the
+           clever Huffman stuff will work.
+           In the stored text, we use "@@" to indicate @,
+           "@0" to indicate a zero byte,
+           "@ANNNN" to indicate an abbreviation,
+           "@DNNNN" to indicate a dynamic string thing.
+           "@UNNNN" to indicate a four-byte Unicode value (0x100 or higher).
+           (NNNN is a four-digit hex number using the letters A-P... an
+           ugly representation but a convenient one.) 
+        */
 
-    end_z_chars();
-  }
-  else {
+        for (i=0; text_in[i]!=0; i++) {
 
-    /* The text storage here is, of course, temporary. Compression
-       will occur when we're finished compiling, so that all the
-       clever Huffman stuff will work.
-       In the stored text, we use "@@" to indicate @,
-       "@0" to indicate a zero byte,
-       "@ANNNN" to indicate an abbreviation,
-       "@DNNNN" to indicate a dynamic string thing.
-       "@UNNNN" to indicate a four-byte Unicode value (0x100 or higher).
-       (NNNN is a four-digit hex number using the letters A-P... an
-       ugly representation but a convenient one.) 
-    */
+            /*  Contract ".  " into ". " if double-space-removing switch set:
+                likewise "?  " and "!  " if the setting is high enough. */
+            if ((double_space_setting >= 1)
+                && (text_in[i+1]==' ') && (text_in[i+2]==' ')) {
+                if (text_in[i]=='.'
+                    || (double_space_setting >= 2 
+                        && (text_in[i]=='?' || text_in[i]=='!'))) {
+                    text_in[i+1] = text_in[i];
+                    i++;
+                }
+            }
 
-    for (i=0; text_in[i]!=0; i++) {
+            total_chars_trans++;
 
-      /*  Contract ".  " into ". " if double-space-removing switch set:
-          likewise "?  " and "!  " if the setting is high enough. */
-      if ((double_space_setting >= 1)
-        && (text_in[i+1]==' ') && (text_in[i+2]==' ')) {
-        if (text_in[i]=='.'
-          || (double_space_setting >= 2 
-            && (text_in[i]=='?' || text_in[i]=='!'))) {
-          text_in[i+1] = text_in[i];
-          i++;
-        }
-      }
-
-      total_chars_trans++;
-
-      /*  Try abbreviations if the economy switch set. We have to be in
-          compression mode too, since the abbreviation mechanism is part
-          of string decompression. */
+            /*  Try abbreviations if the economy switch set. We have to be in
+                compression mode too, since the abbreviation mechanism is part
+                of string decompression. */
       
-      if ((economy_switch) && (compression_switch) && (!is_abbreviation)
-        && ((k=abbrevs_lookup[text_in[i]])!=-1)
-        && ((j=try_abbreviations_from(text_in, i, k)) != -1)) {
-        char *cx = abbreviation_text(j);
-        i += (strlen(cx)-1);
-        write_z_char_g('@');
-        write_z_char_g('A');
-        write_z_char_g('A' + ((j >>12) & 0x0F));
-        write_z_char_g('A' + ((j >> 8) & 0x0F));
-        write_z_char_g('A' + ((j >> 4) & 0x0F));
-        write_z_char_g('A' + ((j     ) & 0x0F));
-      }
-      else if (text_in[i] == '@') {
-        if (text_in[i+1]=='@') {
-          /* An ASCII code */
-          i+=2; j=atoi((char *) (text_in+i));
-          if (j == '@' || j == '\0') {
-            write_z_char_g('@');
-            if (j == 0) {
-              j = '0';
-              if (!compression_switch)
-                warning("Ascii @@0 will prematurely terminate non-compressed \
+            if ((economy_switch) && (compression_switch) && (!is_abbreviation)
+                && ((k=abbrevs_lookup[text_in[i]])!=-1)
+                && ((j=try_abbreviations_from(text_in, i, k)) != -1)) {
+                char *cx = abbreviation_text(j);
+                i += (strlen(cx)-1);
+                write_z_char_g('@');
+                write_z_char_g('A');
+                write_z_char_g('A' + ((j >>12) & 0x0F));
+                write_z_char_g('A' + ((j >> 8) & 0x0F));
+                write_z_char_g('A' + ((j >> 4) & 0x0F));
+                write_z_char_g('A' + ((j     ) & 0x0F));
+            }
+            else if (text_in[i] == '@') {
+                if (text_in[i+1]=='@') {
+                    /* An ASCII code */
+                    i+=2; j=atoi((char *) (text_in+i));
+                    if (j == '@' || j == '\0') {
+                        write_z_char_g('@');
+                        if (j == 0) {
+                            j = '0';
+                            if (!compression_switch)
+                                warning("Ascii @@0 will prematurely terminate non-compressed \
 string.");
-            }
-          }
-          write_z_char_g(j);
-          while (isdigit(text_in[i])) i++;
-          i--;
-        }
-        else if (text_in[i+1]=='(') {
-            int len = 0, digits = 0;
-            i += 2;
-            /* This accepts "12xyz" as a symbol, which it really isn't,
-               but that just means it won't be found. */
-            while ((text_in[i] == '_' || isalnum(text_in[i]))) {
-                char ch = text_in[i++];
-                if (isdigit(ch)) digits++;
-                ensure_memory_list_available(&temp_symbol_memlist, len+1);
-                temp_symbol[len++] = ch;
-            }
-            ensure_memory_list_available(&temp_symbol_memlist, len+1);
-            temp_symbol[len] = '\0';
-            j = -1;
-            /* We would like to parse temp_symbol as *either* a decimal
-               number or a constant symbol. */
-            if (text_in[i] != ')' || len == 0) {
-                error("'@(...)' abbreviation must contain a symbol");
-            }
-            else if (digits == len) {
-                /* all digits; parse as decimal */
-                j = atoi(temp_symbol);
-            }
-            else {
-                int sym = get_symbol_index(temp_symbol);
-                if (sym < 0 || (symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
-                    error_named("'@(...)' abbreviation expected a known constant value, but contained", temp_symbol);
+                        }
+                    }
+                    write_z_char_g(j);
+                    while (isdigit(text_in[i])) i++;
+                    i--;
+                }
+                else if (text_in[i+1]=='(') {
+                    int len = 0, digits = 0;
+                    i += 2;
+                    /* This accepts "12xyz" as a symbol, which it really isn't,
+                       but that just means it won't be found. */
+                    while ((text_in[i] == '_' || isalnum(text_in[i]))) {
+                        char ch = text_in[i++];
+                        if (isdigit(ch)) digits++;
+                        ensure_memory_list_available(&temp_symbol_memlist, len+1);
+                        temp_symbol[len++] = ch;
+                    }
+                    ensure_memory_list_available(&temp_symbol_memlist, len+1);
+                    temp_symbol[len] = '\0';
+                    j = -1;
+                    /* We would like to parse temp_symbol as *either* a decimal
+                       number or a constant symbol. */
+                    if (text_in[i] != ')' || len == 0) {
+                        error("'@(...)' abbreviation must contain a symbol");
+                    }
+                    else if (digits == len) {
+                        /* all digits; parse as decimal */
+                        j = atoi(temp_symbol);
+                    }
+                    else {
+                        int sym = get_symbol_index(temp_symbol);
+                        if (sym < 0 || (symbols[sym].flags & UNKNOWN_SFLAG) || symbols[sym].type != CONSTANT_T || symbols[sym].marker) {
+                            error_named("'@(...)' abbreviation expected a known constant value, but contained", temp_symbol);
+                        }
+                        else {
+                            symbols[sym].flags |= USED_SFLAG;
+                            j = symbols[sym].value;
+                        }
+                    }
+                    if (j >= MAX_DYNAMIC_STRINGS) {
+                        error_max_dynamic_strings(j);
+                        j = -1;
+                    }
+                    if (j+1 >= no_dynamic_strings)
+                        no_dynamic_strings = j+1;
+                    if (j >= 0) {
+                        write_z_char_g('@');
+                        write_z_char_g('D');
+                        write_z_char_g('A' + ((j >>12) & 0x0F));
+                        write_z_char_g('A' + ((j >> 8) & 0x0F));
+                        write_z_char_g('A' + ((j >> 4) & 0x0F));
+                        write_z_char_g('A' + ((j     ) & 0x0F));
+                    }
+                    else {
+                        write_z_char_g(' '); /* error fallback */
+                    }
+                }
+                else if (isdigit(text_in[i+1])) {
+                    int d1, d2;
+                    d1 = character_digit_value[text_in[i+1]];
+                    d2 = character_digit_value[text_in[i+2]];
+                    if ((d1 == 127) || (d1 >= 10) || (d2 == 127) || (d2 >= 10)) {
+                        error("'@..' must have two decimal digits");
+                    }
+                    else {
+                        if (!compression_switch)
+                            warning("'@..' print variable will not work in non-compressed \
+string; substituting '   '.");
+                        i += 2;
+                        j = d1*10 + d2;
+                        if (j >= MAX_DYNAMIC_STRINGS) {
+                            error_max_dynamic_strings(j);
+                            j = -1;
+                        }
+                        if (j+1 >= no_dynamic_strings)
+                            no_dynamic_strings = j+1;
+                        if (j >= 0) {
+                            write_z_char_g('@');
+                            write_z_char_g('D');
+                            write_z_char_g('A' + ((j >>12) & 0x0F));
+                            write_z_char_g('A' + ((j >> 8) & 0x0F));
+                            write_z_char_g('A' + ((j >> 4) & 0x0F));
+                            write_z_char_g('A' + ((j     ) & 0x0F));
+                        }
+                        else {
+                            write_z_char_g(' '); /* error fallback */
+                        }
+                    }
                 }
                 else {
-                    symbols[sym].flags |= USED_SFLAG;
-                    j = symbols[sym].value;
+                    unicode = text_to_unicode((char *) (text_in+i));
+                    i += textual_form_length - 1;
+                    if (unicode == '@' || unicode == '\0') {
+                        write_z_char_g('@');
+                        write_z_char_g(unicode ? '@' : '0');
+                    }
+                    else if (unicode >= 0 && unicode < 256) {
+                        write_z_char_g(unicode);
+                    }
+                    else {
+                        if (!compression_switch) {
+                            warning("Unicode characters will not work in non-compressed \
+string; substituting '?'.");
+                            write_z_char_g('?');
+                        }
+                        else {
+                            j = unicode_entity_index(unicode);
+                            write_z_char_g('@');
+                            write_z_char_g('U');
+                            write_z_char_g('A' + ((j >>12) & 0x0F));
+                            write_z_char_g('A' + ((j >> 8) & 0x0F));
+                            write_z_char_g('A' + ((j >> 4) & 0x0F));
+                            write_z_char_g('A' + ((j     ) & 0x0F));
+                        }
+                    }
                 }
             }
-            if (j >= MAX_DYNAMIC_STRINGS) {
-                error_max_dynamic_strings(j);
-                j = -1;
-            }
-            if (j+1 >= no_dynamic_strings)
-                no_dynamic_strings = j+1;
-            if (j >= 0) {
-                write_z_char_g('@');
-                write_z_char_g('D');
-                write_z_char_g('A' + ((j >>12) & 0x0F));
-                write_z_char_g('A' + ((j >> 8) & 0x0F));
-                write_z_char_g('A' + ((j >> 4) & 0x0F));
-                write_z_char_g('A' + ((j     ) & 0x0F));
-            }
-            else {
-                write_z_char_g(' '); /* error fallback */
-            }
-        }
-        else if (isdigit(text_in[i+1])) {
-          int d1, d2;
-          d1 = character_digit_value[text_in[i+1]];
-          d2 = character_digit_value[text_in[i+2]];
-          if ((d1 == 127) || (d1 >= 10) || (d2 == 127) || (d2 >= 10)) {
-            error("'@..' must have two decimal digits");
-          }
-          else {
-            if (!compression_switch)
-              warning("'@..' print variable will not work in non-compressed \
-string; substituting '   '.");
-            i += 2;
-            j = d1*10 + d2;
-            if (j >= MAX_DYNAMIC_STRINGS) {
-              error_max_dynamic_strings(j);
-              j = -1;
-            }
-            if (j+1 >= no_dynamic_strings)
-              no_dynamic_strings = j+1;
-            if (j >= 0) {
-                write_z_char_g('@');
-                write_z_char_g('D');
-                write_z_char_g('A' + ((j >>12) & 0x0F));
-                write_z_char_g('A' + ((j >> 8) & 0x0F));
-                write_z_char_g('A' + ((j >> 4) & 0x0F));
-                write_z_char_g('A' + ((j     ) & 0x0F));
-            }
-            else {
-                write_z_char_g(' '); /* error fallback */
-            }
-          }
-        }
-        else {
-          unicode = text_to_unicode((char *) (text_in+i));
-          i += textual_form_length - 1;
-          if (unicode == '@' || unicode == '\0') {
-            write_z_char_g('@');
-            write_z_char_g(unicode ? '@' : '0');
-          }
-          else if (unicode >= 0 && unicode < 256) {
-            write_z_char_g(unicode);
-          }
-          else {
-            if (!compression_switch) {
-              warning("Unicode characters will not work in non-compressed \
+            else if (text_in[i] == '^')
+                write_z_char_g(0x0A);
+            else if (text_in[i] == '~')
+                write_z_char_g('"');
+            else if (character_set_unicode) {
+                if (text_in[i] & 0x80) {
+                    unicode = text_to_unicode((char *) (text_in+i));
+                    i += textual_form_length - 1;
+                    if (unicode >= 0 && unicode < 256) {
+                        write_z_char_g(unicode);
+                    }
+                    else {
+                        if (!compression_switch) {
+                            warning("Unicode characters will not work in non-compressed \
 string; substituting '?'.");
-              write_z_char_g('?');
+                            write_z_char_g('?');
+                        }
+                        else {
+                            j = unicode_entity_index(unicode);
+                            write_z_char_g('@');
+                            write_z_char_g('U');
+                            write_z_char_g('A' + ((j >>12) & 0x0F));
+                            write_z_char_g('A' + ((j >> 8) & 0x0F));
+                            write_z_char_g('A' + ((j >> 4) & 0x0F));
+                            write_z_char_g('A' + ((j     ) & 0x0F));
+                        }
+                    }
+                }
+                else {
+                    write_z_char_g(text_in[i]);
+                }
             }
             else {
-              j = unicode_entity_index(unicode);
-              write_z_char_g('@');
-              write_z_char_g('U');
-              write_z_char_g('A' + ((j >>12) & 0x0F));
-              write_z_char_g('A' + ((j >> 8) & 0x0F));
-              write_z_char_g('A' + ((j >> 4) & 0x0F));
-              write_z_char_g('A' + ((j     ) & 0x0F));
-            }
-          }
-        }
-      }
-      else if (text_in[i] == '^')
-        write_z_char_g(0x0A);
-      else if (text_in[i] == '~')
-        write_z_char_g('"');
-      else if (character_set_unicode) {
-        if (text_in[i] & 0x80) {
-          unicode = text_to_unicode((char *) (text_in+i));
-          i += textual_form_length - 1;
-          if (unicode >= 0 && unicode < 256) {
-            write_z_char_g(unicode);
-          }
-          else {
-            if (!compression_switch) {
-              warning("Unicode characters will not work in non-compressed \
+                unicode = iso_to_unicode_grid[text_in[i]];
+                if (unicode >= 0 && unicode < 256) {
+                    write_z_char_g(unicode);
+                }
+                else {
+                    if (!compression_switch) {
+                        warning("Unicode characters will not work in non-compressed \
 string; substituting '?'.");
-              write_z_char_g('?');
+                        write_z_char_g('?');
+                    }
+                    else {
+                        j = unicode_entity_index(unicode);
+                        write_z_char_g('@');
+                        write_z_char_g('U');
+                        write_z_char_g('A' + ((j >>12) & 0x0F));
+                        write_z_char_g('A' + ((j >> 8) & 0x0F));
+                        write_z_char_g('A' + ((j >> 4) & 0x0F));
+                        write_z_char_g('A' + ((j     ) & 0x0F));
+                    }
+                }
             }
-            else {
-              j = unicode_entity_index(unicode);
-              write_z_char_g('@');
-              write_z_char_g('U');
-              write_z_char_g('A' + ((j >>12) & 0x0F));
-              write_z_char_g('A' + ((j >> 8) & 0x0F));
-              write_z_char_g('A' + ((j >> 4) & 0x0F));
-              write_z_char_g('A' + ((j     ) & 0x0F));
-            }
-          }
         }
-        else {
-          write_z_char_g(text_in[i]);
-        }
-      }
-      else {
-        unicode = iso_to_unicode_grid[text_in[i]];
-        if (unicode >= 0 && unicode < 256) {
-          write_z_char_g(unicode);
-        }
-        else {
-          if (!compression_switch) {
-            warning("Unicode characters will not work in non-compressed \
-string; substituting '?'.");
-            write_z_char_g('?');
-          }
-          else {
-            j = unicode_entity_index(unicode);
-            write_z_char_g('@');
-            write_z_char_g('U');
-            write_z_char_g('A' + ((j >>12) & 0x0F));
-            write_z_char_g('A' + ((j >> 8) & 0x0F));
-            write_z_char_g('A' + ((j >> 4) & 0x0F));
-            write_z_char_g('A' + ((j     ) & 0x0F));
-          }
-        }
-      }
-    }
-    write_z_char_g(0);
-    zchars_trans_in_last_string=total_zchars_trans-zchars_trans_in_last_string;
+        write_z_char_g(0);
+        zchars_trans_in_last_string=total_zchars_trans-zchars_trans_in_last_string;
 
   }
 
@@ -1079,22 +1079,22 @@ string; substituting '?'.");
 
 static int unicode_entity_index(int32 unicode)
 {
-  int j;
-  int buck = unicode % UNICODE_HASH_BUCKETS;
+    int j;
+    int buck = unicode % UNICODE_HASH_BUCKETS;
 
-  for (j = unicode_usage_hash[buck]; j >= 0; j=unicode_usage_entries[j].next) {
-    if (unicode_usage_entries[j].ch == unicode)
-      break;
-  }
-  if (j < 0) {
-    ensure_memory_list_available(&unicode_usage_entries_memlist, no_unicode_chars+1);
-    j = no_unicode_chars++;
-    unicode_usage_entries[j].ch = unicode;
-    unicode_usage_entries[j].next = unicode_usage_hash[buck];
-    unicode_usage_hash[buck] = j;
-  }
+    for (j = unicode_usage_hash[buck]; j >= 0; j=unicode_usage_entries[j].next) {
+        if (unicode_usage_entries[j].ch == unicode)
+            break;
+    }
+    if (j < 0) {
+        ensure_memory_list_available(&unicode_usage_entries_memlist, no_unicode_chars+1);
+        j = no_unicode_chars++;
+        unicode_usage_entries[j].ch = unicode;
+        unicode_usage_entries[j].next = unicode_usage_hash[buck];
+        unicode_usage_hash[buck] = j;
+    }
 
-  return j;
+    return j;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -1103,335 +1103,335 @@ static int unicode_entity_index(int32 unicode)
 
 
 static void compress_makebits(int entnum, int depth, int prevbit,
-  huffbitlist_t *bits);
+    huffbitlist_t *bits);
 
 /*   The compressor. This uses the usual Huffman compression algorithm. */
 void compress_game_text()
 {
-  int entities=0, branchstart, branches;
-  int numlive;
-  int32 lx;
-  int jx;
-  int ch;
-  int32 ix;
-  int max_char_set;
-  huffbitlist_t bits;
+    int entities=0, branchstart, branches;
+    int numlive;
+    int32 lx;
+    int jx;
+    int ch;
+    int32 ix;
+    int max_char_set;
+    huffbitlist_t bits;
 
-  if (compression_switch) {
-    max_char_set = 257 + no_abbreviations + no_dynamic_strings + no_unicode_chars;
+    if (compression_switch) {
+        max_char_set = 257 + no_abbreviations + no_dynamic_strings + no_unicode_chars;
 
-    huff_entities = my_calloc(sizeof(huffentity_t), max_char_set*2+1, 
-      "huffman entities");
-    hufflist = my_calloc(sizeof(huffentity_t *), max_char_set, 
-      "huffman node list");
+        huff_entities = my_calloc(sizeof(huffentity_t), max_char_set*2+1, 
+                                  "huffman entities");
+        hufflist = my_calloc(sizeof(huffentity_t *), max_char_set, 
+                             "huffman node list");
 
-    /* How many entities have we currently got? Well, 256 plus the
-       string-terminator plus Unicode chars plus abbreviations plus
-       dynamic strings. */
-    entities = 256+1;
-    huff_unicode_start = entities;
-    entities += no_unicode_chars;
-    huff_abbrev_start = entities;
-    if (economy_switch)
-      entities += no_abbreviations;
-    huff_dynam_start = entities;
-    entities += no_dynamic_strings;
+        /* How many entities have we currently got? Well, 256 plus the
+           string-terminator plus Unicode chars plus abbreviations plus
+           dynamic strings. */
+        entities = 256+1;
+        huff_unicode_start = entities;
+        entities += no_unicode_chars;
+        huff_abbrev_start = entities;
+        if (economy_switch)
+            entities += no_abbreviations;
+        huff_dynam_start = entities;
+        entities += no_dynamic_strings;
 
-    if (entities > max_char_set)
-      compiler_error("Too many entities for max_char_set");
+        if (entities > max_char_set)
+            compiler_error("Too many entities for max_char_set");
 
-    /* Characters */
-    for (jx=0; jx<256; jx++) {
-      huff_entities[jx].type = 2;
-      huff_entities[jx].count = 0;
-      huff_entities[jx].u.ch = jx;
-    }
-    /* Terminator */
-    huff_entities[256].type = 1;
-    huff_entities[256].count = 0;
-    for (jx=0; jx<no_unicode_chars; jx++) {
-      huff_entities[huff_unicode_start+jx].type = 4;
-      huff_entities[huff_unicode_start+jx].count = 0;
-      huff_entities[huff_unicode_start+jx].u.val = jx;
-    }
-    if (economy_switch) {
-      for (jx=0; jx<no_abbreviations; jx++) {
-        huff_entities[huff_abbrev_start+jx].type = 3;
-        huff_entities[huff_abbrev_start+jx].count = 0;
-        huff_entities[huff_abbrev_start+jx].u.val = jx;
-      }
-    }
-    for (jx=0; jx<no_dynamic_strings; jx++) {
-      huff_entities[huff_dynam_start+jx].type = 9;
-      huff_entities[huff_dynam_start+jx].count = 0;
-      huff_entities[huff_dynam_start+jx].u.val = jx;
-    }
-  }
-  else {
-    /* No compression; use defaults that will make it easy to check
-       for errors. */
-    no_huff_entities = 257;
-    huff_unicode_start = 257;
-    huff_abbrev_start = 257;
-    huff_dynam_start = 257+no_abbreviations;
-    compression_table_size = 0;
-  }
-
-  if (compression_switch) {
-
-    for (lx=0, ix=0; lx<no_strings; lx++) {
-      int escapelen=0, escapetype=0;
-      int done=FALSE;
-      int32 escapeval=0;
-      while (!done) {
-        ch = static_strings_area[ix];
-        ix++;
-        if (ix > static_strings_extent || ch < 0)
-          compiler_error("Read too much not-yet-compressed text.");
-        if (escapelen == -1) {
-          escapelen = 0;
-          if (ch == '@') {
-            ch = '@';
-          }
-          else if (ch == '0') {
-            ch = '\0';
-          }
-          else if (ch == 'A' || ch == 'D' || ch == 'U') {
-            escapelen = 4;
-            escapetype = ch;
-            escapeval = 0;
-            continue;
-          }
-          else {
-            compiler_error("Strange @ escape in processed text.");
-          }
+        /* Characters */
+        for (jx=0; jx<256; jx++) {
+            huff_entities[jx].type = 2;
+            huff_entities[jx].count = 0;
+            huff_entities[jx].u.ch = jx;
         }
-        else if (escapelen) {
-          escapeval = (escapeval << 4) | ((ch-'A') & 0x0F);
-          escapelen--;
-          if (escapelen == 0) {
-            if (escapetype == 'A') {
-              ch = huff_abbrev_start+escapeval;
+        /* Terminator */
+        huff_entities[256].type = 1;
+        huff_entities[256].count = 0;
+        for (jx=0; jx<no_unicode_chars; jx++) {
+            huff_entities[huff_unicode_start+jx].type = 4;
+            huff_entities[huff_unicode_start+jx].count = 0;
+            huff_entities[huff_unicode_start+jx].u.val = jx;
+        }
+        if (economy_switch) {
+            for (jx=0; jx<no_abbreviations; jx++) {
+                huff_entities[huff_abbrev_start+jx].type = 3;
+                huff_entities[huff_abbrev_start+jx].count = 0;
+                huff_entities[huff_abbrev_start+jx].u.val = jx;
             }
-            else if (escapetype == 'D') {
-              ch = huff_dynam_start+escapeval;
+        }
+        for (jx=0; jx<no_dynamic_strings; jx++) {
+            huff_entities[huff_dynam_start+jx].type = 9;
+            huff_entities[huff_dynam_start+jx].count = 0;
+            huff_entities[huff_dynam_start+jx].u.val = jx;
+        }
+    }
+    else {
+        /* No compression; use defaults that will make it easy to check
+           for errors. */
+        no_huff_entities = 257;
+        huff_unicode_start = 257;
+        huff_abbrev_start = 257;
+        huff_dynam_start = 257+no_abbreviations;
+        compression_table_size = 0;
+    }
+
+    if (compression_switch) {
+
+        for (lx=0, ix=0; lx<no_strings; lx++) {
+            int escapelen=0, escapetype=0;
+            int done=FALSE;
+            int32 escapeval=0;
+            while (!done) {
+                ch = static_strings_area[ix];
+                ix++;
+                if (ix > static_strings_extent || ch < 0)
+                    compiler_error("Read too much not-yet-compressed text.");
+                if (escapelen == -1) {
+                    escapelen = 0;
+                    if (ch == '@') {
+                        ch = '@';
+                    }
+                    else if (ch == '0') {
+                        ch = '\0';
+                    }
+                    else if (ch == 'A' || ch == 'D' || ch == 'U') {
+                        escapelen = 4;
+                        escapetype = ch;
+                        escapeval = 0;
+                        continue;
+                    }
+                    else {
+                        compiler_error("Strange @ escape in processed text.");
+                    }
+                }
+                else if (escapelen) {
+                    escapeval = (escapeval << 4) | ((ch-'A') & 0x0F);
+                    escapelen--;
+                    if (escapelen == 0) {
+                        if (escapetype == 'A') {
+                            ch = huff_abbrev_start+escapeval;
+                        }
+                        else if (escapetype == 'D') {
+                            ch = huff_dynam_start+escapeval;
+                        }
+                        else if (escapetype == 'U') {
+                            ch = huff_unicode_start+escapeval;
+                        }
+                        else {
+                            compiler_error("Strange @ escape in processed text.");
+                        }
+                    }
+                    else
+                        continue;
+                }
+                else {
+                    if (ch == '@') {
+                        escapelen = -1;
+                        continue;
+                    }
+                    if (ch == 0) {
+                        ch = 256;
+                        done = TRUE;
+                    }
+                }
+                huff_entities[ch].count++;
             }
-            else if (escapetype == 'U') {
-              ch = huff_unicode_start+escapeval;
+        }
+
+        numlive = 0;
+        for (jx=0; jx<entities; jx++) {
+            if (huff_entities[jx].count) {
+                hufflist[numlive] = &(huff_entities[jx]);
+                numlive++;
+            }
+        }
+
+        branchstart = entities;
+        branches = 0;
+
+        while (numlive > 1) {
+            int best1, best2;
+            int best1num, best2num;
+            huffentity_t *bran;
+
+            if (hufflist[0]->count < hufflist[1]->count) {
+                best1 = 0;
+                best2 = 1;
             }
             else {
-              compiler_error("Strange @ escape in processed text.");
+                best2 = 0;
+                best1 = 1;
             }
-          }
-          else
-            continue;
+
+            best1num = hufflist[best1]->count;
+            best2num = hufflist[best2]->count;
+
+            for (jx=2; jx<numlive; jx++) {
+                if (hufflist[jx]->count < best1num) {
+                    best2 = best1;
+                    best2num = best1num;
+                    best1 = jx;
+                    best1num = hufflist[best1]->count;
+                }
+                else if (hufflist[jx]->count < best2num) {
+                    best2 = jx;
+                    best2num = hufflist[best2]->count;
+                }
+            }
+
+            bran = &(huff_entities[branchstart+branches]);
+            branches++;
+            bran->type = 0;
+            bran->count = hufflist[best1]->count + hufflist[best2]->count;
+            bran->u.branch[0] = (hufflist[best1] - huff_entities);
+            bran->u.branch[1] = (hufflist[best2] - huff_entities);
+            hufflist[best1] = bran;
+            if (best2 < numlive-1) {
+                memmove(&(hufflist[best2]), &(hufflist[best2+1]), 
+                        ((numlive-1) - best2) * sizeof(huffentity_t *));
+            }
+            numlive--;
         }
-        else {
-          if (ch == '@') {
-            escapelen = -1;
-            continue;
-          }
-          if (ch == 0) {
-            ch = 256;
-            done = TRUE;
-          }
-        }
-        huff_entities[ch].count++;
-      }
+
+        huff_entity_root = (hufflist[0] - huff_entities);
+
+        for (ix=0; ix<MAXHUFFBYTES; ix++)
+            bits.b[ix] = 0;
+        compression_table_size = 12;
+
+        no_huff_entities = 0; /* compress_makebits will total this up */
+        compress_makebits(huff_entity_root, 0, -1, &bits);
     }
 
-    numlive = 0;
-    for (jx=0; jx<entities; jx++) {
-      if (huff_entities[jx].count) {
-        hufflist[numlive] = &(huff_entities[jx]);
-        numlive++;
-      }
-    }
+    /* Now, sadly, we have to compute the size of the string section,
+       without actually doing the compression. */
+    compression_string_size = 0;
 
-    branchstart = entities;
-    branches = 0;
+    ensure_memory_list_available(&compressed_offsets_memlist, no_strings);
 
-    while (numlive > 1) {
-      int best1, best2;
-      int best1num, best2num;
-      huffentity_t *bran;
+    for (lx=0, ix=0; lx<no_strings; lx++) {
+        int escapelen=0, escapetype=0;
+        int done=FALSE;
+        int32 escapeval=0;
+        jx = 0; 
+        compressed_offsets[lx] = compression_table_size + compression_string_size;
+        compression_string_size++; /* for the type byte */
+        while (!done) {
+            ch = static_strings_area[ix];
+            ix++;
+            if (ix > static_strings_extent || ch < 0)
+                compiler_error("Read too much not-yet-compressed text.");
+            if (escapelen == -1) {
+                escapelen = 0;
+                if (ch == '@') {
+                    ch = '@';
+                }
+                else if (ch == '0') {
+                    ch = '\0';
+                }
+                else if (ch == 'A' || ch == 'D' || ch == 'U') {
+                    escapelen = 4;
+                    escapetype = ch;
+                    escapeval = 0;
+                    continue;
+                }
+                else {
+                    compiler_error("Strange @ escape in processed text.");
+                }
+            }
+            else if (escapelen) {
+                escapeval = (escapeval << 4) | ((ch-'A') & 0x0F);
+                escapelen--;
+                if (escapelen == 0) {
+                    if (escapetype == 'A') {
+                        ch = huff_abbrev_start+escapeval;
+                    }
+                    else if (escapetype == 'D') {
+                        ch = huff_dynam_start+escapeval;
+                    }
+                    else if (escapetype == 'U') {
+                        ch = huff_unicode_start+escapeval;
+                    }
+                    else {
+                        compiler_error("Strange @ escape in processed text.");
+                    }
+                }
+                else
+                    continue;
+            }
+            else {
+                if (ch == '@') {
+                    escapelen = -1;
+                    continue;
+                }
+                if (ch == 0) {
+                    ch = 256;
+                    done = TRUE;
+                }
+            }
 
-      if (hufflist[0]->count < hufflist[1]->count) {
-        best1 = 0;
-        best2 = 1;
-      }
-      else {
-        best2 = 0;
-        best1 = 1;
-      }
-
-      best1num = hufflist[best1]->count;
-      best2num = hufflist[best2]->count;
-
-      for (jx=2; jx<numlive; jx++) {
-        if (hufflist[jx]->count < best1num) {
-          best2 = best1;
-          best2num = best1num;
-          best1 = jx;
-          best1num = hufflist[best1]->count;
-        }
-        else if (hufflist[jx]->count < best2num) {
-          best2 = jx;
-          best2num = hufflist[best2]->count;
-        }
-      }
-
-      bran = &(huff_entities[branchstart+branches]);
-      branches++;
-      bran->type = 0;
-      bran->count = hufflist[best1]->count + hufflist[best2]->count;
-      bran->u.branch[0] = (hufflist[best1] - huff_entities);
-      bran->u.branch[1] = (hufflist[best2] - huff_entities);
-      hufflist[best1] = bran;
-      if (best2 < numlive-1) {
-        memmove(&(hufflist[best2]), &(hufflist[best2+1]), 
-          ((numlive-1) - best2) * sizeof(huffentity_t *));
-      }
-      numlive--;
-    }
-
-    huff_entity_root = (hufflist[0] - huff_entities);
-
-    for (ix=0; ix<MAXHUFFBYTES; ix++)
-      bits.b[ix] = 0;
-    compression_table_size = 12;
-
-    no_huff_entities = 0; /* compress_makebits will total this up */
-    compress_makebits(huff_entity_root, 0, -1, &bits);
-  }
-
-  /* Now, sadly, we have to compute the size of the string section,
-     without actually doing the compression. */
-  compression_string_size = 0;
-
-  ensure_memory_list_available(&compressed_offsets_memlist, no_strings);
-
-  for (lx=0, ix=0; lx<no_strings; lx++) {
-    int escapelen=0, escapetype=0;
-    int done=FALSE;
-    int32 escapeval=0;
-    jx = 0; 
-    compressed_offsets[lx] = compression_table_size + compression_string_size;
-    compression_string_size++; /* for the type byte */
-    while (!done) {
-      ch = static_strings_area[ix];
-      ix++;
-      if (ix > static_strings_extent || ch < 0)
-        compiler_error("Read too much not-yet-compressed text.");
-      if (escapelen == -1) {
-        escapelen = 0;
-        if (ch == '@') {
-          ch = '@';
-        }
-        else if (ch == '0') {
-          ch = '\0';
-        }
-        else if (ch == 'A' || ch == 'D' || ch == 'U') {
-          escapelen = 4;
-          escapetype = ch;
-          escapeval = 0;
-          continue;
-        }
-        else {
-          compiler_error("Strange @ escape in processed text.");
-        }
-      }
-      else if (escapelen) {
-        escapeval = (escapeval << 4) | ((ch-'A') & 0x0F);
-        escapelen--;
-        if (escapelen == 0) {
-          if (escapetype == 'A') {
-            ch = huff_abbrev_start+escapeval;
-          }
-          else if (escapetype == 'D') {
-            ch = huff_dynam_start+escapeval;
-          }
-          else if (escapetype == 'U') {
-            ch = huff_unicode_start+escapeval;
-          }
-          else {
-            compiler_error("Strange @ escape in processed text.");
-          }
-        }
-        else
-          continue;
-      }
-      else {
-        if (ch == '@') {
-          escapelen = -1;
-          continue;
-        }
-        if (ch == 0) {
-          ch = 256;
-          done = TRUE;
-        }
-      }
-
-      if (compression_switch) {
-        jx += huff_entities[ch].depth;
-        compression_string_size += (jx/8);
-        jx = (jx % 8);
-      }
-      else {
-        if (ch >= huff_dynam_start) {
-          compression_string_size += 3;
-        }
-        else if (ch >= huff_unicode_start) {
-          compiler_error("Abbreviation/Unicode in non-compressed string \
+            if (compression_switch) {
+                jx += huff_entities[ch].depth;
+                compression_string_size += (jx/8);
+                jx = (jx % 8);
+            }
+            else {
+                if (ch >= huff_dynam_start) {
+                    compression_string_size += 3;
+                }
+                else if (ch >= huff_unicode_start) {
+                    compiler_error("Abbreviation/Unicode in non-compressed string \
 should be impossible.");
+                }
+                else
+                    compression_string_size += 1;
+            }
         }
-        else
-          compression_string_size += 1;
-      }
+        if (compression_switch && jx)
+            compression_string_size++;
     }
-    if (compression_switch && jx)
-      compression_string_size++;
-  }
 
-  done_compression = TRUE;
+    done_compression = TRUE;
 }
 
 static void compress_makebits(int entnum, int depth, int prevbit,
-  huffbitlist_t *bits)
+                              huffbitlist_t *bits)
 {
-  huffentity_t *ent = &(huff_entities[entnum]);
-  char *cx;
+    huffentity_t *ent = &(huff_entities[entnum]);
+    char *cx;
 
-  no_huff_entities++;
-  ent->addr = compression_table_size;
-  ent->depth = depth;
-  ent->bits = *bits;
-  if (depth > 0) {
-    if (prevbit)
-      ent->bits.b[(depth-1) / 8] |= (1 << ((depth-1) % 8));
-  }
+    no_huff_entities++;
+    ent->addr = compression_table_size;
+    ent->depth = depth;
+    ent->bits = *bits;
+    if (depth > 0) {
+        if (prevbit)
+            ent->bits.b[(depth-1) / 8] |= (1 << ((depth-1) % 8));
+    }
 
-  switch (ent->type) {
-  case 0:
-    compression_table_size += 9;
-    compress_makebits(ent->u.branch[0], depth+1, 0, &ent->bits);
-    compress_makebits(ent->u.branch[1], depth+1, 1, &ent->bits);
-    break;
-  case 1:
-    compression_table_size += 1;
-    break;
-  case 2:
-    compression_table_size += 2;
-    break;
-  case 3:
-    cx = abbreviation_text(ent->u.val);
-    compression_table_size += (1 + 1 + strlen(cx));
-    break;
-  case 4:
-  case 9:
-    compression_table_size += 5;
-    break;
-  }
+    switch (ent->type) {
+    case 0:
+        compression_table_size += 9;
+        compress_makebits(ent->u.branch[0], depth+1, 0, &ent->bits);
+        compress_makebits(ent->u.branch[1], depth+1, 1, &ent->bits);
+        break;
+    case 1:
+        compression_table_size += 1;
+        break;
+    case 2:
+        compression_table_size += 2;
+        break;
+    case 3:
+        cx = abbreviation_text(ent->u.val);
+        compression_table_size += (1 + 1 + strlen(cx));
+        break;
+    case 4:
+    case 9:
+        compression_table_size += 5;
+        break;
+    }
 }
 
 /* ------------------------------------------------------------------------- */

--- a/text.c
+++ b/text.c
@@ -2077,144 +2077,144 @@ apostrophe in", dword);
 /* Also used by verbs.c */
 static void dictionary_prepare_g(char *dword, uchar *optresult)
 { 
-  int i, j, k;
-  int32 unicode;
-  int negflag;
+    int i, j, k;
+    int32 unicode;
+    int negflag;
 
-  /* Flag to set if a dict word is truncated. We only do this if
-     DICT_TRUNCATE_FLAG, however. */
-  int truncflag = (DICT_TRUNCATE_FLAG ? TRUNC_DFLAG : NONE_DFLAG);
+    /* Flag to set if a dict word is truncated. We only do this if
+       DICT_TRUNCATE_FLAG, however. */
+    int truncflag = (DICT_TRUNCATE_FLAG ? TRUNC_DFLAG : NONE_DFLAG);
 
-  /* Will be set to suppress dict flags if we're past the size limit.
-     But only if LONG_DICT_FLAG_BUG. */
-  int truncbug = FALSE;
+    /* Will be set to suppress dict flags if we're past the size limit.
+       But only if LONG_DICT_FLAG_BUG. */
+    int truncbug = FALSE;
 
-  prepared_dictflags_pos = 0;
-  prepared_dictflags_neg = 0;
+    prepared_dictflags_pos = 0;
+    prepared_dictflags_neg = 0;
 
-  for (i=0, j=0; (dword[j]!=0); j++) {
-    if ((dword[j] == '/') && (dword[j+1] == '/')) {
-      /* The rest of the word is dict flags. Run through them. */
-      negflag = FALSE;
-      for (j+=2; dword[j] != 0; j++) {
-        if (truncbug) continue; /* do not set flags */
-        switch(dword[j]) {
-        case '~':
-            if (!dword[j+1])
-                error_named("'//~' with no flag character (psn) in dict word", dword);
-            negflag = !negflag;
-            break;
-        case 'p':
-            if (!negflag)
-                prepared_dictflags_pos |= PLURAL_DFLAG;
-            else
-                prepared_dictflags_neg |= PLURAL_DFLAG;
+    for (i=0, j=0; (dword[j]!=0); j++) {
+        if ((dword[j] == '/') && (dword[j+1] == '/')) {
+            /* The rest of the word is dict flags. Run through them. */
             negflag = FALSE;
+            for (j+=2; dword[j] != 0; j++) {
+                if (truncbug) continue; /* do not set flags */
+                switch(dword[j]) {
+                case '~':
+                    if (!dword[j+1])
+                        error_named("'//~' with no flag character (psn) in dict word", dword);
+                    negflag = !negflag;
+                    break;
+                case 'p':
+                    if (!negflag)
+                        prepared_dictflags_pos |= PLURAL_DFLAG;
+                    else
+                        prepared_dictflags_neg |= PLURAL_DFLAG;
+                    negflag = FALSE;
+                    break;
+                case 's':
+                    if (!negflag)
+                        prepared_dictflags_pos |= SING_DFLAG;
+                    else
+                        prepared_dictflags_neg |= SING_DFLAG;
+                    negflag = FALSE;
+                    break;
+                case 'n':
+                    if (!negflag)
+                        prepared_dictflags_pos |= NOUN_DFLAG;
+                    else
+                        prepared_dictflags_neg |= NOUN_DFLAG;
+                    negflag = FALSE;
+                    break;
+                default:
+                    error_named("Expected flag character (psn~) after '//' in dict word", dword);
+                    break;
+                }
+            }
             break;
-        case 's':
-            if (!negflag)
-                prepared_dictflags_pos |= SING_DFLAG;
-            else
-                prepared_dictflags_neg |= SING_DFLAG;
-            negflag = FALSE;
-            break;
-        case 'n':
-            if (!negflag)
-                prepared_dictflags_pos |= NOUN_DFLAG;
-            else
-                prepared_dictflags_neg |= NOUN_DFLAG;
-            negflag = FALSE;
-            break;
-        default:
-          error_named("Expected flag character (psn~) after '//' in dict word", dword);
-          break;
         }
-      }
-      break;
-    }
 
-    /* LONG_DICT_FLAG_BUG emulates the old behavior where we stop looping
-       at DICT_WORD_SIZE. */
-    if (LONG_DICT_FLAG_BUG && i>=DICT_WORD_SIZE)
-        truncbug = TRUE;
+        /* LONG_DICT_FLAG_BUG emulates the old behavior where we stop looping
+           at DICT_WORD_SIZE. */
+        if (LONG_DICT_FLAG_BUG && i>=DICT_WORD_SIZE)
+            truncbug = TRUE;
 
-    k= ((uchar *)dword)[j];
-    if (k=='\'') 
-      warning_named("Obsolete usage: use the ^ character for the \
+        k= ((uchar *)dword)[j];
+        if (k=='\'') 
+            warning_named("Obsolete usage: use the ^ character for the \
 apostrophe in", dword);
-    if (k=='^') 
-      k='\'';
-    if (k=='~') /* as in iso_to_alphabet_grid */
-      k='\"';
+        if (k=='^') 
+            k='\'';
+        if (k=='~') /* as in iso_to_alphabet_grid */
+            k='\"';
 
-    if (k=='@' || (character_set_unicode && (k & 0x80))) {
-      unicode = text_to_unicode(dword+j);
-      j += textual_form_length - 1;
-    }
-    else {
-      unicode = iso_to_unicode_grid[k];
-    }
+        if (k=='@' || (character_set_unicode && (k & 0x80))) {
+            unicode = text_to_unicode(dword+j);
+            j += textual_form_length - 1;
+        }
+        else {
+            unicode = iso_to_unicode_grid[k];
+        }
 
-    if (DICT_CHAR_SIZE != 1 || (unicode >= 0 && unicode < 256)) {
-      k = unicode;
-    }
-    else {
-      error("The dictionary cannot contain Unicode characters beyond Latin-1. \
+        if (DICT_CHAR_SIZE != 1 || (unicode >= 0 && unicode < 256)) {
+            k = unicode;
+        }
+        else {
+            error("The dictionary cannot contain Unicode characters beyond Latin-1. \
 Define DICT_CHAR_SIZE=4 for a Unicode-compatible dictionary.");
-      k = '?';
-    }
+            k = '?';
+        }
     
-    if (k >= 'A' && k <= 'Z')
-      k += ('a' - 'A');
+        if (k >= 'A' && k <= 'Z')
+            k += ('a' - 'A');
 
-    ensure_memory_list_available(&prepared_sort_memlist, DICT_WORD_BYTES);
+        ensure_memory_list_available(&prepared_sort_memlist, DICT_WORD_BYTES);
     
+        if (DICT_CHAR_SIZE == 1) {
+            if (i<DICT_WORD_SIZE)
+                prepared_sort[i++] = k;
+            else
+                prepared_dictflags_pos |= truncflag;          
+        }
+        else {
+            if (i<DICT_WORD_SIZE) {
+                prepared_sort[4*i]   = (k >> 24) & 0xFF;
+                prepared_sort[4*i+1] = (k >> 16) & 0xFF;
+                prepared_sort[4*i+2] = (k >>  8) & 0xFF;
+                prepared_sort[4*i+3] = (k)       & 0xFF;
+                i++;
+            }
+            else {
+                prepared_dictflags_pos |= truncflag;          
+            }
+        }
+    }
+
+    if (i > DICT_WORD_SIZE)
+        compiler_error("dict word buffer overflow");
+
+    /* Right-pad with zeroes */
     if (DICT_CHAR_SIZE == 1) {
-      if (i<DICT_WORD_SIZE)
-        prepared_sort[i++] = k;
-      else
-        prepared_dictflags_pos |= truncflag;          
+        for (; i<DICT_WORD_SIZE; i++)
+            prepared_sort[i] = 0;
     }
     else {
-      if (i<DICT_WORD_SIZE) {
-        prepared_sort[4*i]   = (k >> 24) & 0xFF;
-        prepared_sort[4*i+1] = (k >> 16) & 0xFF;
-        prepared_sort[4*i+2] = (k >>  8) & 0xFF;
-        prepared_sort[4*i+3] = (k)       & 0xFF;
-        i++;
-      }
-      else {
-        prepared_dictflags_pos |= truncflag;          
-      }
+        for (; i<DICT_WORD_SIZE; i++) {
+            prepared_sort[4*i]   = 0;
+            prepared_sort[4*i+1] = 0;
+            prepared_sort[4*i+2] = 0;
+            prepared_sort[4*i+3] = 0;
+        }
     }
-  }
 
-  if (i > DICT_WORD_SIZE)
-    compiler_error("dict word buffer overflow");
-
-  /* Right-pad with zeroes */
-  if (DICT_CHAR_SIZE == 1) {
-    for (; i<DICT_WORD_SIZE; i++)
-      prepared_sort[i] = 0;
-  }
-  else {
-    for (; i<DICT_WORD_SIZE; i++) {
-      prepared_sort[4*i]   = 0;
-      prepared_sort[4*i+1] = 0;
-      prepared_sort[4*i+2] = 0;
-      prepared_sort[4*i+3] = 0;
-    }
-  }
-
-  if (optresult) copy_sorts(optresult, prepared_sort);
+    if (optresult) copy_sorts(optresult, prepared_sort);
 }
 
 extern void dictionary_prepare(char *dword, uchar *optresult)
 {
-  if (!glulx_mode)
-    dictionary_prepare_z(dword, optresult);
-  else
-    dictionary_prepare_g(dword, optresult);
+    if (!glulx_mode)
+        dictionary_prepare_z(dword, optresult);
+    else
+        dictionary_prepare_g(dword, optresult);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/veneer.c
+++ b/veneer.c
@@ -30,7 +30,7 @@ extern void compile_initial_routine(void)
         In order not to impose these restrictions on "Main", we compile a
         trivial routine consisting of a call to "Main" followed by "quit".   */
 
-  int32 j;
+    int32 j;
     assembly_operand AO;
 
     j = symbol_index("Main__", -1, NULL);
@@ -2262,129 +2262,129 @@ static void compile_symbol_table_routine(void)
     symbols[j].flags |= SYSTEM_SFLAG + USED_SFLAG;
     if (trace_fns_setting==3) symbols[j].flags |= STAR_SFLAG;
 
-  if (!glulx_mode) {
+    if (!glulx_mode) {
 
-    if (define_INFIX_switch == FALSE)
-    {   assemblez_0(rfalse_zc);
-        variables[1].usage = TRUE;
-        variables[2].usage = TRUE;
-        assemble_routine_end(FALSE, null_debug_locations);
-        veneer_mode = FALSE;
-        return;
-    }
-
-    INITAOTV(&AO, VARIABLE_OT, 1);
-    INITAOT(&AO2, SHORT_CONSTANT_OT);
-    INITAOT(&AO3, LONG_CONSTANT_OT);
-
-    arrays_l = next_label++;
-    routines_l = next_label++;
-    constants_l = next_label++;
-
-    sequence_point_follows = FALSE;
-    AO2.value = 1;
-    assemblez_2_branch(je_zc, AO, AO2, arrays_l, TRUE);
-    sequence_point_follows = FALSE;
-    AO2.value = 2;
-    assemblez_2_branch(je_zc, AO, AO2, routines_l, TRUE);
-    sequence_point_follows = FALSE;
-    AO2.value = 3;
-    assemblez_2_branch(je_zc, AO, AO2, constants_l, TRUE);
-    sequence_point_follows = FALSE;
-    assemblez_0(rtrue_zc);
-
-    assemble_label_no(arrays_l);
-    AO.value = 2;
-    for (j=0; j<no_arrays; j++)
-    {   {   AO2.value = j;
-            if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
-            else AO2.type = LONG_CONSTANT_OT;
-            nl = next_label++;
-            sequence_point_follows = FALSE;
-            assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
-            AO3.value = arrays[j].size;
-            AO3.marker = 0;
-            assemblez_store(temp_var2, AO3);
-            AO3.value = arrays[j].type;
-            if (symbols[arrays[j].symbol].flags & (INSF_SFLAG+SYSTEM_SFLAG))
-                AO3.value = AO3.value + 16;
-            AO3.marker = 0;
-            assemblez_store(temp_var3, AO3);
-            AO3.value = symbols[arrays[j].symbol].value;
-            AO3.marker = (!arrays[j].loc ? ARRAY_MV : STATIC_ARRAY_MV);
-            assemblez_1(ret_zc, AO3);
-            assemble_label_no(nl);
+        if (define_INFIX_switch == FALSE)
+        {   assemblez_0(rfalse_zc);
+            variables[1].usage = TRUE;
+            variables[2].usage = TRUE;
+            assemble_routine_end(FALSE, null_debug_locations);
+            veneer_mode = FALSE;
+            return;
         }
-    }
-    sequence_point_follows = FALSE;
-    assemblez_0(rtrue_zc);
-    assemble_label_no(routines_l);
-    for (j=0; j<no_named_routines; j++)
-    {   AO2.value = j;
-        if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
-        else AO2.type = LONG_CONSTANT_OT;
-        nl = next_label++;
+    
+        INITAOTV(&AO, VARIABLE_OT, 1);
+        INITAOT(&AO2, SHORT_CONSTANT_OT);
+        INITAOT(&AO3, LONG_CONSTANT_OT);
+    
+        arrays_l = next_label++;
+        routines_l = next_label++;
+        constants_l = next_label++;
+    
         sequence_point_follows = FALSE;
-        assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
-        AO3.value = 0;
-        if (symbols[named_routine_symbols[j]].flags
-            & (INSF_SFLAG+SYSTEM_SFLAG)) AO3.value = 16;
-        AO3.marker = 0;
-        assemblez_store(temp_var3, AO3);
-        AO3.value = symbols[named_routine_symbols[j]].value;
-        AO3.marker = IROUTINE_MV;
-        assemblez_1(ret_zc, AO3);
-        assemble_label_no(nl);
-    }
-    sequence_point_follows = FALSE;
-    assemblez_0(rtrue_zc);
-
-    assemble_label_no(constants_l);
-    for (j=0, no_named_constants=0; j<no_symbols; j++)
-    {   if (((symbols[j].type == OBJECT_T) || (symbols[j].type == CLASS_T)
-            || (symbols[j].type == CONSTANT_T))
-            && ((symbols[j].flags & (UNKNOWN_SFLAG+ACTION_SFLAG))==0))
-        {   AO2.value = no_named_constants++;
+        AO2.value = 1;
+        assemblez_2_branch(je_zc, AO, AO2, arrays_l, TRUE);
+        sequence_point_follows = FALSE;
+        AO2.value = 2;
+        assemblez_2_branch(je_zc, AO, AO2, routines_l, TRUE);
+        sequence_point_follows = FALSE;
+        AO2.value = 3;
+        assemblez_2_branch(je_zc, AO, AO2, constants_l, TRUE);
+        sequence_point_follows = FALSE;
+        assemblez_0(rtrue_zc);
+    
+        assemble_label_no(arrays_l);
+        AO.value = 2;
+        for (j=0; j<no_arrays; j++)
+        {   {   AO2.value = j;
+                if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
+                else AO2.type = LONG_CONSTANT_OT;
+                nl = next_label++;
+                sequence_point_follows = FALSE;
+                assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
+                AO3.value = arrays[j].size;
+                AO3.marker = 0;
+                assemblez_store(temp_var2, AO3);
+                AO3.value = arrays[j].type;
+                if (symbols[arrays[j].symbol].flags & (INSF_SFLAG+SYSTEM_SFLAG))
+                    AO3.value = AO3.value + 16;
+                AO3.marker = 0;
+                assemblez_store(temp_var3, AO3);
+                AO3.value = symbols[arrays[j].symbol].value;
+                AO3.marker = (!arrays[j].loc ? ARRAY_MV : STATIC_ARRAY_MV);
+                assemblez_1(ret_zc, AO3);
+                assemble_label_no(nl);
+            }
+        }
+        sequence_point_follows = FALSE;
+        assemblez_0(rtrue_zc);
+        assemble_label_no(routines_l);
+        for (j=0; j<no_named_routines; j++)
+        {   AO2.value = j;
             if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
             else AO2.type = LONG_CONSTANT_OT;
             nl = next_label++;
             sequence_point_follows = FALSE;
             assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
             AO3.value = 0;
-            if (symbols[j].type == OBJECT_T) AO3.value = 2;
-            if (symbols[j].type == CLASS_T) AO3.value = 1;
-            if (symbols[j].flags & (INSF_SFLAG+SYSTEM_SFLAG))
-                AO3.value = AO3.value + 16;
+            if (symbols[named_routine_symbols[j]].flags
+                & (INSF_SFLAG+SYSTEM_SFLAG)) AO3.value = 16;
             AO3.marker = 0;
             assemblez_store(temp_var3, AO3);
-            AO3.value = j;
-            AO3.marker = SYMBOL_MV;
+            AO3.value = symbols[named_routine_symbols[j]].value;
+            AO3.marker = IROUTINE_MV;
             assemblez_1(ret_zc, AO3);
             assemble_label_no(nl);
         }
-    }
-    no_named_constants = 0; AO3.marker = 0;
-
-    sequence_point_follows = FALSE;
-    assemblez_0(rfalse_zc);
-    variables[1].usage = TRUE;
-    variables[2].usage = TRUE;
-    assemble_routine_end(FALSE, null_debug_locations);
-    veneer_mode = FALSE;
-  }
-  else {
-
-    if (define_INFIX_switch == FALSE)
-    {   assembleg_1(return_gc, zero_operand);
+        sequence_point_follows = FALSE;
+        assemblez_0(rtrue_zc);
+    
+        assemble_label_no(constants_l);
+        for (j=0, no_named_constants=0; j<no_symbols; j++)
+        {   if (((symbols[j].type == OBJECT_T) || (symbols[j].type == CLASS_T)
+                || (symbols[j].type == CONSTANT_T))
+                && ((symbols[j].flags & (UNKNOWN_SFLAG+ACTION_SFLAG))==0))
+            {   AO2.value = no_named_constants++;
+                if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
+                else AO2.type = LONG_CONSTANT_OT;
+                nl = next_label++;
+                sequence_point_follows = FALSE;
+                assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
+                AO3.value = 0;
+                if (symbols[j].type == OBJECT_T) AO3.value = 2;
+                if (symbols[j].type == CLASS_T) AO3.value = 1;
+                if (symbols[j].flags & (INSF_SFLAG+SYSTEM_SFLAG))
+                    AO3.value = AO3.value + 16;
+                AO3.marker = 0;
+                assemblez_store(temp_var3, AO3);
+                AO3.value = j;
+                AO3.marker = SYMBOL_MV;
+                assemblez_1(ret_zc, AO3);
+                assemble_label_no(nl);
+            }
+        }
+        no_named_constants = 0; AO3.marker = 0;
+    
+        sequence_point_follows = FALSE;
+        assemblez_0(rfalse_zc);
         variables[1].usage = TRUE;
         variables[2].usage = TRUE;
         assemble_routine_end(FALSE, null_debug_locations);
         veneer_mode = FALSE;
-        return;
     }
-
-    error("*** Infix symbol-table routine is not yet implemented. ***");
-  }
+    else {
+    
+        if (define_INFIX_switch == FALSE)
+        {   assembleg_1(return_gc, zero_operand);
+            variables[1].usage = TRUE;
+            variables[2].usage = TRUE;
+            assemble_routine_end(FALSE, null_debug_locations);
+            veneer_mode = FALSE;
+            return;
+        }
+    
+        error("*** Infix symbol-table routine is not yet implemented. ***");
+    }
 }
 
 extern void compile_veneer(void)

--- a/verbs.c
+++ b/verbs.c
@@ -627,11 +627,11 @@ extern assembly_operand action_of_name(char *name)
     AO.value = symbols[j].value;
     AO.marker = ACTION_MV;
     if (!glulx_mode) {
-      AO.type = SHORT_CONSTANT_OT;
-      if (symbols[j].value >= 256) AO.type = LONG_CONSTANT_OT;
+        AO.type = SHORT_CONSTANT_OT;
+        if (symbols[j].value >= 256) AO.type = LONG_CONSTANT_OT;
     }
     else {
-      AO.type = CONSTANT_OT;
+        AO.type = CONSTANT_OT;
     }
     return AO;
 }

--- a/verbs.c
+++ b/verbs.c
@@ -109,27 +109,27 @@ static int English_verbs_text_size;
 /*   Arrays used by this file                                                */
 /* ------------------------------------------------------------------------- */
 
-  verbt   *Inform_verbs;  /* Allocated up to no_Inform_verbs */
-  static memory_list Inform_verbs_memlist;
-  uchar   *grammar_lines; /* Allocated to grammar_lines_top */
-  static memory_list grammar_lines_memlist;
-  int32    grammar_lines_top;
-  int      no_grammar_lines, no_grammar_tokens;
+verbt   *Inform_verbs;  /* Allocated up to no_Inform_verbs */
+static memory_list Inform_verbs_memlist;
+uchar   *grammar_lines; /* Allocated to grammar_lines_top */
+static memory_list grammar_lines_memlist;
+int32    grammar_lines_top;
+int      no_grammar_lines, no_grammar_tokens;
 
-  actioninfo *actions; /* Allocated to no_actions */
-  memory_list actions_memlist;
-  int32   *grammar_token_routine; /* Allocated to no_grammar_token_routines */
-  static memory_list grammar_token_routine_memlist;
-  actionsort *sorted_actions; /* only used if GRAMMAR_META_FLAG */
-  int no_meta_actions; /* only used if GRAMMAR_META_FLAG */
+actioninfo *actions; /* Allocated to no_actions */
+memory_list actions_memlist;
+int32   *grammar_token_routine; /* Allocated to no_grammar_token_routines */
+static memory_list grammar_token_routine_memlist;
+actionsort *sorted_actions; /* only used if GRAMMAR_META_FLAG */
+int no_meta_actions; /* only used if GRAMMAR_META_FLAG */
 
-  int32   *adjectives; /* Allocated to no_adjectives */
-  static memory_list adjectives_memlist;
+int32   *adjectives; /* Allocated to no_adjectives */
+static memory_list adjectives_memlist;
 
-  static uchar *adjective_sort_code; /* Allocated to no_adjectives*DICT_WORD_BYTES, except it's sometimes no_adjectives+1 because we can bump it tentatively */
-  static memory_list adjective_sort_code_memlist;
+static uchar *adjective_sort_code; /* Allocated to no_adjectives*DICT_WORD_BYTES, except it's sometimes no_adjectives+1 because we can bump it tentatively */
+static memory_list adjective_sort_code_memlist;
 
-  static memory_list action_symname_memlist; /* Used for temporary symbols */
+static memory_list action_symname_memlist; /* Used for temporary symbols */
 
 /* ------------------------------------------------------------------------- */
 /*   Grammar version                                                         */

--- a/verbs.c
+++ b/verbs.c
@@ -586,9 +586,9 @@ extern assembly_operand action_of_name(char *name)
     {   INITAO(&AO);
         AO.value = symbols[j].value;
         if (!glulx_mode)
-          AO.type = LONG_CONSTANT_OT;
+            AO.type = LONG_CONSTANT_OT;
         else
-          set_constant_ot(&AO);
+            set_constant_ot(&AO);
         symbols[j].flags |= USED_SFLAG;
         return AO;
     }
@@ -706,8 +706,8 @@ static int make_adjective_v1(char *English_word)
     dictionary_prepare(English_word, new_sort_code);
     for (i=0; i<no_adjectives; i++)
         if (compare_sorts(new_sort_code,
-          adjective_sort_code+i*DICT_WORD_BYTES) == 0)
-            return(0xff-i);
+            adjective_sort_code+i*DICT_WORD_BYTES) == 0)
+                return(0xff-i);
     adjectives[no_adjectives]
         = dictionary_add(English_word,PREP_DFLAG,0,0xff-no_adjectives);
     return(0xff-no_adjectives++);


### PR DESCRIPTION
When I wrote the original Glulx back-end code for Inform, my editor was set to two-space indentation. As a result, indentation in the source code is wildly inconsistent. It's been a low-level editing headache for decades.

This PR adjusts all the two-space indentation to four-space.

I did _not_ just go through and hammer "reindent" across every source file. For one thing, Emacs indent mode doesn't play well with Graham's idiosyncratic brace style. Also there's a lot of lines that *aren't* indented in four-space increments -- generally multiline expressions or argument lists. I didn't try to change those. I just fixed the functions that _I_ wrote in two-space style.

This PR only touches whitespace. `git diff master HEAD -bw` should print nothing at all.

(With greater indentation, some source lines are now > 80 chars that weren't before. This is a bit ugly, but I'd rather put in a simple PR now and fix word-wrap later.)

(I've been meaning to do this for a while. Now that the options change is in, I have no pending PRs that will clash with wholesale reindentation.) (The https://github.com/DavidKinder/Inform6/pull/330 PR does not clash with this one.)

