### PR TITLE
Constant for adjusting GRAMMAR_META_FLAG

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -189,10 +189,12 @@ extern int parse_given_directive(int internal_flag)
 
         AO = parse_expression(CONSTANT_CONTEXT);
             
-        if (i == grammar_version_symbol) {
-            /* Special case for changing Grammar__Version. We check
-               conditions carefully before applying the change. */
-            int ok = set_grammar_option_constant(OPT_GRAMMAR_VERSION, AO);
+        if (i == grammar_version_symbol || i == grammar_meta_value_symbol) {
+            /* Special case for changing Grammar__Version or
+               Grammar_Meta__Value. We check conditions carefully before
+               applying the change. */
+            optionindex_e optnum = (i == grammar_version_symbol ? OPT_GRAMMAR_VERSION : OPT_GRAMMAR_META_FLAG);
+            int ok = set_grammar_option_constant(optnum, AO);
             if (!ok) {
                 /* Revert to the previous value. This is a bit hacky,
                    in that we've lost the symbol marker and type --

--- a/directs.c
+++ b/directs.c
@@ -198,7 +198,7 @@ extern int parse_given_directive(int internal_flag)
             if (i == grammar_version_symbol) {
                 /* Special case for changing Grammar__Version. We check
                    conditions carefully before applying the change. */
-                set_grammar_option_constant(i, AO);
+                set_grammar_option_constant(OPT_GRAMMAR_VERSION, AO);
             }
         }
 

--- a/header.h
+++ b/header.h
@@ -594,10 +594,14 @@
     ((ptr)[0] = (uchar)(((int32)(val)) >> 8),           \
      (ptr)[1] = (uchar)(((int32)(val))     ) )
 
-/* Precedence for compiler options (see set_compiler_option()) */
+/* Precedence for compiler options (see set_compiler_option()).
+   Only a couple of options (GRAMMAR_VERSION, GRAMMAR_META_FLAG) can
+   be set at SRCCODE level.
+*/
 #define DEFAULT_OPTPREC (0)   /* original default value */
-#define HEADCOM_OPTPREC (1)   /* header comment line */
-#define CMDLINE_OPTPREC (2)   /* command-line option */
+#define SRCCODE_OPTPREC (1)   /* source code constant */
+#define HEADCOM_OPTPREC (2)   /* header comment line */
+#define CMDLINE_OPTPREC (3)   /* command-line option */
 
 /* ------------------------------------------------------------------------- */
 /*   If your compiler doesn't recognise \t, and you use ASCII, you could     */

--- a/header.h
+++ b/header.h
@@ -610,7 +610,7 @@
    or really systematic at all; it was the order of the $LIST in the old
    options system.
 */
-enum optionindex {
+typedef enum optionindex {
     OPT_MAX_ABBREVS               = 0,
     OPT_NUM_ATTR_BYTES            = 1,
     OPT_DICT_WORD_SIZE            = 2,
@@ -639,7 +639,7 @@ enum optionindex {
     OPT_LONG_DICT_FLAG_BUG        = 25,
     OPT_SERIAL                    = 26,
     OPT_OPTIONS_COUNT             = 27, /* terminator */
-};
+} optionindex_e;
 
 /* ------------------------------------------------------------------------- */
 /*   If your compiler doesn't recognise \t, and you use ASCII, you could     */
@@ -2746,7 +2746,8 @@ extern void set_compiler_option(char *str, char *sval, int prec);
 extern void list_compiler_options(void);
 extern void explain_compiler_option(char *str);
 extern void apply_compiler_options(void);
-extern int32 get_grammar_version_option(void);
+extern int32 get_current_option_value(optionindex_e val);
+extern int get_current_option_precedence(optionindex_e val);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "symbols"                                        */

--- a/header.h
+++ b/header.h
@@ -2746,8 +2746,8 @@ extern void set_compiler_option(char *str, char *sval, int prec);
 extern void list_compiler_options(void);
 extern void explain_compiler_option(char *str);
 extern void apply_compiler_options(void);
-extern int32 get_current_option_value(optionindex_e val);
-extern int get_current_option_precedence(optionindex_e val);
+extern int32 get_current_option_value(optionindex_e optnum);
+extern int set_current_option_precedence(optionindex_e optnum, int32 val);
 
 /* ------------------------------------------------------------------------- */
 /*   Extern definitions for "symbols"                                        */

--- a/header.h
+++ b/header.h
@@ -2971,7 +2971,7 @@ extern int32 *grammar_token_routine,
              *adjectives;
 
 extern void set_grammar_version(int val);
-extern void set_grammar_option_constant(int optnum, assembly_operand AO);
+extern int set_grammar_option_constant(int optnum, assembly_operand AO);
 extern void find_the_actions(void);
 extern int lowest_fake_action(void);
 extern void make_fake_action(void);

--- a/header.h
+++ b/header.h
@@ -603,6 +603,44 @@
 #define HEADCOM_OPTPREC (2)   /* header comment line */
 #define CMDLINE_OPTPREC (3)   /* command-line option */
 
+/* Enum for referring to individual options. This doesn't include obsolete
+   options, because we never have to refer to those.
+   
+   Must match the order of alloptions[] in options.c. It's not alphabetical
+   or really systematic at all; it was the order of the $LIST in the old
+   options system.
+*/
+enum optionindex {
+    OPT_MAX_ABBREVS               = 0,
+    OPT_NUM_ATTR_BYTES            = 1,
+    OPT_DICT_WORD_SIZE            = 2,
+    OPT_DICT_CHAR_SIZE            = 3,
+    OPT_GRAMMAR_VERSION           = 4,
+    OPT_GRAMMAR_META_FLAG         = 5,
+    OPT_MAX_DYNAMIC_STRINGS       = 6,
+    OPT_HASH_TAB_SIZE             = 7,
+    OPT_ZCODE_HEADER_EXT_WORDS    = 8,
+    OPT_ZCODE_HEADER_FLAGS_3      = 9,
+    OPT_ZCODE_FILE_END_PADDING    = 10,
+    OPT_ZCODE_LESS_DICT_DATA      = 11,
+    OPT_ZCODE_MAX_INLINE_STRING   = 12,
+    OPT_ZCODE_COMPACT_GLOBALS     = 13,
+    OPT_INDIV_PROP_START          = 14,
+    OPT_MEMORY_MAP_EXTENSION      = 15,
+    OPT_GLULX_OBJECT_EXT_BYTES    = 16,
+    OPT_MAX_STACK_SIZE            = 17,
+    OPT_TRANSCRIPT_FORMAT         = 18,
+    OPT_WARN_UNUSED_ROUTINES      = 19,
+    OPT_OMIT_UNUSED_ROUTINES      = 20,
+    OPT_STRIP_UNREACHABLE_LABELS  = 21,
+    OPT_OMIT_SYMBOL_TABLE         = 22,
+    OPT_DICT_IMPLICIT_SINGULAR    = 23,
+    OPT_DICT_TRUNCATE_FLAG        = 24,
+    OPT_LONG_DICT_FLAG_BUG        = 25,
+    OPT_SERIAL                    = 26,
+    OPT_OPTIONS_COUNT             = 27, /* terminator */
+};
+
 /* ------------------------------------------------------------------------- */
 /*   If your compiler doesn't recognise \t, and you use ASCII, you could     */
 /*   define T_C as (char) 9; failing that, it _must_ be defined as ' '       */

--- a/header.h
+++ b/header.h
@@ -2959,7 +2959,7 @@ extern void compile_veneer(void);
 extern int no_adjectives, no_Inform_verbs, no_grammar_token_routines,
            no_fake_actions, no_actions, no_grammar_lines, no_grammar_tokens,
            grammar_version_number;
-extern int32 grammar_version_symbol;
+extern int32 grammar_version_symbol, grammar_meta_value_symbol;
 extern verbt *Inform_verbs;
 extern uchar *grammar_lines;
 extern int32 grammar_lines_top;

--- a/options.c
+++ b/options.c
@@ -868,9 +868,9 @@ extern int set_current_option_precedence(optionindex_e optnum, int32 val)
 
     alloptions[optnum].precedence = SRCCODE_OPTPREC;
     if (!glulx_mode)
-        alloptions[optnum].val.g = val;
-    else
         alloptions[optnum].val.z = val;
+    else
+        alloptions[optnum].val.g = val;
     
     return TRUE;
 }

--- a/options.c
+++ b/options.c
@@ -849,13 +849,29 @@ extern void apply_compiler_options(void)
     }
 }
 
