### PR TITLE
Safety check for missing label

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -2188,10 +2188,17 @@ static void transfer_routine_z(void)
         }
         else if (zcode_markers[i] == LABEL_MV)
         {
+            int32 label_offset;
             if (asm_trace_level >= 4)
                 printf("Jump detected at offset %04x\n", pc);
             j = (256*zcode_holding_area[i] + zcode_holding_area[i+1]) & 0x7fff;
-            opcode_at_label = zcode_holding_area[i + labels[j].offset - pc];
+            label_offset = i + labels[j].offset - pc;
+            if (label_offset < 0 || label_offset >= zcode_ha_size) {
+                /* Probably the label was never defined. We'll report
+                   that error later. */
+                continue;
+            }
+            opcode_at_label = zcode_holding_area[label_offset];
             if (asm_trace_level >= 4)
                 printf("...To label %d, which is %d from here\n",
                     j, labels[j].offset-pc);


### PR DESCRIPTION
The optimization code in transfer_routine_z() could read outside allocated memory if it encountered an undefined label.

Fixes https://github.com/DavidKinder/Inform6/issues/334 .
