### PR TITLE
Warnings as errors switch

### DIFF
--- a/header.h
+++ b/header.h
@@ -2567,7 +2567,7 @@ extern int
     obsolete_switch,        optabbrevs_trace_setting,
     transcript_switch,      statistics_switch,    optimise_switch,
     version_set_switch,     nowarnings_switch,    hash_switch,
-    memory_map_setting,
+    memory_map_setting,     errorwarnings_switch,
     define_DEBUG_switch,    define_INFIX_switch,
     runtime_error_checking_switch,
     list_verbs_setting,     list_dict_setting,    list_objects_setting,

--- a/inform.c
+++ b/inform.c
@@ -1183,7 +1183,7 @@ disabling -X switch\n");
     status = 0;
     if (no_errors)
         status = 1;
-    if (no_warnings && errorwarnings_switch)
+    if ((no_warnings+no_suppressed_warnings) && errorwarnings_switch)
         status = 1;
     return status;
 }
@@ -1427,18 +1427,10 @@ extern void switches(char *p, int cmode)
                   break;
         case 'w': if (p[i+1] == '2') {
                       s=2;
-                      if (state) {
-                          nowarnings_switch = FALSE;
-                          errorwarnings_switch = TRUE;
-                      }
-                      else {
-                          /* nowarnings_switch does not change */
-                          errorwarnings_switch = FALSE;
-                      }
+                      errorwarnings_switch = state;
                   }
                   else {
                       nowarnings_switch = state;
-                      errorwarnings_switch = FALSE;
                   }
                   break;
         case 'x': hash_switch = state; break;

--- a/inform.c
+++ b/inform.c
@@ -1071,9 +1071,8 @@ static void rennab(float time_taken)
         {   printf("%d error%s", no_errors,(no_errors==1)?"":"s");
             if (t > 0) printf(" and ");
         }
-        if (no_warnings > 0) {
+        if (no_warnings > 0)
             printf("%d warning%s", t, (t==1)?"":"s");
-        }
         if (no_suppressed_warnings > 0)
         {   if (no_warnings > 0)
                 printf(" (%d suppressed)", no_suppressed_warnings);

--- a/inform.c
+++ b/inform.c
@@ -1107,6 +1107,7 @@ static int execute_icl_header(char *file1);
 
 static int compile(int number_of_files_specified, char *file1, char *file2)
 {
+    int status;
     TIMEVALUE time_start, time_end;
     float duration;
 
@@ -1175,7 +1176,13 @@ disabling -X switch\n");
     }
 
     in_compilation = FALSE;
-    return (no_errors==0)?0:1;
+
+    status = 0;
+    if (no_errors)
+        status = 1;
+    if (no_warnings && errorwarnings_switch)
+        status = 1;
+    return status;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/inform.c
+++ b/inform.c
@@ -1073,8 +1073,6 @@ static void rennab(float time_taken)
         }
         if (no_warnings > 0) {
             printf("%d warning%s", t, (t==1)?"":"s");
-            if (errorwarnings_switch)
-                printf(" (treated as error%s)", (t==1)?"":"s");
         }
         if (no_suppressed_warnings > 0)
         {   if (no_warnings > 0)
@@ -1083,6 +1081,8 @@ static void rennab(float time_taken)
             printf("%d suppressed warning%s", no_suppressed_warnings,
                 (no_suppressed_warnings==1)?"":"s");
         }
+        if (t && errorwarnings_switch)
+            printf(" (treated as error%s)", (t==1)?"":"s");
         if (output_has_occurred == FALSE) printf(" (no output)");
         printf("\n");
     }

--- a/inform.c
+++ b/inform.c
@@ -268,6 +268,7 @@ int concise_switch,                 /* -c */
     optimise_switch,                /* -u */
     version_set_switch,             /* -v */
     nowarnings_switch,              /* -w */
+    errorwarnings_switch,           /* -w2 */
     hash_switch,                    /* -x */
     memory_map_setting,             /* $!MAP, -z */
     oddeven_packing_switch,         /* -B */
@@ -339,6 +340,7 @@ static void reset_switch_settings(void)
     optabbrevs_trace_setting = 0;
     version_set_switch = FALSE;
     nowarnings_switch = FALSE;
+    errorwarnings_switch = FALSE;
     hash_switch = FALSE;
     memory_map_setting = 0;
     oddeven_packing_switch = FALSE;
@@ -1412,7 +1414,22 @@ extern void switches(char *p, int cmode)
                   if ((version_number < 5) && (r_e_c_s_set == FALSE))
                       runtime_error_checking_switch = FALSE;
                   break;
-        case 'w': nowarnings_switch = state; break;
+        case 'w': if (p[i+1] == '2') {
+                      s=2;
+                      if (state) {
+                          nowarnings_switch = FALSE;
+                          errorwarnings_switch = TRUE;
+                      }
+                      else {
+                          /* nowarnings_switch does not change */
+                          errorwarnings_switch = FALSE;
+                      }
+                  }
+                  else {
+                      nowarnings_switch = state;
+                      errorwarnings_switch = FALSE;
+                  }
+                  break;
         case 'x': hash_switch = state; break;
         case 'z': memory_map_setting = (state ? 1 : 0); break;
         case 'B': oddeven_packing_switch = state; break;

--- a/inform.c
+++ b/inform.c
@@ -1071,8 +1071,11 @@ static void rennab(float time_taken)
         {   printf("%d error%s", no_errors,(no_errors==1)?"":"s");
             if (t > 0) printf(" and ");
         }
-        if (no_warnings > 0)
+        if (no_warnings > 0) {
             printf("%d warning%s", t, (t==1)?"":"s");
+            if (errorwarnings_switch)
+                printf(" (treated as error%s)", (t==1)?"":"s");
+        }
         if (no_suppressed_warnings > 0)
         {   if (no_warnings > 0)
                 printf(" (%d suppressed)", no_suppressed_warnings);

--- a/inform.c
+++ b/inform.c
@@ -1293,6 +1293,7 @@ One or more words can be supplied as \"commands\". These may be:\n\n\
   v7  compile to version-7 (expanded \"Advanced\") story file\n\
   v8  compile to version-8 (expanded \"Advanced\") story file\n\
   w   disable warning messages\n\
+  w2  treat warning messages as errors\n\
   x   print # for every 100 lines compiled\n\
   z   print memory map of the virtual machine\n\n");
 


### PR DESCRIPTION
Adds the `-w2` switch to report warnings as errors. With this set, both errors and warnings cause the compiler to return a nonzero error status.

Note that you can use `-w` and `-w2` together; this doesn't print warnings but does return a nonzero status if there are any.

Handles https://github.com/DavidKinder/Inform6/issues/361 .