-extern int32 get_current_option_value(optionindex_e val)
+/* Fetch an option value. This is only needed for a couple of options
+   which are not fixed until late in compilation.
+*/
+extern int32 get_current_option_value(optionindex_e optnum)
 {
-    return SELECTVAL(val);
+    return SELECTVAL(optnum);
 }
 
-extern int get_current_option_precedence(optionindex_e val)
+/* Set an option late in compilation.
+   If this returns false, the option has already been set with higher
+   precedence and should not change.
+*/
+extern int set_current_option_precedence(optionindex_e optnum, int32 val)
 {
-    return alloptions[val].precedence;
+    if (alloptions[optnum].precedence > SRCCODE_OPTPREC)
+        return FALSE;
+
+    alloptions[optnum].precedence = SRCCODE_OPTPREC;
+    if (!glulx_mode)
+        alloptions[optnum].val.g = val;
+    else
+        alloptions[optnum].val.z = val;
+    
+    return TRUE;
 }
 

--- a/options.c
+++ b/options.c
@@ -66,42 +66,6 @@ typedef struct optiont_s {
     int precedence;
 } optiont;
 
-/* Enum for referring to individual options. This doesn't include obsolete
-   options, because we never have to refer to those.
-   
-   Must match the order of alloptions[], which is the order of the $LIST
-   in the old options system, which was not very systematic. */
-enum optionindex {
-    OPT_MAX_ABBREVS               = 0,
-    OPT_NUM_ATTR_BYTES            = 1,
-    OPT_DICT_WORD_SIZE            = 2,
-    OPT_DICT_CHAR_SIZE            = 3,
-    OPT_GRAMMAR_VERSION           = 4,
-    OPT_GRAMMAR_META_FLAG         = 5,
-    OPT_MAX_DYNAMIC_STRINGS       = 6,
-    OPT_HASH_TAB_SIZE             = 7,
-    OPT_ZCODE_HEADER_EXT_WORDS    = 8,
-    OPT_ZCODE_HEADER_FLAGS_3      = 9,
-    OPT_ZCODE_FILE_END_PADDING    = 10,
-    OPT_ZCODE_LESS_DICT_DATA      = 11,
-    OPT_ZCODE_MAX_INLINE_STRING   = 12,
-    OPT_ZCODE_COMPACT_GLOBALS     = 13,
-    OPT_INDIV_PROP_START          = 14,
-    OPT_MEMORY_MAP_EXTENSION      = 15,
-    OPT_GLULX_OBJECT_EXT_BYTES    = 16,
-    OPT_MAX_STACK_SIZE            = 17,
-    OPT_TRANSCRIPT_FORMAT         = 18,
-    OPT_WARN_UNUSED_ROUTINES      = 19,
-    OPT_OMIT_UNUSED_ROUTINES      = 20,
-    OPT_STRIP_UNREACHABLE_LABELS  = 21,
-    OPT_OMIT_SYMBOL_TABLE         = 22,
-    OPT_DICT_IMPLICIT_SINGULAR    = 23,
-    OPT_DICT_TRUNCATE_FLAG        = 24,
-    OPT_LONG_DICT_FLAG_BUG        = 25,
-    OPT_SERIAL                    = 26,
-    OPT_OPTIONS_COUNT             = 27, /* terminator */
-};
-
 /* Our catalog of options. */
 static optiont alloptions[] = {
     {

--- a/options.c
+++ b/options.c
@@ -849,10 +849,13 @@ extern void apply_compiler_options(void)
     }
 }
 
