### PR TITLE
Default directive writes a debug entry

### DIFF
--- a/directs.c
+++ b/directs.c
@@ -234,6 +234,7 @@ extern int parse_given_directive(int internal_flag)
 
     case DEFAULT_CODE:
         get_next_token();
+        beginning_debug_location = get_token_location_beginning();
         if (token_type != SYMBOL_TT)
             return ebf_error_recover("name");
 
@@ -242,6 +243,7 @@ extern int parse_given_directive(int internal_flag)
         {   i = token_value;
             symbols[i].flags |= DEFCON_SFLAG;
         }
+        constant_name = token_text;
 
         get_next_token();
         if (!((token_type == SEP_TT) && (token_value == SETEQUALS_SEP)))
@@ -256,6 +258,14 @@ extern int parse_given_directive(int internal_flag)
                     symbols[i].flags |= CHANGE_SFLAG;
                 }
                 else assign_symbol(i, AO.value, CONSTANT_T);
+                
+                if (debugfile_switch && !(symbols[i].flags & REDEFINABLE_SFLAG))
+                {   debug_file_printf("<constant>");
+                    debug_file_printf("<identifier>%s</identifier>", constant_name);
+                    write_debug_symbol_optional_backpatch(i);
+                    write_debug_locations(get_token_location_end(beginning_debug_location));
+                    debug_file_printf("</constant>");
+                }
             }
         }
 


### PR DESCRIPTION
The `Default` directive was failing to create a `<constant>` entry in the gameinfo.dbg file. Now it does (but only if there was no pre-existing constant of that name).

Fixes https://github.com/DavidKinder/Inform6/issues/358 , which was a symptom of this.
