### PR TITLE
Call alloc_label() instead of just grabbing a label number

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -103,11 +103,21 @@ static memory_list labels_memlist;
 static int first_label, last_label;
 
 /* The allocation plan for labels (labels_memlist) is a bit occult.
-   The statement code in states.c will prospectively allocate a new
-   label by doing "next_label++", and then later fill in the entry
-   by calling assemble_label_no() or assemble_forward_label_no().
-   The latter step is what calls ensure. So the memlist can lag behind
-   next_label briefly.
+   The codegen in states.c, expressc.c, etc will prospectively
+   allocate a new label by doing "next_label++", and then later fill
+   in the entry by calling assemble_label_no() or
+   assemble_forward_label_no(). The latter step is what calls ensure.
+   So the memlist can lag behind next_label briefly.
+
+   Furthermore, the entries aren't necessarily filled in order. (This
+   is particularly true when you forward-branch to a label name -- its
+   number is allocated immediately, filled when you arrive at the
+   label.) So the memlist may have uninited entries anywhere until the
+   function completes. (In fact, on a "no such label" error, an entry
+   may *never* be filled.)
+
+   It would be tidier to have a "label_alloc()" function that returned
+   a clean next entry. Eh, maybe someday.
  */
 
 static int *labeluse;     /* Counters indicating how many times a given label

--- a/asm.c
+++ b/asm.c
@@ -3861,9 +3861,12 @@ extern void asm_allocate_arrays(void)
     initialise_memory_list(&labeluse_memlist,
         sizeof(int), 1000, (void**)&labeluse,
         "labeluse");
-    initialise_memory_list(&sequence_points_memlist,
-        sizeof(sequencepointinfo), 1000, (void**)&sequence_points,
-        "sequence points");
+    if (debugfile_switch)
+    {
+        initialise_memory_list(&sequence_points_memlist,
+            sizeof(sequencepointinfo), 1000, (void**)&sequence_points,
+            "sequence points");
+    }
 
     initialise_memory_list(&zcode_holding_area_memlist,
         sizeof(uchar), 2000, (void**)&zcode_holding_area,
@@ -3890,7 +3893,10 @@ extern void asm_free_arrays(void)
     deallocate_memory_list(&variables_memlist);
 
     deallocate_memory_list(&labels_memlist);
-    deallocate_memory_list(&sequence_points_memlist);
+    if (debugfile_switch)
+    {
+        deallocate_memory_list(&sequence_points_memlist);
+    }
 
     deallocate_memory_list(&zcode_holding_area_memlist);
     deallocate_memory_list(&zcode_markers_memlist);

--- a/asm.c
+++ b/asm.c
@@ -217,6 +217,19 @@ static memory_list sequence_points_memlist;
    several -- any "continue" in the loop will jump to .TopLabel.)
 */
 
+extern int alloc_label(void)
+{
+    int label = next_label++;
+
+    ensure_memory_list_available(&labels_memlist, label+1);
+    labels[label].offset = -1;
+    labels[label].symbol = -1;
+    labels[label].prev = -1;
+    labels[label].next = -1;
+
+    return label;
+}
+
 /* Set the position of the given label. The offset will be the current
    zmachine_pc, or -1 if the label is definitely unused.
 

--- a/asm.c
+++ b/asm.c
@@ -102,6 +102,14 @@ static labelinfo *labels; /* Label offsets  (i.e. zmachine_pc values).
 static memory_list labels_memlist;
 static int first_label, last_label;
 
+/* The allocation plan for labels (labels_memlist) is a bit occult.
+   The statement code in states.c will prospectively allocate a new
+   label by doing "next_label++", and then later fill in the entry
+   by calling assemble_label_no() or assemble_forward_label_no().
+   The latter step is what calls ensure. So the memlist can lag behind
+   next_label briefly.
+ */
+
 static int *labeluse;     /* Counters indicating how many times a given label
                              has been used as a branch target. */
 static memory_list labeluse_memlist;

--- a/asm.c
+++ b/asm.c
@@ -103,21 +103,12 @@ static memory_list labels_memlist;
 static int first_label, last_label;
 
 /* The allocation plan for labels (labels_memlist) is a bit occult.
-   The codegen in states.c, expressc.c, etc will prospectively
-   allocate a new label by doing "next_label++", and then later fill
-   in the entry by calling assemble_label_no() or
-   assemble_forward_label_no(). The latter step is what calls ensure.
-   So the memlist can lag behind next_label briefly.
+   The codegen in states.c, expressc.c, etc will call alloc_label(),
+   and then later fill in the entry by calling assemble_label_no() or
+   assemble_forward_label_no().
 
-   Furthermore, the entries aren't necessarily filled in order. (This
-   is particularly true when you forward-branch to a label name -- its
-   number is allocated immediately, filled when you arrive at the
-   label.) So the memlist may have uninited entries anywhere until the
-   function completes. (In fact, on a "no such label" error, an entry
-   may *never* be filled.)
-
-   It would be tidier to have a "label_alloc()" function that returned
-   a clean next entry. Eh, maybe someday.
+   Every allocated label should eventually be filled in. But if the code
+   has a "no such label" error, this will not be true.
  */
 
 static int *labeluse;     /* Counters indicating how many times a given label

--- a/asm.c
+++ b/asm.c
@@ -1069,7 +1069,7 @@ extern void assemblez_instruction(const assembly_instruction *AI)
             sequence_points[next_sequence_point].label = next_label;
             sequence_points[next_sequence_point].location =
                 statement_debug_location;
-            set_label_offset(next_label++, zmachine_pc);
+            set_label_offset(alloc_label(), zmachine_pc);
         }
         next_sequence_point++;
     }
@@ -1452,7 +1452,7 @@ extern void assembleg_instruction(const assembly_instruction *AI)
             sequence_points[next_sequence_point].label = next_label;
             sequence_points[next_sequence_point].location =
                 statement_debug_location;
-            set_label_offset(next_label++, zmachine_pc);
+            set_label_offset(alloc_label(), zmachine_pc);
         }
         next_sequence_point++;
     }
@@ -1866,8 +1866,8 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
         {   char fnt[256]; assembly_operand PV, RFA, CON, STP, SLF; int ln, ln2;
             /* TODO: fnt[256] is unsafe */
           