-/* This option is handled a bit differently; we don't check the value
-   until verbs_begin_pass(). So we have an accessor for it.
-*/
-extern int32 get_grammar_version_option(void)
+extern int32 get_current_option_value(optionindex_e val)
 {
-    return SELECTVAL(OPT_GRAMMAR_VERSION);
+    return SELECTVAL(val);
 }
+
+extern int get_current_option_precedence(optionindex_e val)
+{
+    return alloptions[val].precedence;
+}
+

--- a/symbols.c
+++ b/symbols.c
@@ -890,6 +890,8 @@ static void stockup_symbols(void)
     if (OMIT_SYMBOL_TABLE)
         create_symbol("OMIT_SYMBOL_TABLE", 0, CONSTANT_T);
 
+    create_rsymbol("Grammar_Meta__Value", GRAMMAR_META_FLAG, CONSTANT_T);
+    grammar_meta_value_symbol = get_symbol_index("Grammar_Meta__Value");
     if (GRAMMAR_META_FLAG)
         create_symbol("GRAMMAR_META_FLAG", 0, CONSTANT_T);
 

--- a/verbs.c
+++ b/verbs.c
@@ -230,6 +230,7 @@ int set_grammar_option_constant(int optnum, assembly_operand AO)
         if (GRAMMAR_META_FLAG) {
             int ix = symbol_index("GRAMMAR_META_FLAG", -1, NULL);
             assign_symbol(ix, 0, CONSTANT_T);
+            symbols[ix].flags |= USED_SFLAG;
         }
         else {
             int ix = get_symbol_index("GRAMMAR_META_FLAG");

--- a/verbs.c
+++ b/verbs.c
@@ -53,6 +53,8 @@ int32 grammar_meta_value_symbol;       /* Index of "Grammar_Meta__Value"     */
 int no_actions,                        /* Number of actions made so far      */
     no_fake_actions;                   /* Number of fake actions made so far */
 
+int any_action_symbols;            /* Have we evaluated action name symbols? */
+
 /* ------------------------------------------------------------------------- */
 /*   Adjectives.  (The term "adjective" is traditional; they are mainly      */
 /*                prepositions, such as "onto".)                             */
@@ -205,6 +207,10 @@ int set_grammar_option_constant(int optnum, assembly_operand AO)
     }
     if (no_grammar_lines > 0) {
         error_fmt("Once an action has been defined it is too late to change %s", symname);
+        return FALSE;
+    }
+    if (any_action_symbols && optnum == OPT_GRAMMAR_META_FLAG) {
+        error_fmt("Once an action value has been referenced it is too late to change %s", symname);
         return FALSE;
     }
 
