### PR TITLE
Don't set the alphabet or unicode tables in v3/4

### DIFF
--- a/chars.c
+++ b/chars.c
@@ -1557,7 +1557,7 @@ extern void chars_begin_pass(void)
 {
     char *str;
 
-    if (!glulx_mode) {
+    if (!glulx_mode && version_number >= 5) {
         str = get_current_option_string_value(OPT_ZCHAR_TABLE);
         if (str) {
             new_zscii_characters_raw(str);

--- a/directs.c
+++ b/directs.c
@@ -1196,6 +1196,11 @@ extern int parse_given_directive(int internal_flag)
             panic_mode_error_recovery(); return FALSE;
         }
 
+        if (version_number < 5) {
+            error("The Zcharacter directive requires Z-machine version 5 or later.");
+            panic_mode_error_recovery(); return FALSE;
+        }
+
         directive_keywords.enabled = TRUE;
         get_next_token();
         directive_keywords.enabled = FALSE;

--- a/directs.c
+++ b/directs.c
@@ -1184,6 +1184,7 @@ extern int parse_given_directive(int internal_flag)
     /* --------------------------------------------------------------------- */
     /*   Zcharacter table <num> ...                                          */
     /*   Zcharacter table + <num> ...                                        */
+    /*   Zcharacter terminating <num> ...                                    */
     /*   Zcharacter <string> <string> <string>                               */
     /*   Zcharacter <char>                                                   */
     /* --------------------------------------------------------------------- */

--- a/tables.c
+++ b/tables.c
@@ -353,7 +353,10 @@ static void construct_storyfile_z(void)
     /*  -------------------- Z-character set table ------------------------- */
 
     if (alphabet_modified)
-    {   charset_at = mark;
+    {
+        if (version_number < 5)
+            error("The alphabet table may only be modified in Z-machine version 5 and later.");
+        charset_at = mark;
         for (i=0;i<3;i++) for (j=0;j<26;j++)
         {   if (alphabet[i][j] == '~') p[mark++] = '\"';
             else p[mark++] = alphabet[i][j];
@@ -364,7 +367,10 @@ static void construct_storyfile_z(void)
 
     unicode_at = 0;
     if (zscii_defn_modified)
-    {   unicode_at = mark;
+    {
+        if (version_number < 5)
+            error("The Unicode table may only be used in Z-machine version 5 and later.");
+        unicode_at = mark;
         p[mark++] = zscii_high_water_mark;
         for (i=0;i<zscii_high_water_mark;i++)
         {   j = zscii_to_unicode(155 + i);


### PR DESCRIPTION
See https://github.com/DavidKinder/Inform6/issues/367 .

The behavior came out a bit surprising for historical reasons. The `Zcharacter` directive produces an error if you use it in z3/4. (Same as it does if you use it in Glulx.)

But the `$ZCHAR_TABLE` and `$ZALPHABET` *options* are silently ignored in z3/4. (Same as if you'd tried to set `$ZCODE_COMPACT_GLOBALS` in Glulx.) 

I could make the `Zcharacter` directive a warning, rather than an error. But I can't think of a solid reason to.