-            ln = next_label++;
-            ln2 = next_label++;
+            ln = alloc_label();
+            ln2 = alloc_label();
           
             if (define_INFIX_switch)
             {
@@ -2007,8 +2007,8 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
                    }
                 */
                 assembleg_store(temp_var4, zero_operand);
-                lntop = next_label++;
-                lnbottom = next_label++;
+                lntop = alloc_label();
+                lnbottom = alloc_label();
                 assemble_label_no(lntop);
                 assembleg_2_branch(jge_gc, temp_var4, AO, lnbottom); /* AO is _vararg_count */
                 assembleg_1(streamchar_gc, AO2); /* AO2 is space */

--- a/asm.c
+++ b/asm.c
@@ -1755,6 +1755,7 @@ extern int assemble_forward_label_no(int n)
 
 extern void define_symbol_label(int symbol)
 {
+    /* The symbol type should be LABEL_T. */
     int label = symbols[symbol].value;
     /* We may be creating a new label (label = next_label) or filling in
        the value of an old one. So we call ensure. */

--- a/asm.c
+++ b/asm.c
@@ -234,7 +234,8 @@ extern int alloc_label(void)
 */
 static void set_label_offset(int label, int32 offset)
 {
-    ensure_memory_list_available(&labels_memlist, label+1);
+    if (label < 0 || label >= next_label)
+        fatalerror("Called set_label_offset on unallocated label");
 
     labels[label].offset = offset;
     labels[label].symbol = -1;
@@ -1779,9 +1780,8 @@ extern void define_symbol_label(int symbol)
 {
     /* The symbol type should be LABEL_T. */
     int label = symbols[symbol].value;
-    /* We may be creating a new label (label = next_label) or filling in
-       the value of an old one. So we call ensure. */
-    ensure_memory_list_available(&labels_memlist, label+1);
+    if (label < 0 || label >= next_label)
+        fatalerror("Called define_symbol_label on unallocated label");
     labels[label].symbol = symbol;
 }
 

--- a/asm.c
+++ b/asm.c
@@ -29,7 +29,7 @@ int execution_never_reaches_here;  /* nonzero if the current PC value in the
                                       the previous instruction was a "quit"
                                       opcode and no label is set to here
                                       (see EXECSTATE flags for more) */
-int next_label,                    /* Used to count the labels created all
+static int next_label,             /* Used to count the labels created all
                                       over Inform in current routine, from 0 */
     next_sequence_point;           /* Likewise, for sequence points          */
 int no_sequence_points;            /* Total over all routines; kept for

--- a/expressc.c
+++ b/expressc.c
@@ -2154,23 +2154,25 @@ static void generate_code_from(int n, int void_flag)
                              goto IndirectFunctionCallZ;
     
                          case CHILDREN_SYSF:
-                             {  assembly_operand AO;
+                             {   assembly_operand AO;
+                                 int label, label2;
                                  AO = ET[ET[below].right].value;
                                  if (runtime_error_checking_switch)
                                      AO = check_nonzero_at_runtime(AO, -1,
                                          CHILDREN_RTE);
+                                 label = alloc_label();
+                                 label2 = alloc_label();
                                  assemblez_store(temp_var1, zero_operand);
                                  assemblez_objcode(get_child_zc,
-                                     AO, stack_pointer, next_label+1, FALSE);
-                                 assemble_label_no(next_label);
+                                     AO, stack_pointer, label2, FALSE);
+                                 assemble_label_no(label);
                                  assemblez_inc(temp_var1);
                                  assemblez_objcode(get_sibling_zc,
                                      stack_pointer, stack_pointer,
-                                     next_label, TRUE);
-                                 assemble_label_no(next_label+1);
+                                     label, TRUE);
+                                 assemble_label_no(label2);
                                  assemblez_store(temp_var2, stack_pointer);
                                  if (!void_flag) write_result_z(Result, temp_var1);
-                                 next_label += 2;
                              }
                              break;
     
@@ -2966,25 +2968,27 @@ static void generate_code_from(int n, int void_flag)
                              break;
     
                          case CHILDREN_SYSF:
-                             {  assembly_operand AO;
-                                AO = ET[ET[below].right].value;
-                                if (runtime_error_checking_switch)
-                                    AO = check_nonzero_at_runtime(AO, -1,
-                                        CHILDREN_RTE);
-                                INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
-                                assembleg_store(temp_var1, zero_operand);
-                                assembleg_3(aload_gc, AO, AO2, temp_var2);
-                                AO2.value = GOBJFIELD_SIBLING();
-                                assemble_label_no(next_label);
-                                assembleg_1_branch(jz_gc, temp_var2, next_label+1);
-                                assembleg_3(add_gc, temp_var1, one_operand, 
-                                  temp_var1);
-                                assembleg_3(aload_gc, temp_var2, AO2, temp_var2);
-                                assembleg_0_branch(jump_gc, next_label);
-                                assemble_label_no(next_label+1);
-                                next_label += 2;
-                                if (!void_flag) 
-                                  write_result_g(Result, temp_var1);
+                             {   int label, label2;
+                                 assembly_operand AO;
+                                 AO = ET[ET[below].right].value;
+                                 if (runtime_error_checking_switch)
+                                     AO = check_nonzero_at_runtime(AO, -1,
+                                         CHILDREN_RTE);
+                                 label = alloc_label();
+                                 label2 = alloc_label();
+                                 INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
+                                 assembleg_store(temp_var1, zero_operand);
+                                 assembleg_3(aload_gc, AO, AO2, temp_var2);
+                                 AO2.value = GOBJFIELD_SIBLING();
+                                 assemble_label_no(label);
+                                 assembleg_1_branch(jz_gc, temp_var2, label2);
+                                 assembleg_3(add_gc, temp_var1, one_operand, 
+                                     temp_var1);
+                                 assembleg_3(aload_gc, temp_var2, AO2, temp_var2);
+                                 assembleg_0_branch(jump_gc, label);
+                                 assemble_label_no(label2);
+                                 if (!void_flag) 
+                                     write_result_g(Result, temp_var1);
                              }
                              break;
     

--- a/expressc.c
+++ b/expressc.c
@@ -3045,7 +3045,7 @@ static void generate_code_from(int n, int void_flag)
                                  AO2.value = GOBJFIELD_SIBLING();
                                  assembleg_3(aload_gc, temp_var1, AO2, temp_var2);
                                  assembleg_2_branch(jeq_gc, temp_var3, temp_var2,
-                                     label+3);
+                                     label3);
                                  assembleg_store(temp_var1, temp_var2);
                                  assembleg_0_branch(jump_gc, label);
                                  assemble_label_no(label2);

--- a/expressc.c
+++ b/expressc.c
@@ -336,12 +336,12 @@ static void annotate_for_conditions(int n, int a, int b)
         || (operators[opnum].precedence == 3))
     {   if ((a == -1) && (b == -1))
         {   if (opnum == LOGAND_OP)
-            {   b = next_label++;
+            {   b = alloc_label();
                 ET[n].false_label = b;
                 ET[n].to_expression = TRUE;
             }
             else
-            {   a = next_label++;
+            {   a = alloc_label();
                 ET[n].true_label = a;
                 ET[n].to_expression = TRUE;
             }
@@ -351,7 +351,7 @@ static void annotate_for_conditions(int n, int a, int b)
     switch(opnum)
     {   case LOGAND_OP:
             if (b == -1)
-            {   b = next_label++;
+            {   b = alloc_label();
                 ET[n].false_label = b;
                 ET[n].label_after = b;
             }
@@ -362,7 +362,7 @@ static void annotate_for_conditions(int n, int a, int b)
             return;
         case LOGOR_OP:
             if (a == -1)
-            {   a = next_label++;
+            {   a = alloc_label();
                 ET[n].true_label = a;
                 ET[n].label_after = a;
             }
@@ -502,8 +502,8 @@ static void access_memory_z(int oc, assembly_operand AO1, assembly_operand AO2,
 
     if ((AO1.marker == ARRAY_MV || AO1.marker == STATIC_ARRAY_MV))
     {   
-        int passed_label = next_label++, failed_label = next_label++,
-            final_label = next_label++; 
+        int passed_label = alloc_label(), failed_label = alloc_label(),
+            final_label = alloc_label(); 
         /* Calculate the largest permitted array entry + 1
            Here "size_ao.value" = largest permitted entry of its own kind */
         max_ao = size_ao;
@@ -619,8 +619,8 @@ static assembly_operand check_nonzero_at_runtime_z(assembly_operand AO1,
         && (AO1.marker == 0) && (AO1.value >= 1) && (AO1.value < no_objects))
         return AO1;
 
-    passed_label = next_label++;
-    failed_label = next_label++;
+    passed_label = alloc_label();
+    failed_label = alloc_label();
     INITAOTV(&AO2, LONG_CONSTANT_OT, actual_largest_object_SC);
     AO2.marker = INCON_MV;
     INITAOTV(&AO3, SHORT_CONSTANT_OT, 5);
@@ -686,7 +686,7 @@ static assembly_operand check_nonzero_at_runtime_z(assembly_operand AO1,
                the temporary variable */
             INITAOTV(&AO2, SHORT_CONSTANT_OT, 2);
             AO3 = temp_var2; assemblez_store(AO3, AO2);
-            last_label = next_label++;
+            last_label = alloc_label();
             assemblez_jump(last_label);
             assemble_label_no(passed_label);
             assemblez_store(AO3, AO1);
@@ -726,11 +726,11 @@ static void compile_conditional_z(int oc,
     
     if (oc<200)
     {   if ((runtime_error_checking_switch) && (oc == jin_zc))
-        {   if (flag) error_label = next_label++;
+        {   if (flag) error_label = alloc_label();
             AO1 = check_nonzero_at_runtime(AO1, error_label, IN_RTE);
         }
         if ((runtime_error_checking_switch) && (oc == test_attr_zc))
-        {   if (flag) error_label = next_label++;
+        {   if (flag) error_label = alloc_label();
             AO1 = check_nonzero_at_runtime(AO1, error_label, HAS_RTE);
             switch(AO2.type)
             {   case SHORT_CONSTANT_OT:
@@ -742,7 +742,7 @@ static void compile_conditional_z(int oc,
                     }
                     /* Fall through */
                 case VARIABLE_OT:
-                {   int pa_label = next_label++, fa_label = next_label++;
+                {   int pa_label = alloc_label(), fa_label = alloc_label();
                     assembly_operand en_ao, zero_ao, max_ao;
                     assemblez_store(temp_var1, AO1);
                     if ((AO1.type == VARIABLE_OT)&&(AO1.value == 0))
@@ -759,7 +759,7 @@ static void compile_conditional_z(int oc,
                     en_ao = zero_ao; en_ao.value = 19;
                     assemblez_4(call_vn_zc, veneer_routine(RT__Err_VR),
                         en_ao, temp_var1, temp_var2);
-                    va_flag = TRUE; va_label = next_label++;
+                    va_flag = TRUE; va_label = alloc_label();
                     assemblez_jump(va_label);
                     assemble_label_no(pa_label);
                 }
@@ -1122,9 +1122,9 @@ static void access_memory_g(int oc, assembly_operand AO1, assembly_operand AO2,
             return;
         }
 
-        passed_label = next_label++; 
-        failed_label = next_label++;
-        final_label = next_label++;
+        passed_label = alloc_label(); 
+        failed_label = alloc_label();
+        final_label = alloc_label();
 
         index_ao = AO2;
         if ((AO2.type == LOCALVAR_OT)&&(AO2.value == 0))
@@ -1220,8 +1220,8 @@ static assembly_operand check_nonzero_at_runtime_g(assembly_operand AO1,
 
     pre_unreach = execution_never_reaches_here;
   
-    passed_label = next_label++;
-    failed_label = next_label++;  
+    passed_label = alloc_label();
+    failed_label = alloc_label();  
 
     if ((AO1.type == LOCALVAR_OT) && (AO1.value == 0) && (AO1.marker == 0)) {
         /* That is, if AO1 is the stack pointer */
@@ -1308,7 +1308,7 @@ static assembly_operand check_nonzero_at_runtime_g(assembly_operand AO1,
             /* Store either "Object" or the operand's value in the temporary
                variable. */
             assembleg_store(temp_var2, AO2);
-            last_label = next_label++;
+            last_label = alloc_label();
             assembleg_jump(last_label);
             assemble_label_no(passed_label);
             assembleg_store(temp_var2, AO1);
@@ -1339,7 +1339,7 @@ static void compile_conditional_g(condclass *cc,
             check_warn_symbol_type(&AO2, ATTRIBUTE_T, 0, "\"has/hasnt\" expression");
             if (runtime_error_checking_switch) {
                 if (flag) 
-                    error_label = next_label++;
+                    error_label = alloc_label();
                 AO1 = check_nonzero_at_runtime(AO1, error_label, HAS_RTE);
                 if (is_constant_ot(AO2.type) && AO2.marker == 0) {
                     if ((AO2.value < 0) || (AO2.value >= NUM_ATTR_BYTES*8)) {
@@ -1347,7 +1347,7 @@ static void compile_conditional_g(condclass *cc,
                     }
                 }
                 else {
-                    int pa_label = next_label++, fa_label = next_label++;
+                    int pa_label = alloc_label(), fa_label = alloc_label();
                     assembly_operand en_ao, max_ao;
 
                     if ((AO1.type == LOCALVAR_OT) && (AO1.value == 0)) {
@@ -1385,7 +1385,7 @@ static void compile_conditional_g(condclass *cc,
                     assembleg_3(call_gc, veneer_routine(RT__Err_VR),
                         three_operand, zero_operand);
                     va_flag = TRUE; 
-                    va_label = next_label++;
+                    va_label = alloc_label();
                     assembleg_jump(va_label);
                     assemble_label_no(pa_label);
                 }
@@ -1419,7 +1419,7 @@ static void compile_conditional_g(condclass *cc,
             check_warn_symbol_type(&AO2, OBJECT_T, CLASS_T, "\"in/notin\" expression");
             if (runtime_error_checking_switch) {
                 if (flag) 
-                    error_label = next_label++;
+                    error_label = alloc_label();
                 AO1 = check_nonzero_at_runtime(AO1, error_label, IN_RTE);
             }
             INITAO(&AO4);
@@ -1631,7 +1631,7 @@ static void generate_code_from(int n, int void_flag)
                       .branch_other                                          */
     
                 if (branch_other == -1)
-                {   branch_other = next_label++; make_branch_label = TRUE;
+                {   branch_other = alloc_label(); make_branch_label = TRUE;
                 }
             }
     
@@ -1782,7 +1782,7 @@ static void generate_code_from(int n, int void_flag)
                     .branch_other                                          */
         
                 if (branch_other == -1) {
-                    branch_other = next_label++; make_branch_label = TRUE;
+                    branch_other = alloc_label(); make_branch_label = TRUE;
                 }
             }
 
@@ -1894,7 +1894,7 @@ static void generate_code_from(int n, int void_flag)
                     {
                         assemblez_store(temp_var1, ET[below].value);
                         assemblez_store(temp_var2, by_ao);
-                        ln = next_label++;
+                        ln = alloc_label();
                         assemblez_1_branch(jz_zc, temp_var2, ln, FALSE);
                         INITAOT(&error_ao, SHORT_CONSTANT_OT);
                         error_ao.value = DBYZERO_RTE;
@@ -2520,7 +2520,7 @@ static void generate_code_from(int n, int void_flag)
                     else
                     {   assembleg_store(temp_var1, ET[below].value);
                         assembleg_store(temp_var2, by_ao);
-                        ln = next_label++;
+                        ln = alloc_label();
                         assembleg_1_branch(jnz_gc, temp_var2, ln);
                         INITAO(&error_ao);
                         error_ao.value = DBYZERO_RTE;
@@ -2916,8 +2916,8 @@ static void generate_code_from(int n, int void_flag)
                                  /* One argument, not known at compile time */
                                  int ln, ln2;
                                  assembleg_store(temp_var1, ET[ET[below].right].value);
-                                 ln = next_label++;
-                                 ln2 = next_label++;
+                                 ln = alloc_label();
+                                 ln2 = alloc_label();
                                  assembleg_2_branch(jle_gc, temp_var1, zero_operand, ln);
                                  assembleg_2(random_gc,
                                      temp_var1, stack_pointer);
@@ -3176,7 +3176,7 @@ static void generate_code_from(int n, int void_flag)
             }
             else if (ET[n].true_label != -1)
             {
-                donelabel = next_label++;
+                donelabel = alloc_label();
                 if (!execution_never_reaches_here) {
                     assemblez_1(push_zc, zero_operand);
                     assemblez_jump(donelabel);
@@ -3187,7 +3187,7 @@ static void generate_code_from(int n, int void_flag)
             }
             else
             {
-                donelabel = next_label++;
+                donelabel = alloc_label();
                 if (!execution_never_reaches_here) {
                     assemblez_1(push_zc, one_operand);
                     assemblez_jump(donelabel);
@@ -3217,7 +3217,7 @@ static void generate_code_from(int n, int void_flag)
             }
             else if (ET[n].true_label != -1)
             {
-                donelabel = next_label++;
+                donelabel = alloc_label();
                 if (!execution_never_reaches_here) {
                     assembleg_store(stack_pointer, zero_operand);
                     assembleg_jump(donelabel);
@@ -3228,7 +3228,7 @@ static void generate_code_from(int n, int void_flag)
             }
             else
             {
-                donelabel = next_label++;
+                donelabel = alloc_label();
                 if (!execution_never_reaches_here) {
                     assembleg_store(stack_pointer, one_operand);
                     assembleg_jump(donelabel);

--- a/expressc.c
+++ b/expressc.c
@@ -2178,20 +2178,22 @@ static void generate_code_from(int n, int void_flag)
     
                          case YOUNGEST_SYSF:
                              {   assembly_operand AO;
+                                 int label, label2;
                                  AO = ET[ET[below].right].value;
                                  if (runtime_error_checking_switch)
                                      AO = check_nonzero_at_runtime(AO, -1,
                                          YOUNGEST_RTE);
+                                 label = alloc_label();
+                                 label2 = alloc_label();
                                  assemblez_objcode(get_child_zc,
-                                     AO, temp_var1, next_label+1, FALSE);
+                                     AO, temp_var1, label2, FALSE);
                                  assemblez_1(push_zc, temp_var1);
-                                 assemble_label_no(next_label);
+                                 assemble_label_no(label);
                                  assemblez_store(temp_var1, stack_pointer);
                                  assemblez_objcode(get_sibling_zc,
-                                     temp_var1, stack_pointer, next_label, TRUE);
-                                 assemble_label_no(next_label+1);
+                                     temp_var1, stack_pointer, label, TRUE);
+                                 assemble_label_no(label2);
                                  if (!void_flag) write_result_z(Result, temp_var1);
-                                 next_label += 2;
                              }
                              break;
     
@@ -3008,23 +3010,26 @@ static void generate_code_from(int n, int void_flag)
                              break;
     
                          case YOUNGEST_SYSF:
-                             AO = ET[ET[below].right].value;
-                             if (runtime_error_checking_switch)
-                                 AO = check_nonzero_at_runtime(AO, -1,
-                                     YOUNGEST_RTE);
-                             INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
-                             assembleg_3(aload_gc, AO, AO2, temp_var1);
-                             AO2.value = GOBJFIELD_SIBLING();
-                             assembleg_1_branch(jz_gc, temp_var1, next_label+1);
-                             assemble_label_no(next_label);
-                             assembleg_3(aload_gc, temp_var1, AO2, temp_var2);
-                             assembleg_1_branch(jz_gc, temp_var2, next_label+1);
-                             assembleg_store(temp_var1, temp_var2);
-                             assembleg_0_branch(jump_gc, next_label);
-                             assemble_label_no(next_label+1);
-                             if (!void_flag) 
-                               write_result_g(Result, temp_var1);
-                             next_label += 2;
+                             {   int label, label2;
+                                 AO = ET[ET[below].right].value;
+                                 if (runtime_error_checking_switch)
+                                     AO = check_nonzero_at_runtime(AO, -1,
+                                         YOUNGEST_RTE);
+                                 label = alloc_label();
+                                 label2 = alloc_label();
+                                 INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_CHILD());
+                                 assembleg_3(aload_gc, AO, AO2, temp_var1);
+                                 AO2.value = GOBJFIELD_SIBLING();
+                                 assembleg_1_branch(jz_gc, temp_var1, label2);
+                                 assemble_label_no(label);
+                                 assembleg_3(aload_gc, temp_var1, AO2, temp_var2);
+                                 assembleg_1_branch(jz_gc, temp_var2, label2);
+                                 assembleg_store(temp_var1, temp_var2);
+                                 assembleg_0_branch(jump_gc, label);
+                                 assemble_label_no(label2);
+                                 if (!void_flag) 
+                                     write_result_g(Result, temp_var1);
+                             }
                              break;
     
                          case ELDER_SYSF:

--- a/header.h
+++ b/header.h
@@ -2242,6 +2242,7 @@ extern void assemble_label_no(int n);
 extern int assemble_forward_label_no(int n);
 extern void assemble_jump(int n);
 extern void define_symbol_label(int symbol);
+extern int alloc_label(void);
 extern int32 assemble_routine_header(int debug_flag,
     char *name, int embedded_flag, int the_symbol);
 extern void assemble_routine_end(int embedded_flag, debug_locations locations);

--- a/header.h
+++ b/header.h
@@ -2225,7 +2225,7 @@ extern debug_location statement_debug_location;
 extern int   execution_never_reaches_here;
 extern variableinfo *variables;
 extern memory_list variables_memlist;
-extern int   next_label, no_sequence_points;
+extern int   no_sequence_points;
 extern assembly_instruction AI;
 extern int32 *named_routine_symbols;
 

--- a/states.c
+++ b/states.c
@@ -256,9 +256,9 @@ extern int parse_label(void)
     }
 
     if ((token_type == SYMBOL_TT) && (symbols[token_value].flags & UNKNOWN_SFLAG))
-    {   assign_symbol(token_value, next_label, LABEL_T);
+    {   int label = alloc_label();
+        assign_symbol(token_value, label, LABEL_T);
         define_symbol_label(token_value);
-        next_label++;
         symbols[token_value].flags |= CHANGE_SFLAG + USED_SFLAG;
         return(symbols[token_value].value);
     }
@@ -752,11 +752,11 @@ static int parse_named_label_statements()
         }
 
         if (symbols[token_value].flags & UNKNOWN_SFLAG)
-        {   assign_symbol(token_value, next_label, LABEL_T);
+        {   int label = alloc_label();
+            assign_symbol(token_value, label, LABEL_T);
             symbols[token_value].flags |= USED_SFLAG;
-            assemble_label_no(next_label);
+            assemble_label_no(label);
             define_symbol_label(token_value);
-            next_label++;
         }
         else
         {   if (symbols[token_value].type != LABEL_T) {
@@ -1432,13 +1432,14 @@ static void parse_statement_z(int break_label, int continue_label)
                              && ((AO4.type != VARIABLE_OT)
                                  ||(AO4.value != AO.value)))
                          {   assembly_operand en_ao;
+                             int label = alloc_label();
                              INITAOTV(&en_ao, SHORT_CONSTANT_OT, OBJECTLOOP_BROKEN_RTE);
                              assemblez_2_branch(jin_zc, AO, AO4,
-                                 next_label, TRUE);
+                                 label, TRUE);
                              assemblez_3(call_vn_zc, veneer_routine(RT__Err_VR),
                                  en_ao, AO);
                              assemblez_jump(ln2);
-                             assemble_label_no(next_label++);
+                             assemble_label_no(label);
                          }
                      }
                      else AO2 = AO;
@@ -2449,17 +2450,18 @@ static void parse_statement_g(int break_label, int continue_label)
                              && ((AO5.type != LOCALVAR_OT)||(AO5.value != 0))
                              && ((AO5.type != LOCALVAR_OT)||(AO5.value != AO.value)))
                          {   assembly_operand en_ao;
+                             int label = alloc_label();
                              INITAO(&en_ao);
                              en_ao.value = OBJECTLOOP_BROKEN_RTE;
                              set_constant_ot(&en_ao);
                              INITAOTV(&AO4, BYTECONSTANT_OT, GOBJFIELD_PARENT());
                              assembleg_3(aload_gc, AO, AO4, stack_pointer);
                              assembleg_2_branch(jeq_gc, stack_pointer, AO5, 
-                                 next_label);
+                                 label);
                              assembleg_call_2(veneer_routine(RT__Err_VR),
                                  en_ao, AO, zero_operand);
                              assembleg_jump(ln2);
-                             assemble_label_no(next_label++);
+                             assemble_label_no(label);
                          }
                      }
                      else {

--- a/states.c
+++ b/states.c
@@ -1431,8 +1431,8 @@ static void parse_statement_z(int break_label, int continue_label)
                              && ((AO4.type != VARIABLE_OT)||(AO4.value != 0))
                              && ((AO4.type != VARIABLE_OT)
                                  ||(AO4.value != AO.value)))
-                         {   assembly_operand en_ao;
-                             int label = alloc_label();
+                         {   int label = alloc_label();
+                             assembly_operand en_ao;
                              INITAOTV(&en_ao, SHORT_CONSTANT_OT, OBJECTLOOP_BROKEN_RTE);
                              assemblez_2_branch(jin_zc, AO, AO4,
                                  label, TRUE);
@@ -2449,8 +2449,8 @@ static void parse_statement_g(int break_label, int continue_label)
                          if ((ln == 3)
                              && ((AO5.type != LOCALVAR_OT)||(AO5.value != 0))
                              && ((AO5.type != LOCALVAR_OT)||(AO5.value != AO.value)))
-                         {   assembly_operand en_ao;
-                             int label = alloc_label();
+                         {   int label = alloc_label();
+                             assembly_operand en_ao;
                              INITAO(&en_ao);
                              en_ao.value = OBJECTLOOP_BROKEN_RTE;
                              set_constant_ot(&en_ao);

--- a/states.c
+++ b/states.c
@@ -914,8 +914,8 @@ static void parse_statement_z(int break_label, int continue_label)
     /*  -------------------------------------------------------------------- */
 
         case DO_CODE:
-                 assemble_label_no(ln = next_label++);
-                 ln2 = next_label++; ln3 = next_label++;
+                 assemble_label_no(ln = alloc_label());
+                 ln2 = alloc_label(); ln3 = alloc_label();
                  parse_code_block(ln3, ln2, 0);
                  statements.enabled = TRUE;
                  get_next_token();
@@ -1011,8 +1011,8 @@ static void parse_statement_z(int break_label, int continue_label)
                      if ((token_type==SEP_TT)&&(token_value == SUPERCLASS_SEP))
                      {   get_next_token();
                          if ((token_type==SEP_TT)&&(token_value == CLOSEB_SEP))
-                         {   assemble_label_no(ln = next_label++);
-                             ln2 = next_label++;
+                         {   assemble_label_no(ln = alloc_label());
+                             ln2 = alloc_label();
                              parse_code_block(ln2, ln, 0);
                              sequence_point_follows = FALSE;
                              if (!execution_never_reaches_here)
@@ -1044,9 +1044,9 @@ static void parse_statement_z(int break_label, int continue_label)
                      flag = test_for_incdec(AO2);
                  }
 
-                 ln = next_label++;
-                 ln2 = next_label++;
-                 ln3 = next_label++;
+                 ln = alloc_label();
+                 ln2 = alloc_label();
+                 ln3 = alloc_label();
 
                  if ((AO2.type == OMITTED_OT) || (flag != 0))
                  {
@@ -1188,7 +1188,7 @@ static void parse_statement_z(int break_label, int continue_label)
                      ln = -3;
                  else
                  {   put_token_back();
-                     ln = next_label++;
+                     ln = alloc_label();
                  }
 
                  /* The condition */
@@ -1225,7 +1225,7 @@ static void parse_statement_z(int break_label, int continue_label)
                  if ((token_type == STATEMENT_TT) && (token_value == ELSE_CODE))
                  {   flag = TRUE;
                      if (ln >= 0)
-                     {   ln2 = next_label++;
+                     {   ln2 = alloc_label();
                          if (!execution_never_reaches_here)
                          {   sequence_point_follows = FALSE;
                              assemblez_jump(ln2);
@@ -1419,9 +1419,9 @@ static void parse_statement_z(int break_label, int continue_label)
                          AO2 = AO3;
                      }
                      assemblez_store(AO, AO2);
-                     assemblez_1_branch(jz_zc, AO, ln2 = next_label++, TRUE);
-                     assemble_label_no(ln4 = next_label++);
-                     parse_code_block(ln2, ln3 = next_label++, 0);
+                     assemblez_1_branch(jz_zc, AO, ln2 = alloc_label(), TRUE);
+                     assemble_label_no(ln4 = alloc_label());
+                     parse_code_block(ln2, ln3 = alloc_label(), 0);
                      sequence_point_follows = FALSE;
                      assemble_label_no(ln3);
                      if (runtime_error_checking_switch)
@@ -1452,9 +1452,9 @@ static void parse_statement_z(int break_label, int continue_label)
                  INITAOTV(&AO2, SHORT_CONSTANT_OT, 1);
                  assemblez_store(AO, AO2);
 
-                 assemble_label_no(ln = next_label++);
-                 ln2 = next_label++;
-                 ln3 = next_label++;
+                 assemble_label_no(ln = alloc_label());
+                 ln2 = alloc_label();
+                 ln3 = alloc_label();
                  if (flag)
                  {   put_token_back();
                      put_token_back();
@@ -1635,8 +1635,8 @@ static void parse_statement_z(int break_label, int continue_label)
                  INITAOTV(&AO, SHORT_CONSTANT_OT, 32);
                  INITAOTV(&AO3, SHORT_CONSTANT_OT, 1);
 
-                 assemblez_2_branch(jl_zc, AO2, AO3, ln = next_label++, TRUE);
-                 assemble_label_no(ln2 = next_label++);
+                 assemblez_2_branch(jl_zc, AO2, AO3, ln = alloc_label(), TRUE);
+                 assemble_label_no(ln2 = alloc_label());
                  assemblez_1(print_char_zc, AO);
                  assemblez_dec(AO2);
                  assemblez_1_branch(jz_zc, AO2, ln2, FALSE);
@@ -1725,7 +1725,7 @@ static void parse_statement_z(int break_label, int continue_label)
                  INITAOTV(&AO2, VARIABLE_OT, globalv_z_temp_var1);
                  assemblez_store(AO2, AO);
 
-                 parse_code_block(ln = next_label++, continue_label, 1);
+                 parse_code_block(ln = alloc_label(), continue_label, 1);
                  assemble_forward_label_no(ln);
                  return;
 
@@ -1734,11 +1734,11 @@ static void parse_statement_z(int break_label, int continue_label)
     /*  -------------------------------------------------------------------- */
 
         case WHILE_CODE:
-                 assemble_label_no(ln = next_label++);
+                 assemble_label_no(ln = alloc_label());
                  match_open_bracket();
 
                  code_generate(parse_expression(CONDITION_CONTEXT),
-                     CONDITION_CONTEXT, ln2 = next_label++);
+                     CONDITION_CONTEXT, ln2 = alloc_label());
                  match_close_bracket();
 
                  parse_code_block(ln2, ln, 0);
@@ -1883,8 +1883,8 @@ static void parse_statement_g(int break_label, int continue_label)
     /*  -------------------------------------------------------------------- */
 
         case DO_CODE:
-                 assemble_label_no(ln = next_label++);
-                 ln2 = next_label++; ln3 = next_label++;
+                 assemble_label_no(ln = alloc_label());
+                 ln2 = alloc_label(); ln3 = alloc_label();
                  parse_code_block(ln3, ln2, 0);
                  statements.enabled = TRUE;
                  get_next_token();
@@ -1962,8 +1962,8 @@ static void parse_statement_g(int break_label, int continue_label)
                      if ((token_type==SEP_TT)&&(token_value == SUPERCLASS_SEP))
                      {   get_next_token();
                          if ((token_type==SEP_TT)&&(token_value == CLOSEB_SEP))
-                         {   assemble_label_no(ln = next_label++);
-                             ln2 = next_label++;
+                         {   assemble_label_no(ln = alloc_label());
+                             ln2 = alloc_label();
                              parse_code_block(ln2, ln, 0);
                              sequence_point_follows = FALSE;
                              if (!execution_never_reaches_here)
@@ -1995,9 +1995,9 @@ static void parse_statement_g(int break_label, int continue_label)
                      flag = test_for_incdec(AO2);
                  }
 
-                 ln = next_label++;
-                 ln2 = next_label++;
-                 ln3 = next_label++;
+                 ln = alloc_label();
+                 ln2 = alloc_label();
+                 ln3 = alloc_label();
 
                  if ((AO2.type == OMITTED_OT) || (flag != 0))
                  {
@@ -2178,7 +2178,7 @@ static void parse_statement_g(int break_label, int continue_label)
                      ln = -3;
                  else
                  {   put_token_back();
-                     ln = next_label++;
+                     ln = alloc_label();
                  }
 
                  /* The condition */
@@ -2215,7 +2215,7 @@ static void parse_statement_g(int break_label, int continue_label)
                  if ((token_type == STATEMENT_TT) && (token_value == ELSE_CODE))
                  {   flag = TRUE;
                      if (ln >= 0)
-                     {   ln2 = next_label++;
+                     {   ln2 = alloc_label();
                          if (!execution_never_reaches_here)
                          {   sequence_point_follows = FALSE;
                              assembleg_jump(ln2);
@@ -2438,9 +2438,9 @@ static void parse_statement_g(int break_label, int continue_label)
                          /* do nothing */
                      }
                      assembleg_store(AO, AO2);
-                     assembleg_1_branch(jz_gc, AO, ln2 = next_label++);
-                     assemble_label_no(ln4 = next_label++);
-                     parse_code_block(ln2, ln3 = next_label++, 0);
+                     assembleg_1_branch(jz_gc, AO, ln2 = alloc_label());
+                     assemble_label_no(ln4 = alloc_label());
+                     parse_code_block(ln2, ln3 = alloc_label(), 0);
                      sequence_point_follows = FALSE;
                      assemble_label_no(ln3);
                      if (runtime_error_checking_switch) {
@@ -2487,9 +2487,9 @@ static void parse_statement_g(int break_label, int continue_label)
                  }
                  assembleg_store(AO, AO2);
 
-                 assemble_label_no(ln = next_label++);
-                 ln2 = next_label++;
-                 ln3 = next_label++;
+                 assemble_label_no(ln = alloc_label());
+                 ln2 = alloc_label();
+                 ln3 = alloc_label();
                  if (flag)
                  {   put_token_back();
                      put_token_back();
@@ -2588,8 +2588,8 @@ static void parse_statement_g(int break_label, int continue_label)
                  AO.value = 32; set_constant_ot(&AO);
 
                  assembleg_2_branch(jlt_gc, temp_var1, one_operand, 
-                     ln = next_label++);
-                 assemble_label_no(ln2 = next_label++);
+                     ln = alloc_label());
+                 assemble_label_no(ln2 = alloc_label());
                  assembleg_1(streamchar_gc, AO);
                  assembleg_dec(temp_var1);
                  assembleg_1_branch(jnz_gc, temp_var1, ln2);
@@ -2689,7 +2689,7 @@ static void parse_statement_g(int break_label, int continue_label)
 
                  assembleg_store(temp_var1, AO); 
 
-                 parse_code_block(ln = next_label++, continue_label, 1);
+                 parse_code_block(ln = alloc_label(), continue_label, 1);
                  assemble_forward_label_no(ln);
                  return;
 
@@ -2698,11 +2698,11 @@ static void parse_statement_g(int break_label, int continue_label)
     /*  -------------------------------------------------------------------- */
 
         case WHILE_CODE:
-                 assemble_label_no(ln = next_label++);
+                 assemble_label_no(ln = alloc_label());
                  match_open_bracket();
 
                  code_generate(parse_expression(CONDITION_CONTEXT),
-                     CONDITION_CONTEXT, ln2 = next_label++);
+                     CONDITION_CONTEXT, ln2 = alloc_label());
                  match_close_bracket();
 
                  parse_code_block(ln2, ln, 0);

--- a/syntax.c
+++ b/syntax.c
@@ -365,7 +365,7 @@ static void parse_switch_spec(assembly_operand switch_value, int label,
                 panic_mode_error_recovery();
                 return;
             case 1: goto GenSpecCode;
-            case 3: if (label_after == -1) label_after = next_label++;
+            case 3: if (label_after == -1) label_after = alloc_label();
         }
     } while(TRUE);
 
@@ -383,7 +383,7 @@ static void generate_switch_spec(assembly_operand switch_value, int label, int l
     sequence_point_follows = FALSE;
 
     if ((speccount > max_equality_args) && (label_after == -1))
-        label_after = next_label++;
+        label_after = alloc_label();
 
     if (label_after == -1)
     {   compile_alternatives(switch_value, speccount, 0, label, FALSE); return;
@@ -413,11 +413,12 @@ static void generate_switch_spec(assembly_operand switch_value, int label, int l
                         label, TRUE);
                 }
                 else
-                {   assemblez_2_branch(jl_zc, switch_value, spec_stack[i],
-                        next_label, TRUE);
+                {   int label = alloc_label();
+                    assemblez_2_branch(jl_zc, switch_value, spec_stack[i],
+                        label, TRUE);
                     assemblez_2_branch(jg_zc, switch_value, spec_stack[i+1],
                         label_after, FALSE);
-                    assemble_label_no(next_label++);
+                    assemble_label_no(label);
                 }
             }
             else {
@@ -428,11 +429,12 @@ static void generate_switch_spec(assembly_operand switch_value, int label, int l
                         label);
                 }
                 else
-                {   assembleg_2_branch(jlt_gc, switch_value, spec_stack[i],
-                        next_label);
+                {   int label = alloc_label();
+                    assembleg_2_branch(jlt_gc, switch_value, spec_stack[i],
+                        label);
                     assembleg_2_branch(jle_gc, switch_value, spec_stack[i+1],
                         label_after);
-                    assemble_label_no(next_label++);
+                    assemble_label_no(label);
                 }
             }
             i = i+2;
@@ -586,7 +588,7 @@ extern int32 parse_routine(char *source, int embedded_flag, char *name,
                     assemble_label_no(switch_label);
                 }
 
-                switch_label = next_label++;
+                switch_label = alloc_label();
                 switch_clause_made = TRUE;
                 put_token_back(); put_token_back();
 
@@ -742,7 +744,7 @@ extern void parse_code_block(int break_label, int continue_label,
                             assemble_label_no(switch_label);
                         }
                         
-                        switch_label = next_label++;
+                        switch_label = alloc_label();
                         switch_clause_made = TRUE;
                         
                         AO = temp_var1;
@@ -783,7 +785,7 @@ extern void parse_code_block(int break_label, int continue_label,
                         assemble_label_no(switch_label);
                     }
 
-                    switch_label = next_label++;
+                    switch_label = alloc_label();
                     switch_clause_made = TRUE;
                     put_token_back(); put_token_back();
                     if (unary_minus_flag) put_token_back();

--- a/veneer.c
+++ b/veneer.c
@@ -2277,9 +2277,9 @@ static void compile_symbol_table_routine(void)
         INITAOT(&AO2, SHORT_CONSTANT_OT);
         INITAOT(&AO3, LONG_CONSTANT_OT);
     
-        arrays_l = next_label++;
-        routines_l = next_label++;
-        constants_l = next_label++;
+        arrays_l = alloc_label();
+        routines_l = alloc_label();
+        constants_l = alloc_label();
     
         sequence_point_follows = FALSE;
         AO2.value = 1;
@@ -2299,7 +2299,7 @@ static void compile_symbol_table_routine(void)
         {   {   AO2.value = j;
                 if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
                 else AO2.type = LONG_CONSTANT_OT;
-                nl = next_label++;
+                nl = alloc_label();
                 sequence_point_follows = FALSE;
                 assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
                 AO3.value = arrays[j].size;
@@ -2323,7 +2323,7 @@ static void compile_symbol_table_routine(void)
         {   AO2.value = j;
             if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
             else AO2.type = LONG_CONSTANT_OT;
-            nl = next_label++;
+            nl = alloc_label();
             sequence_point_follows = FALSE;
             assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
             AO3.value = 0;
@@ -2347,7 +2347,7 @@ static void compile_symbol_table_routine(void)
             {   AO2.value = no_named_constants++;
                 if (AO2.value<256) AO2.type = SHORT_CONSTANT_OT;
                 else AO2.type = LONG_CONSTANT_OT;
-                nl = next_label++;
+                nl = alloc_label();
                 sequence_point_follows = FALSE;
                 assemblez_2_branch(je_zc, AO, AO2, nl, FALSE);
                 AO3.value = 0;


### PR DESCRIPTION
The handling of `labels[]` and `labels_memlist` was kind of nasty. Code all through the compiler would pick a label number by saying `label = next_label++`, then use it freely. 

This meant that assemble_label_no() and define_symbol_label() were handed arbitrary arguments, and had to call ensure_memlist to make sure the value was in bounds. The logic that every label entry was initialized before use was extremely occult. (And not even valid if a function had a "label not found" error.)

This PR restructures this. You now call `label = alloc_label()`, which ensures that the structure is valid and initialized up front. The `next_label` variable is now static.