@@ -655,6 +661,8 @@ extern assembly_operand action_of_name(char *name)
     }
     symbols[j].flags |= USED_SFLAG;
 
+    any_action_symbols = TRUE;
+    
     INITAO(&AO);
     AO.value = symbols[j].value;
     AO.marker = ACTION_MV;
@@ -1655,6 +1663,7 @@ extern void init_verbs_vars(void)
 {
     no_fake_actions = 0;
     no_actions = 0;
+    any_action_symbols = FALSE;
     no_meta_actions = -1;
     no_grammar_lines = 0;
     no_grammar_tokens = 0;
@@ -1685,7 +1694,8 @@ extern void verbs_begin_pass(void)
     no_grammar_token_routines=0;
     no_actions=0;
 
-    no_fake_actions=0;
+    no_fake_actions = 0;
+    any_action_symbols = FALSE;
     grammar_lines_top = 0;
 
     /* Set the version requested by compiler setting (with validity check) */

--- a/verbs.c
+++ b/verbs.c
@@ -162,9 +162,10 @@ void set_grammar_version(int val)
 }
 
 /* This is called if we encounter a "Constant Grammar__Version=X" directive.
-   Check that the change is valid and safe. If so, do it.
+   Check that the change is valid and safe. If so, do it and return true.
+   Otherwise, do nothing and return false.
 */
