### PR TITLE
Eliminate unreachable return opcodes (Z-code)

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -288,8 +288,10 @@ static void mark_label_unused(int label)
     if (label < 0 || label >= next_label)
         return;
     
-    if (label >= labeluse_size || labeluse[label] == 0)
-        fatalerror("Tried to mark never-used label as less used");
+    if (label >= labeluse_size || labeluse[label] == 0) {
+        compiler_error("Tried to mark never-used label as less used");
+        return;
+    }
 
     labeluse[label] -= 1;
 }

--- a/asm.c
+++ b/asm.c
@@ -2222,7 +2222,7 @@ static void transfer_routine_z(void)
             short form) with DELETED_MV.
             We also look for jumps that can be entirely eliminated (because
             they are jumping to the very next instruction). The opcode and
-            both label bytes get DELETED_MV.
+            its operand gets DELETED_MV.
             We also look for jumps that can be eliminated because they
             are jumping to a (one-byte) return opcode. The jump opcode is
             replaced by a copy of the destination opcode; the original
@@ -2332,10 +2332,10 @@ static void transfer_routine_z(void)
 
              The tricky bit is that several labels can point to the same
              return opcode. We must check that they're *all* unused.
-             (However, we only need check never_reaches flag for the first
-             one. Later labels at the same address get marked reachable,
-             but that just means "from the previous label", not from a
-             previous real opcode.)
+             (However, we only need check the never_reaches flag for the
+             first one. Later labels at the same address get marked
+             reachable, but that just means "from the previous label", not
+             from a previous real opcode.)
     */
 
     if (last_label >= 0) {

--- a/asm.c
+++ b/asm.c
@@ -1860,7 +1860,7 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
             for (i=0; i<no_locals; i++) { byteout(0,0); byteout(0,0); }
 
         next_label = 0; next_sequence_point = 0;
-        first_label = 0; last_label = -1;
+        first_label = -1; last_label = -1;
         labeluse_size = 0;
 
         /*  Compile code to print out text like "a=3, b=4, c=5" when the     */
@@ -1948,7 +1948,7 @@ extern int32 assemble_routine_header(int routine_asterisked, char *name,
         }
 
         next_label = 0; next_sequence_point = 0;
-        first_label = 0; last_label = -1; 
+        first_label = -1; last_label = -1; 
         labeluse_size = 0;
 
         if ((routine_asterisked) || (define_INFIX_switch)) {

--- a/asm.c
+++ b/asm.c
@@ -264,6 +264,9 @@ static void set_label_offset(int label, int32 offset)
 
 /* Increase the counter indicating how many times the given label is
    jumped to.
+   Note that we may do this for labels that aren't yet allocated. That's
+   why labeluse[] is a separate array, with a separate allocation
+   count (labeluse_size).
 */
 static void mark_label_used(int label)
 {

--- a/asm.c
+++ b/asm.c
@@ -2334,8 +2334,8 @@ static void transfer_routine_z(void)
              return opcode. We must check that they're *all* unused.
              (However, we only need check never_reaches flag for the first
              one. Later labels at the same address get marked reachable,
-             but that just means "from the previous label", not from real
-             code.)
+             but that just means "from the previous label", not from a
+             previous real opcode.)
     */
 
     if (last_label >= 0) {

--- a/asm.c
+++ b/asm.c
@@ -2334,9 +2334,21 @@ static void transfer_routine_z(void)
     if (last_label >= 0)
     {   if (asm_trace_level >= 4)
         {   printf("Opening label: %d\n", first_label);
-            for (i=0;i<next_label;i++)
-                printf("Label %d offset %04x next -> %d previous -> %d\n",
-                    i, labels[i].offset, labels[i].next, labels[i].prev);
+            for (i=0;i<next_label;i++) {
+                if (labels[i].offset < 0) {
+                    printf("Label %d omitted (used=%d%s)\n",
+                        i,
+                        (i < labeluse_size ? labeluse[i] : 0),
+                        (labels[i].never_reaches ? ", jo" : ""));
+                    continue;
+                }
+                printf("Label %d offset %04x (used=%d%s) (next->%d, prev->%d)\n",
+                    i,
+                    labels[i].offset,
+                    (i < labeluse_size ? labeluse[i] : 0),
+                    (labels[i].never_reaches ? ", jo" : ""),
+                    labels[i].next, labels[i].prev);
+            }
         }
 
         /* label will advance through the linked list as pc increases. */
@@ -2585,9 +2597,21 @@ static void transfer_routine_g(void)
     if (last_label >= 0) {
         if (asm_trace_level >= 4) {
             printf("Opening label: %d\n", first_label);
-            for (i=0;i<next_label;i++)
-                printf("Label %d offset %04x next -> %d previous -> %d\n",
-                       i, labels[i].offset, labels[i].next, labels[i].prev);
+            for (i=0;i<next_label;i++) {
+                if (labels[i].offset < 0) {
+                    printf("Label %d omitted (used=%d%s)\n",
+                        i,
+                        (i < labeluse_size ? labeluse[i] : 0),
+                        (labels[i].never_reaches ? ", jo" : ""));
+                    continue;
+                }
+                printf("Label %d offset %04x (used=%d%s) (next->%d, prev->%d)\n",
+                    i,
+                    labels[i].offset,
+                    (i < labeluse_size ? labeluse[i] : 0),
+                    (labels[i].never_reaches ? ", jo" : ""),
+                    labels[i].next, labels[i].prev);
+            }
         }
 
         /* label will advance through the linked list as pc increases. */

--- a/asm.c
+++ b/asm.c
@@ -2304,7 +2304,8 @@ static void transfer_routine_z(void)
             if (asm_trace_level >= 4)
                 printf("...To label %d (opcode %x), which is %d from here\n",
                     j, opcode_at_label, labels[j].offset-pc);
-            if (labels[j].offset-pc == 2 && i >= 1 && zcode_holding_area[i-1] == opcodes_table_z[jump_zc].code+128) {
+            if (labels[j].offset-pc == 2 && i >= 1
+                && zcode_holding_area[i-1] == 0x8C) {  /* jump */
                 if (asm_trace_level >= 4) printf("...Deleting jump\n");
                 mark_label_unused(j);
                 zcode_markers[i-1] = DELETED_MV;

--- a/asm.c
+++ b/asm.c
@@ -288,7 +288,6 @@ static void mark_label_unused(int label)
     if (label < 0 || label >= next_label)
         return;
     
-    /* Never marked used. */
     if (label >= labeluse_size || labeluse[label] == 0)
         fatalerror("Tried to mark never-used label as less used");
 

--- a/asm.c
+++ b/asm.c
@@ -2308,7 +2308,10 @@ static void transfer_routine_z(void)
                 && zcode_holding_area[i-1] == 0x8C) {  /* jump */
                 if (asm_trace_level >= 4) printf("...Deleting jump\n");
                 /* Do *not* mark the label unused, because we're going
-                   to fall through to it. */
+                   to fall through to it.
+                   (Pedants would want to mark the label unused but also
+                   clear the never_reaches flag. Doing nothing is easier,
+                   same result.) */
                 zcode_markers[i-1] = DELETED_MV;
                 zcode_markers[i] = DELETED_MV;
                 zcode_markers[i+1] = DELETED_MV;
@@ -2325,7 +2328,9 @@ static void transfer_routine_z(void)
         }
     }
 
-    /*  (2) ### */
+    /*  (1a) Check for any return opcodes which are no longer branched to
+             at all, and which also cannot be reached from the previous
+             opcode. These can be deleted. */
 
     if (last_label >= 0) {
         for (label=first_label; label>=0; label=labels[label].next) {

--- a/asm.c
+++ b/asm.c
@@ -2307,7 +2307,7 @@ static void transfer_routine_z(void)
                 if (asm_trace_level >= 4) printf("...Deleting jump\n");
                 /* Do *not* mark the label unused, because we're going
                    to fall through to it.
-                   (Pedants would want to mark the label unused but also
+                   (Pedantically we'd want to mark the label unused and then
                    clear the never_reaches flag. Doing nothing is easier,
                    same result.) */
                 zcode_markers[i-1] = DELETED_MV;

--- a/asm.c
+++ b/asm.c
@@ -2307,7 +2307,8 @@ static void transfer_routine_z(void)
             if (labels[j].offset-pc == 2 && i >= 1
                 && zcode_holding_area[i-1] == 0x8C) {  /* jump */
                 if (asm_trace_level >= 4) printf("...Deleting jump\n");
-                mark_label_unused(j);
+                /* Do *not* mark the label unused, because we're going
+                   to fall through to it. */
                 zcode_markers[i-1] = DELETED_MV;
                 zcode_markers[i] = DELETED_MV;
                 zcode_markers[i+1] = DELETED_MV;
@@ -2575,7 +2576,8 @@ static void transfer_routine_g(void)
                        j, addr, labels[j].offset - offset_of_next);
             if (addr == 2 && i >= 2 && opmodeoffset == 2 && zcode_holding_area[opmodebyte-1] == opcodes_table_g[jump_gc].code) {
                 if (asm_trace_level >= 4) printf("...Deleting branch\n");
-                mark_label_unused(j);
+                /* Do *not* mark the label unused, because we're going
+                   to fall through to it. */
                 zcode_markers[i-2] = DELETED_MV;
                 zcode_markers[i-1] = DELETED_MV;
                 zcode_markers[i] = DELETED_MV;

--- a/asm.c
+++ b/asm.c
@@ -2225,8 +2225,8 @@ static void transfer_routine_z(void)
             both label bytes get DELETED_MV.
             We also look for jumps that can be eliminated because they
             are jumping to a (one-byte) return opcode. The jump opcode is
-            replaced by a copy of the destination opcode; the label bytes
-            get DELETED_MV.
+            replaced by a copy of the destination opcode; the original
+            operand gets DELETED_MV.
             Also branches to an rtrue/rfalse opcode, which can be converted
             to the rtrue/rfalse form of the branch. */
       

--- a/asm.c
+++ b/asm.c
@@ -241,10 +241,12 @@ static void set_label_offset(int label, int32 offset)
     labels[label].offset = offset;
     labels[label].symbol = -1;
     labels[label].never_reaches = execution_never_reaches_here;
+    
     if (offset < 0) {
         /* Mark this label as invalid and don't put it in the linked list. */
         labels[label].prev = -1;
         labels[label].next = -1;
+        labels[label].never_reaches = TRUE;
         return;
     }
     

--- a/asm.c
+++ b/asm.c
@@ -2241,7 +2241,7 @@ static void transfer_routine_z(void)
                 printf("Branch detected at offset %04x (branch opcode %x)\n",
                     pc, branch_opcode);
             j = (256*zcode_holding_area[i] + zcode_holding_area[i+1]) & 0x7fff;
-            label_offset = i + labels[j].offset - pc;
+            label_offset = labels[j].offset - adjusted_pc;
             if (label_offset < 0 || label_offset >= zcode_ha_size) {
                 /* Probably the label was never defined. We'll report
                    that error later. */
@@ -2294,7 +2294,7 @@ static void transfer_routine_z(void)
             if (asm_trace_level >= 4)
                 printf("Jump detected at offset %04x\n", pc);
             j = (256*zcode_holding_area[i] + zcode_holding_area[i+1]) & 0x7fff;
-            label_offset = i + labels[j].offset - pc;
+            label_offset = labels[j].offset - adjusted_pc;
             if (label_offset < 0 || label_offset >= zcode_ha_size) {
                 /* Probably the label was never defined. We'll report
                    that error later. */

--- a/asm.c
+++ b/asm.c
@@ -2226,11 +2226,9 @@ static void transfer_routine_z(void)
             We also look for jumps that can be eliminated because they
             are jumping to a (one-byte) return opcode. The jump opcode is
             replaced by a copy of the destination opcode; the label bytes
-            get DELETED_MV. (However, we don't do the extra work to detect
-            whether this orphans the destination opcode.)
+            get DELETED_MV.
             Also branches to an rtrue/rfalse opcode, which can be converted
-            to the rtrue/rfalse form of the branch. (Same orphan problem
-            applies.) */
+            to the rtrue/rfalse form of the branch. */
       
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++)
     {   if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV)
@@ -2329,8 +2327,8 @@ static void transfer_routine_z(void)
     }
 
     /*  (1a) Check for any return opcodes which are no longer branched to
-             at all, and which also cannot be reached from the previous
-             opcode. These can be deleted. */
+             at all (as a result of step 1), and which also cannot be
+             reached from the previous opcode. These can be deleted. */
 
     if (last_label >= 0) {
         for (label=first_label; label>=0; label=labels[label].next) {

--- a/asm.c
+++ b/asm.c
@@ -2576,10 +2576,10 @@ static void transfer_routine_g(void)
             short form) with DELETED_MV.
             We also look for branches that can be entirely eliminated (because
             they are jumping to the very next instruction). The opcode and
-            all label bytes get DELETED_MV.
+            its operand gets DELETED_MV.
             (This doesn't bother with the "replace jump with return"
-            optimization that Z-code does. Figuring out the operand
-            lengths is too much work.) */
+            optimization that Z-code does. It's harder and Glulx isn't
+            generally in need of tight optimization.) */
 
     for (i=0, pc=adjusted_pc; i<zcode_ha_size; i++, pc++) {
         if (zcode_markers[i] >= BRANCH_MV && zcode_markers[i] < BRANCHMAX_MV) {

--- a/asm.c
+++ b/asm.c
@@ -2307,7 +2307,7 @@ static void transfer_routine_z(void)
             (if two labels move inside the "short" range as a result of
             a previous optimisation).  However, this is acceptably uncommon. */
 
-    if (next_label > 0)
+    if (last_label >= 0)
     {   if (asm_trace_level >= 4)
         {   printf("Opening label: %d\n", first_label);
             for (i=0;i<next_label;i++)
@@ -2557,7 +2557,7 @@ static void transfer_routine_g(void)
             optimisations which are possible but which have been missed
             (if two labels move inside the "short" range as a result of
             a previous optimisation).  However, this is acceptably uncommon. */
-    if (next_label > 0) {
+    if (last_label >= 0) {
         if (asm_trace_level >= 4) {
             printf("Opening label: %d\n", first_label);
             for (i=0;i<next_label;i++)

--- a/asm.c
+++ b/asm.c
@@ -215,6 +215,7 @@ extern int alloc_label(void)
     ensure_memory_list_available(&labels_memlist, label+1);
     labels[label].offset = -1;
     labels[label].symbol = -1;
+    labels[label].never_reaches = FALSE;
     labels[label].prev = -1;
     labels[label].next = -1;
 
@@ -239,6 +240,7 @@ static void set_label_offset(int label, int32 offset)
 
     labels[label].offset = offset;
     labels[label].symbol = -1;
+    labels[label].never_reaches = execution_never_reaches_here;
     if (offset < 0) {
         /* Mark this label as invalid and don't put it in the linked list. */
         labels[label].prev = -1;

--- a/expressc.c
+++ b/expressc.c
@@ -3032,13 +3032,13 @@ static void generate_code_from(int n, int void_flag)
     
                          case ELDER_SYSF:
                              {   int label, label2, label3;
-                                 label = alloc_label();
-                                 label2 = alloc_label();
-                                 label3 = alloc_label();
                                  AO = ET[ET[below].right].value;
                                  if (runtime_error_checking_switch)
                                      AO = check_nonzero_at_runtime(AO, -1,
                                          YOUNGEST_RTE);
+                                 label = alloc_label();
+                                 label2 = alloc_label();
+                                 label3 = alloc_label();
                                  assembleg_store(temp_var3, AO);
                                  INITAOTV(&AO2, BYTECONSTANT_OT, GOBJFIELD_PARENT());
                                  assembleg_3(aload_gc, temp_var3, AO2, temp_var1);

--- a/expressc.c
+++ b/expressc.c
@@ -2199,8 +2199,6 @@ static void generate_code_from(int n, int void_flag)
     
                          case ELDER_SYSF:
                              {   int label, label2;
-                                 label = alloc_label();
-                                 label2 = alloc_label();
                                  assemblez_store(temp_var1, ET[ET[below].right].value);
                                  if (runtime_error_checking_switch)
                                      check_nonzero_at_runtime(temp_var1, -1,

--- a/header.h
+++ b/header.h
@@ -916,6 +916,7 @@ typedef struct arrayinfo_s {
 typedef struct labelinfo_s {
     int32 offset; /* Offset (zmachine_pc) value */
     int32 symbol; /* Symbol numbers if defined in source */
+    int never_reaches;  /* Set if execution never reaches here (from above) */
     int next;     /* For linked list */
     int prev;     /* For linked list */
 } labelinfo;


### PR DESCRIPTION
Resolves https://github.com/DavidKinder/Inform6/issues/341 . This fixes the "Unfortunately the dead-code-strip phase has already finished by this point ..." comment introduced in 6.43, and also lets us drop the same comment in 6.45.

To do this, we record the `execution_never_reaches_here` for each label. (True means the label cannot be reached by running forward from the previous opcode.) We also count the number of branches to each label. (The `labeluse[]` counter.)

When eliminating a branch in transfer_routine_z(), we *decrement* the `labeluse[]` counter for its label.

Then, in a new step (line 2329), we run through labels and notice any which (a) have counter==0; (b) have `never_reaches` true; (c) refer to a one-byte return opcode. Such opcodes can be DELETED.

(It may be that several labels refer to a single address. In that case, we add up all their counters to make sure they're _all_ unused.)

As a small additional cleanup, we initialize the linked links refs `first_label`, `last_label` to both be -1 (as is traditional for doubly linked lists.) I was previously initing `first_label` to zero.

I also changed the expression `i + labels[j].offset - pc` to `labels[j].offset - adjusted_pc`. Same value, much easier to understand.
