### PR TITLE
Accept @@NN escapes in dict words, char constants, etc

### DIFF
--- a/chars.c
+++ b/chars.c
@@ -1092,6 +1092,7 @@ extern int32 text_to_unicode(char *text)
 {   int i;
 
     textual_form_error = FALSE;
+    
     if (text[0] != '@')
     {   if (character_set_unicode)
         {   if (text[0] & 0x80) /* 8-bit */
@@ -1211,6 +1212,12 @@ extern int32 text_to_unicode(char *text)
             }
             total = total*16 + d;
         }
+        if (i == 2 && !textual_form_error) {
+            error("'@{...}' must contain hexadecimal digits");
+            textual_form_error = TRUE;
+            return '?';
+        }
+        
         while ((text[i] != '}') && (text[i] != 0)) i++;
         if (text[i] == '}') i++;
         textual_form_length = i;

--- a/chars.c
+++ b/chars.c
@@ -1175,15 +1175,17 @@ extern int32 text_to_unicode(char *text)
     }
 
     if (text[1] != '{')
-    {   for (i=0; accents[i] != 0; i+=2)
+    {   for (i=0; accents[i] != 0; i+=2) {
             if ((text[1] == accents[i]) && (text[2] == accents[i+1]))
             {   textual_form_length = 3;
                 return default_zscii_to_unicode_c01[i/2];
             }
-
-        {   ebf_error("'@' plus an accent code, '@@..', or '@{...}'", text);
-            textual_form_error = TRUE;
         }
+
+        ebf_error("'@' plus an accent code, '@@NUM', or '@{HEX}'", text);
+        textual_form_error = TRUE;
+        textual_form_length = 1;
+        return '?';
     }
     else
     {   int32 total = 0;

--- a/chars.c
+++ b/chars.c
@@ -1066,10 +1066,11 @@ extern int32 zscii_to_unicode(int z)
 /*  This routine is not used for ordinary text compilation as it is too      */
 /*  slow, but it's useful for handling @ string escapes, or to avoid writing */
 /*  special code when speed is not especially required.                      */
-/*  Note that the two string escapes which can define Unicode are:           */
+/*  Note that the string escapes which can define Unicode are:               */
 /*                                                                           */
 /*      @..      where .. is an accent                                       */
-/*  and @{...}   where ... specifies a Unicode char in hexadecimal           */
+/*      @@...    where ... is decimal digits                                 */
+/*      @{...}   where ... specifies a Unicode char in hexadecimal           */
 /*               (1 to 6 digits long)                                        */
 /*                                                                           */
 /*  The global textual_form_length is set to the number of characters        */
@@ -1154,8 +1155,19 @@ extern int32 text_to_unicode(char *text)
         }
     }
 
+    if (text[1] == '@' && isdigit((uchar)text[2]))
+    {   int32 total = 0;
+        int i = 2;
+        while (isdigit((uchar)text[i])) {
+            total = 10*total + (text[i]-'0');
+            i++;
+        }
+        textual_form_length = i;
+        return total;
+    }
+    
     if ((isdigit((uchar)text[1])) || (text[1] == '@'))
-    {   ebf_error("'@' plus an accent code or '@{...}'", text);
+    {   ebf_error("'@' plus an accent code, '@@..', or '@{...}'", text);
         textual_form_error = TRUE;
         textual_form_length = 1;
         return '?';

--- a/chars.c
+++ b/chars.c
@@ -1088,6 +1088,8 @@ extern int32 zscii_to_unicode(int z)
 int textual_form_length;
 int textual_form_error;
 
+/* The text argument must have room for at least seven characters plus
+   terminator. */
 extern int32 text_to_unicode(char *text)
 {   int i;
 

--- a/chars.c
+++ b/chars.c
@@ -1072,8 +1072,12 @@ extern int32 zscii_to_unicode(int z)
 /*  and @{...}   where ... specifies a Unicode char in hexadecimal           */
 /*               (1 to 6 digits long)                                        */
 /*                                                                           */
-/*  If either syntax is malformed, an error is generated                     */
-/*  and the Unicode (= ISO = ASCII) character value of '?' is returned       */
+/*  The global textual_form_length is set to the number of characters        */
+/*  consumed (at least 1).                                                   */
+/*                                                                           */
+/*  If the syntax is malformed, an error is generated, the global            */
+/*  textual_form_error is set, and the Unicode (= ISO = ASCII) character     */
+/*  value of '?' is returned.                                                */
 /*                                                                           */
 /*  In Unicode mode (character_set_unicode is true), this handles UTF-8      */
 /*  decoding as well as @-expansion. (So it's called when an '@' appears     */
@@ -1081,10 +1085,12 @@ extern int32 zscii_to_unicode(int z)
 /* ------------------------------------------------------------------------- */
 
 int textual_form_length;
+int textual_form_error;
 
 extern int32 text_to_unicode(char *text)
 {   int i;
 
+    textual_form_error = FALSE;
     if (text[0] != '@')
     {   if (character_set_unicode)
         {   if (text[0] & 0x80) /* 8-bit */
@@ -1093,10 +1099,12 @@ extern int32 text_to_unicode(char *text)
                         textual_form_length = 4;
                         if ((text[0] & 0xf8) != 0xf0)
                         {   error("Invalid 4-byte UTF-8 string.");
+                            textual_form_error = TRUE;
                             return '?';
                         }
                         if ((text[1] & 0xc0) != 0x80 || (text[2] & 0xc0) != 0x80 || (text[3] & 0xc0) != 0x80)
                         {   error("Invalid 4-byte UTF-8 string.");
+                            textual_form_error = TRUE;
                             return '?';
                         }
                         return (text[0] & 0x07) << 18
@@ -1108,6 +1116,7 @@ extern int32 text_to_unicode(char *text)
                         textual_form_length = 3;
                         if ((text[1] & 0xc0) != 0x80 || (text[2] & 0xc0) != 0x80)
                         {   error("Invalid 3-byte UTF-8 string.");
+                            textual_form_error = TRUE;
                             return '?';
                         }
                         return (text[0] & 0x0f) << 12
@@ -1119,6 +1128,7 @@ extern int32 text_to_unicode(char *text)
                         textual_form_length = 2;
                         if ((text[1] & 0xc0) != 0x80)
                         {   error("Invalid 2-byte UTF-8 string.");
+                            textual_form_error = TRUE;
                             return '?';
                         }
                         return (text[0] & 0x1f) << 6
@@ -1126,6 +1136,7 @@ extern int32 text_to_unicode(char *text)
                         break;
                     default: /* broken */
                         error("Invalid UTF-8 string.");
+                        textual_form_error = TRUE;
                         textual_form_length = 1;
                         return '?';
                         break;
@@ -1145,6 +1156,7 @@ extern int32 text_to_unicode(char *text)
 
     if ((isdigit((uchar)text[1])) || (text[1] == '@'))
     {   ebf_error("'@' plus an accent code or '@{...}'", text);
+        textual_form_error = TRUE;
         textual_form_length = 1;
         return '?';
     }
@@ -1159,6 +1171,7 @@ extern int32 text_to_unicode(char *text)
         {   char uac[4];
             uac[0]='@'; uac[1]=text[1]; uac[2]=text[2]; uac[3]=0;
             error_named("No such accented character as", uac);
+            textual_form_error = TRUE;
         }
     }
     else
@@ -1167,16 +1180,22 @@ extern int32 text_to_unicode(char *text)
         while (text[++i] != '}')
         {   if (text[i] == 0)
             {   error("'@{' without matching '}'");
-                total = '?'; break;
+                textual_form_error = TRUE;
+                total = '?';
+                break;
             }
             if (i == 8)
             {   error("At most six hexadecimal digits allowed in '@{...}'");
-                total = '?'; break;
+                textual_form_error = TRUE;
+                total = '?';
+                break;
             }
             d = character_digit_value[(uchar)text[i]];
             if (d == 127)
             {   error("'@{...}' may only contain hexadecimal digits");
-                total = '?'; break;
+                textual_form_error = TRUE;
+                total = '?';
+                break;
             }
             total = total*16 + d;
         }

--- a/chars.c
+++ b/chars.c
@@ -1217,7 +1217,6 @@ extern int32 text_to_unicode(char *text)
             textual_form_error = TRUE;
             return '?';
         }
-        
         while ((text[i] != '}') && (text[i] != 0)) i++;
         if (text[i] == '}') i++;
         textual_form_length = i;

--- a/chars.c
+++ b/chars.c
@@ -1088,8 +1088,6 @@ extern int32 zscii_to_unicode(int z)
 int textual_form_length;
 int textual_form_error;
 
-/* The text argument must have room for at least seven characters plus
-   terminator. */
 extern int32 text_to_unicode(char *text)
 {   int i;
 
@@ -1238,6 +1236,8 @@ extern int32 text_to_unicode(char *text)
 /*  In either case, output uses the same ISO set as the source code.         */
 /* ------------------------------------------------------------------------- */
 
+/* The text argument must have room for at least seven characters plus
+   terminator. */
 extern void zscii_to_text(char *text, int zscii)
 {   int i;
     int32 unicode;

--- a/chars.c
+++ b/chars.c
@@ -1222,9 +1222,6 @@ extern int32 text_to_unicode(char *text)
         textual_form_length = i;
         return total;
     }
-
-    textual_form_length = 1;
-    return '?';
 }
 
 /* ------------------------------------------------------------------------- */

--- a/chars.c
+++ b/chars.c
@@ -1167,8 +1167,8 @@ extern int32 text_to_unicode(char *text)
         return total;
     }
     
-    if ((isdigit((uchar)text[1])) || (text[1] == '@'))
-    {   ebf_error("'@' plus an accent code, '@@..', or '@{...}'", text);
+    if ((isdigit((uchar)text[1])) || (text[1] == '('))
+    {   error_named("Abbreviations can only be used in double-quoted strings; found", text);
         textual_form_error = TRUE;
         textual_form_length = 1;
         return '?';
@@ -1181,9 +1181,7 @@ extern int32 text_to_unicode(char *text)
                 return default_zscii_to_unicode_c01[i/2];
             }
 
-        {   char uac[4];
-            uac[0]='@'; uac[1]=text[1]; uac[2]=text[2]; uac[3]=0;
-            error_named("No such accented character as", uac);
+        {   ebf_error("'@' plus an accent code, '@@..', or '@{...}'", text);
             textual_form_error = TRUE;
         }
     }

--- a/header.h
+++ b/header.h
@@ -2371,7 +2371,7 @@ extern int   zscii_high_water_mark;
 extern char  alphabet_used[];
 extern int   iso_to_alphabet_grid[];
 extern int   zscii_to_alphabet_grid[];
-extern int   textual_form_length;
+extern int   textual_form_length, textual_form_error;
 
 extern int   iso_to_unicode(int iso);
 extern int   unicode_to_zscii(int32 u);

--- a/text.c
+++ b/text.c
@@ -666,9 +666,9 @@ advance as part of 'Zcharacter table':", unicode);
     
                     @@decimalnumber  :  write this ZSCII char (0 to 1023)
                     @twodigits or    :  write the abbreviation string with this
-                    @(digits)           decimal number
+                    @(digits)               decimal number
                     @(symbol)        :  write the abbreviation string with this
-                                        (constant) value
+                                            (constant) value
                     @accentcode      :  this accented character: e.g.,
                                             for @'e write an E-acute
                     @{...}           :  this Unicode char (in hex)          */


### PR DESCRIPTION
I updated text_to_unicode() to handle the `@@64` style of escape as well as `@{4F}` and `@:u`. It also sets a global error flag on error, which will be useful later.

With that in place, I was able to remove the `@@64` handler code from translate_text(); that is now taken care of at the text_to_unicode() level. This means that the decimal and hex escapes are completely interchangeable; either can be used anywhere the other is.

With *that* in place, the printing of `@{5E}` and `@{7E}` (in Z-code) is now consistent with `@@94` and `@@126`. Previously the hex forms were decoded to `^` and `~` and then decoded *again* to newline and `"`.

It's possible that someone was using `@{7E}` in a string for double-quote, in which case this change will hurt them. But I don't think it's likely.

While I was in there, I added error checks for the degenerate forms `@@` and `@{}` (zero decimal or hex digits). Previously these were accepted and generated a null character, which is definitely not good for printing.

Fixes https://github.com/DavidKinder/Inform6/issues/348 and https://github.com/DavidKinder/Inform6/issues/249 .

Test branch is https://github.com/erkyrath/Inform6-Testing/tree/consistent-escape .