-void set_grammar_option_constant(int optnum, assembly_operand AO)
+int set_grammar_option_constant(int optnum, assembly_operand AO)
 {
     char *symname;
     int origval;
@@ -175,30 +176,32 @@ void set_grammar_option_constant(int optnum, assembly_operand AO)
     }
     else {
         compiler_error("set_grammar_option_constant called with invalid symbol");
-        return;
+        return FALSE;
     }
 
     if (AO.marker != 0) {
         error_fmt("%s must be given an explicit constant value", symname);
-        return;
+        return FALSE;
     }
     if (!set_current_option_precedence(optnum, AO.value)) {
         /* already set with higher precedence */
-        return;
+        return FALSE;
     }
     if (origval == AO.value) {
         /* no change needed */
-        return;
+        return FALSE;
     }
     if (no_fake_actions > 0) {
         error_fmt("Once a fake action has been defined it is too late to change %s", symname);
-        return;
+        return FALSE;
     }
     if (no_grammar_lines > 0) {
         error_fmt("Once an action has been defined it is too late to change %s", symname);
-        return;
+        return FALSE;
     }
+    
     set_grammar_version(AO.value);
+    return TRUE;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/verbs.c
+++ b/verbs.c
@@ -53,7 +53,7 @@ int32 grammar_meta_value_symbol;       /* Index of "Grammar_Meta__Value"     */
 int no_actions,                        /* Number of actions made so far      */
     no_fake_actions;                   /* Number of fake actions made so far */
 
-int any_action_symbols;            /* Have we evaluated action name symbols? */
+int any_action_symbols;            /* Have we evaluated action-name symbols? */
 
 /* ------------------------------------------------------------------------- */
 /*   Adjectives.  (The term "adjective" is traditional; they are mainly      */

--- a/verbs.c
+++ b/verbs.c
@@ -182,10 +182,14 @@ void set_grammar_option_constant(int optnum, assembly_operand AO)
         error_fmt("%s must be given an explicit constant value", symname);
         return;
     }
+    if (!set_current_option_precedence(optnum, AO.value)) {
+        /* already set with higher precedence */
+        return;
+    }
     if (origval == AO.value) {
         /* no change needed */
         return;
-    }    
+    }
     if (no_fake_actions > 0) {
         error_fmt("Once a fake action has been defined it is too late to change %s", symname);
         return;

--- a/verbs.c
+++ b/verbs.c
@@ -1657,7 +1657,7 @@ extern void verbs_begin_pass(void)
     grammar_lines_top = 0;
 
     /* Set the version requested by compiler setting (with validity check) */
-    set_grammar_version(get_grammar_version_option());
+    set_grammar_version(get_current_option_value(OPT_GRAMMAR_VERSION));
 }
 
 extern void verbs_allocate_arrays(void)

--- a/verbs.c
+++ b/verbs.c
@@ -224,7 +224,6 @@ int set_grammar_option_constant(int optnum, assembly_operand AO)
             if (ix >= 0)
                 end_symbol_scope(ix, FALSE);
         }
-        printf("### Grammar_Meta__Value to %d\n", GRAMMAR_META_FLAG);
     }
     
     return TRUE;

--- a/verbs.c
+++ b/verbs.c
@@ -169,7 +169,7 @@ void set_grammar_option_constant(int optnum, assembly_operand AO)
     char *symname;
     int origval;
 
-    if (optnum == grammar_version_symbol) {
+    if (optnum == OPT_GRAMMAR_VERSION) {
         symname = "Grammar__Version";
         origval = grammar_version_number;
     }

--- a/verbs.c
+++ b/verbs.c
@@ -215,10 +215,16 @@ int set_grammar_option_constant(int optnum, assembly_operand AO)
     }
 
     if (optnum == OPT_GRAMMAR_VERSION) {
-        set_grammar_version(AO.value);
+        set_grammar_version(AO.value);   /* Rejects invalid values */
     }
     else if (optnum == OPT_GRAMMAR_META_FLAG) {
+        /* The option clips the value to max 1, but that's slightly
+           inconvenient here. We'll just reject it. */
+        if (AO.value != 0 && AO.value != 1)
+            error_fmt("%s must be 0 or 1", symname);
+        
         GRAMMAR_META_FLAG = AO.value;
+        
         /* Now we have to create or destroy the GRAMMAR_META_FLAG constant,
            as appropriate. */
         if (GRAMMAR_META_FLAG) {

--- a/verbs.c
+++ b/verbs.c
@@ -15,21 +15,24 @@
 /* The grammar version is handled in a somewhat messy way. It can be:
      1 for pre-Inform 6.06 table format
      2 for modern Inform format
+     3 for alternate more-compact format.
      
    The default is 1 for Z-code (for backwards compatibility), 2 for Glulx.
-   This can be altered by the $GRAMMAR_VERSION compiler setting, and
-   then altered again during compilation by a "Constant Grammar__Version"
-   directive. (Note double underscore.)
+   This can be altered by the $GRAMMAR_VERSION compiler setting, or during
+   compilation by a "Constant Grammar__Version" directive. (Note double
+   underscore.)
 
    Typically the library has a "Constant Grammar__Version 2;" line to
    ensure we get the modern version for both VMs.
 
-   (Note also the $GRAMMAR_META_FLAG setting, which lets us indicate
-   which actions are meta, rather than relying on dict word flags.)
+   Note also the $GRAMMAR_META_FLAG setting, which lets us indicate
+   which actions are meta, rather than relying on dict word flags.
+   This can similarly be altered by "Constant Grammar_Meta__Value 1".
  */
 int grammar_version_number;
 int32 grammar_version_symbol;          /* Index of "Grammar__Version"
                                           within symbols table               */
+int32 grammar_meta_value_symbol;       /* Index of "Grammar_Meta__Value"     */
 
 /* ------------------------------------------------------------------------- */
 /*   Actions.                                                                */


### PR DESCRIPTION
Feature https://github.com/DavidKinder/Inform6/issues/327 . You can now set (or clear) the `$GRAMMAR_META_FLAG` option in code by writing

```
Constant Grammar_Meta__Value = 0;
! ...or...
Constant Grammar_Meta__Value = 1;
```

You still *check* the option by writing 

```
#Ifdef GRAMMAR_META_FLAG;
! ...
#Endif;
```

This is awkward, but parallel to the existing `$GRAMMAR_VERSION`, which can be set in code by writing (e.g.)

```
Constant Grammar__Version = 3;
```

The intended use is the same: a library can set the grammar options in included code, so that the user doesn't have to set the option themself. PunyLib is expected to pick this up once it's released.

---

Most of our compiler options cannot be altered in mid-compile. `$GRAMMAR_VERSION` and `$GRAMMAR_META_FLAG` are exceptions because we don't need to know the grammar table format until the first `Verb` or action statement. We already had special-case code in directs.c for the `Constant` directive, checking for `Grammar__Version`. I've now extended this to handle `Grammar_Meta__Value` as well.

---

Implementation:

The `optionindex` enum has moved from options.c to header.h.

The special-case setting routine is set_grammar_option_constant() in verbs.c. This returns whether the change is permissible.

We now have a new `SRCCODE_OPTPREC` precedence level, in between `DEFAULT` and `HEADCOM`. (The `Constant` form of the option can be overridden with a header comment or command-line option.) This is a change from previous behavior, where `Constant Grammar__Version` form overrode the `$GRAMMAR_VERSION` forms. I'm pretty sure no real-world games tried to specify both, though. Grammar table format is universally left up to the library.

(If you try to do `Constant Grammar__Version` or `Constant Grammar_Meta__Value` when the command-line option has already been set, the I6 constant silently stays the same.)

